### PR TITLE
Machine-readable database-provider list

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -1,7 +1,7 @@
 # OPTIMADE API specification v0.9.7-develop
 
-[1. Introduction](#h.1) 
- 
+[1. Introduction](#h.1)
+
 [2. Term definition](#h.2)
 
 [3. General API requirements and conventions](#h.3)  
@@ -48,7 +48,9 @@
 
 &nbsp;&nbsp;&nbsp;&nbsp;[6.3. 'Calculation' entries](#h.6.3)  
 
-[Appendix: Database-specific namespace prefixes](#h.app)  
+[Appendix 1: Database provider-specific namespace prefixes](#h.app1)  
+[Appendix 2: The Filter language EBNF grammar](#h.app2)  
+[Appendix 3: The regular expressions to check OPTiMaDe number syntax](#h.app3)
 
 # <a name="h.1">1. Introduction</a>
 
@@ -79,9 +81,9 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
-* Database provider: A service that provides a database of materials information.
-* Database-specific prefix: This specification defines a set of
-  database-specific prefixes in its [Appendix](#h.app).
+* Database provider: A service that provides one or more databases of materials information.
+* Database provider-specific prefix: This specification defines a set of
+  database provider-specific prefixes in [Appendix 1](#h.app1).
 * Entry: a type of resource over which a query can be formulated using the API
   (structure, calculations).
 * Property: anything that can be in the filtering of results.
@@ -170,8 +172,8 @@ declare these formats in their 'info' endpoints.
 
 An API implementation MAY return other formats than as specified here.
 These can be implemented and documented however the implementor chooses.
-However, they MUST be prefixed by a database-specific prefix as defined in the
-[Appendix](#h.app).
+However, they MUST be prefixed by a database provider-specific prefix as defined in
+[Appendix 1](#h.app1).
 
 Specifying a **response_format** URL query parameter that selects a
 response format different from JSON API allows the API specification
@@ -223,8 +225,7 @@ Every response MUST contain the following fields:
         * **last\_id**: a string containing the last ID returned.        
         * **response\_message**: OPTIONAL response string from the server.
         * Other OPTIONAL additional information _global to the query_ that is not specified
-          in this document, MUST start with a database-specific prefix as defined in
-          the [Appendix](#h.app).
+          in this document, MUST start with a database provider-specific prefix as defined in [Appendix 1](#h.app1).
     * Example:  
         For a request made to http://example.com/optimade/v0.9/structures/?filter=a=1 AND b=2
 
@@ -655,9 +656,9 @@ The following tokens are used in the filter query component:
     * 0\_kvak (starts with a number);
     * "foo bar" (contains space; contains quotes)
     
-    Identifiers that start with an underscore are specific to a database, and
-    MUST be on the format of a database specific prefix as defined in the
-    [Appendix](#h.app).
+    Identifiers that start with an underscore are specific to a database and its
+    provider, and MUST be on the format of a database provider-specific prefix as
+    defined in [Appendix 1](#h.app1).
 
     Examples:
 
@@ -859,9 +860,9 @@ This section defines standard entry types and their properties.
     * 2007-04-05T14:30Z
 * Querying: Date-time queries are permitted ([RFC 3339](http://tools.ietf.org/html/rfc3339)).
 
-### <a name="h.6.1.2">6.1.3. database-specific properties</a>
-* Description: Databases are allowed to insert database-specific entries in the output of both standard entry types, and database-specific entry types.
-* Requirements/Conventions: these MUST be prefixed by a database-specific prefix as defined in the [Appendix](#h.app).
+### <a name="h.6.1.3">6.1.3. database provider-specific properties</a>
+* Description: Database providers are allowed to insert database-specific entries in the output of both standard entry types, and database-specific entry types.
+* Requirements/Conventions: these MUST be prefixed by a database provider-specific prefix as defined in [Appendix 1](#h.app1).
 * Examples:
     * \_exmpl\_formula\_sum 
     * \_exmpl\_band\_gap
@@ -1127,26 +1128,61 @@ Multiple Entry Types", as well as the following properties:
 
 ## <a name="h.6.3">6.3. 'Calculation' entries</a>
 
-Calculation entries have the properties described above in "Properties Used by
-Multiple Entry Types".
+Calculation entries have the properties described above in [section '6.1: Properties Used by Multiple Entry Types'](#h.6.1).
 
-## <a name="h.app">Appendix: Database-specific namespace prefixes</a>
+## <a name="h.app1">Appendix 1: Database provider-specific namespace prefixes</a>
 
-This standard refers to database-specific prefixes. These are assigned and
+This standard refers to database provider-specific prefixes. These are assigned and
 included in this standard. The presently assigned prefixes are:
 
-* \_exmpl\_: used for examples, not to be assigned to a real database
-* \_aflow\_: aflow.org
-* \_cam\_: Cambridge databases
-* \_cod\_: crystallography open database
-* \_mcloud\_: materialscloud.org
-* \_mp\_: materialsproject.org
-* \_nmd\_: nomad laboratory
-* \_omdb\_: open materials database
-* \_oqmd\_: open quantum materials database
-* \_pcod\_: predicted crystallography open database
-* \_tcod\_: theoretical crystallography open database
+```YAML
+# BEGIN OPTIMADE PROVIDER LIST
+---
+exmpl:
+  - description: used for examples, not to be assigned to a real database
+  - url: null
+aflow:
+  - description: aflow.org
+  - url: null
+cam:
+  - description: Cambridge databases
+  - url: null
+cod:
+  - description: Crystallography open database
+  - url: http://crystallography.net/cod/optimade/
+mcloud:
+  - description: materialscloud.org
+  - url: null
+mp:
+  - description: materialsproject.org
+  - url: null
+nmd:
+  - description: nomad laboratory
+  - url: null
+omdb:
+  - description: open materials database
+  - url: null
+oqmd:
+  - description: open quantum materials database
+  - url: null
+pcod:
+  - description: predicted crystallography open database
+  - url: null
+tcod:
+  - description: theoretical crystallography open database
+  - url: http://crystallography.net/tcod/optimade/
+...
+# END OPTIMADE PROVIDER LIST
+```
 
+The key of the YAML mappings above represents reserved names for database providers.
+Each key MUST be used by the respective database provider when adding database specific
+entries to their databases.
+As an example, for the `exmpl` the custom string `_exmpl_` MUST be prefixed
+as discussed in [section '6.1.3: database provider-specific properties'](#h.6.1.3)
+
+The above YAML mapping serves as a machine-readable list of OPTiMaDe providers and their
+default database.
 
 API implementations SHOULD NOT make up and use new prefixes not included in
 this standard, but SHOULD rather work to get such prefixes included in a future
@@ -1156,7 +1192,8 @@ The initial underscore indicates an identifier that is under a separate
 namespace that is under the ownership of that organisation. Identifiers
 prefixed with underscores will not be used for standardized names.
 
-## Appendix 1. The Filter language EBNF grammar.
+## <a name="h.app2">Appendix 2. The Filter language EBNF grammar.</a>
+
 ```
 (* BEGIN EBNF GRAMMAR Filter *)
 (* The top-level 'filter' rule: *)
@@ -1250,7 +1287,9 @@ Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;
 (* END EBNF GRAMMAR Number *)
 (* END EBNF GRAMMAR Filter *)
 ```
-## Appendix 2. The regular expressions to check OPTiMaDe number syntax.
+
+## <a name="h.app3">Appendix 3. The regular expressions to check OPTiMaDe number syntax.</a>
+
 ```
 #BEGIN PCRE numbers
 # The string below contains a Perl-Compatible Regular Expression to recognise

--- a/optimade.md
+++ b/optimade.md
@@ -48,7 +48,7 @@
 
 &nbsp;&nbsp;&nbsp;&nbsp;[6.3. 'Calculation' entries](#h.6.3)  
 
-[Appendix 1: Database provider-specific namespace prefixes](#h.app1)  
+[Appendix 1: Database-provider-specific namespace prefixes](#h.app1)  
 [Appendix 2: The Filter language EBNF grammar](#h.app2)  
 [Appendix 3: The regular expressions to check OPTiMaDe number syntax](#h.app3)
 
@@ -82,8 +82,8 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 
 * Database provider: A service that provides one or more databases of materials information.
-* Database provider-specific prefix: This specification defines a set of
-  database provider-specific prefixes in [Appendix 1](#h.app1).
+* Database-provider-specific prefix: This specification defines a set of
+  database-provider-specific prefixes in [Appendix 1](#h.app1).
 * Entry: a type of resource over which a query can be formulated using the API
   (structure, calculations).
 * Property: anything that can be in the filtering of results.
@@ -172,7 +172,7 @@ declare these formats in their 'info' endpoints.
 
 An API implementation MAY return other formats than as specified here.
 These can be implemented and documented however the implementor chooses.
-However, they MUST be prefixed by a database provider-specific prefix as defined in
+However, they MUST be prefixed by a database-provider-specific prefix as defined in
 [Appendix 1](#h.app1).
 
 Specifying a **response_format** URL query parameter that selects a
@@ -225,7 +225,7 @@ Every response MUST contain the following fields:
         * **last\_id**: a string containing the last ID returned.        
         * **response\_message**: OPTIONAL response string from the server.
         * Other OPTIONAL additional information _global to the query_ that is not specified
-          in this document, MUST start with a database provider-specific prefix as defined in [Appendix 1](#h.app1).
+          in this document, MUST start with a database-provider-specific prefix as defined in [Appendix 1](#h.app1).
     * Example:  
         For a request made to http://example.com/optimade/v0.9/structures/?filter=a=1 AND b=2
 
@@ -332,7 +332,7 @@ There MAY be multiple entry listing endpoints, depending on how many types of
 entries a database provides. Specific standard entry types are specified in a
 later section of this specification. The API implementation MAY provide other
 entry types than the ones standardized in this specification, but such entry
-types MUST be prefixed by a database-specific prefix.
+types MUST be prefixed by a database-provider-specific prefix.
 
 ### <a name="h.4.1.1">4.1.1. URL Query Parameters</a>
 
@@ -372,10 +372,10 @@ Standard OPTIONAL URL query parameters not in the JSON API specification:
 Additional OPTIONAL URL query parameters not described above are not
 considered to be part of this standard, and are instead considered to
 be 'custom URL query parameters'. These custom URL query parameters
-MUST be of the format "&lt;database-specific
+MUST be of the format "&lt;database-provider-specific
 prefix&gt;&lt;url\_query\_parameter\_name&gt;".  These names adhere to
 the requirements on implementation-specific query parameters of
-[JSON API](http://jsonapi.org) since the database-specific prefixes
+[JSON API](http://jsonapi.org) since the database-provider-specific prefixes
 contain an underscore (a LOW LINE character '_').
 
 Example uses of custom URL query parameters include providing an access token for the
@@ -410,7 +410,7 @@ needs the following fields
       representing the entry's last modification time
     * **immutable\_id**: an OPTIONAL field containing the entry's immutable ID
 
-  Database-specific properties need to include the database-specific prefix.
+  Database-provider-specific properties need to include the database-provider-specific prefix.
 
 OPTIONALLY it can also contains the following fields:
 
@@ -656,8 +656,8 @@ The following tokens are used in the filter query component:
     * 0\_kvak (starts with a number);
     * "foo bar" (contains space; contains quotes)
     
-    Identifiers that start with an underscore are specific to a database and its
-    provider, and MUST be on the format of a database provider-specific prefix as
+    Identifiers that start with an underscore are specific to a database provider,
+    and MUST be on the format of a database-provider-specific prefix as
     defined in [Appendix 1](#h.app1).
 
     Examples:
@@ -860,9 +860,11 @@ This section defines standard entry types and their properties.
     * 2007-04-05T14:30Z
 * Querying: Date-time queries are permitted ([RFC 3339](http://tools.ietf.org/html/rfc3339)).
 
-### <a name="h.6.1.3">6.1.3. database provider-specific properties</a>
-* Description: Database providers are allowed to insert database-specific entries in the output of both standard entry types, and database-specific entry types.
-* Requirements/Conventions: these MUST be prefixed by a database provider-specific prefix as defined in [Appendix 1](#h.app1).
+### <a name="h.6.1.3">6.1.3. database-provider-specific properties</a>
+* Description: Database providers are allowed to insert database-provider-specific
+entries in the output of both standard entry types, and database-provider-specific
+entry types.
+* Requirements/Conventions: these MUST be prefixed by a database-provider-specific prefix as defined in [Appendix 1](#h.app1).
 * Examples:
     * \_exmpl\_formula\_sum 
     * \_exmpl\_band\_gap
@@ -1130,59 +1132,60 @@ Multiple Entry Types", as well as the following properties:
 
 Calculation entries have the properties described above in [section '6.1: Properties Used by Multiple Entry Types'](#h.6.1).
 
-## <a name="h.app1">Appendix 1: Database provider-specific namespace prefixes</a>
+## <a name="h.app1">Appendix 1: Database-provider-specific namespace prefixes</a>
 
-This standard refers to database provider-specific prefixes. These are assigned and
-included in this standard. The presently assigned prefixes are:
+This standard refers to database-provider-specific prefixes. These are assigned and
+included in this standard.
+
+The database-provider-specific prefixes are listed below as a YAML mapping
+and serves as a machine-readable list of OPTiMaDe providers.
+The presently assigned prefixes are:
 
 ```YAML
 # BEGIN OPTIMADE PROVIDER LIST
 ---
 exmpl:
-  - description: used for examples, not to be assigned to a real database
-  - url: null
+  description: used for examples, not to be assigned to a real database
+  optimade_url: null
 aflow:
-  - description: aflow.org
-  - url: null
+  description: aflow.org
+  optimade_url: null
 cam:
-  - description: Cambridge databases
-  - url: null
+  description: Cambridge databases
+  optimade_url: null
 cod:
-  - description: Crystallography open database
-  - url: http://crystallography.net/cod/optimade/
+  description: Crystallography open database
+  optimade_url: null
 mcloud:
-  - description: materialscloud.org
-  - url: null
+  description: materialscloud.org
+  optimade_url: null
 mp:
-  - description: materialsproject.org
-  - url: null
+  description: materialsproject.org
+  optimade_url: null
 nmd:
-  - description: nomad laboratory
-  - url: null
+  description: nomad laboratory
+  optimade_url: null
 omdb:
-  - description: open materials database
-  - url: null
+  description: open materials database
+  optimade_url: null
 oqmd:
-  - description: open quantum materials database
-  - url: null
+  description: open quantum materials database
+  optimade_url: null
 pcod:
-  - description: predicted crystallography open database
-  - url: null
+  description: predicted crystallography open database
+  optimade_url: null
 tcod:
-  - description: theoretical crystallography open database
-  - url: http://crystallography.net/tcod/optimade/
+  description: theoretical crystallography open database
+  optimade_url: null
 ...
 # END OPTIMADE PROVIDER LIST
 ```
 
-The key of the YAML mappings above represents reserved names for database providers.
+The key of the YAML mappings represents reserved names for database providers.
 Each key MUST be used by the respective database provider when adding database specific
 entries to their databases.
-As an example, for the `exmpl` the custom string `_exmpl_` MUST be prefixed
-as discussed in [section '6.1.3: database provider-specific properties'](#h.6.1.3)
-
-The above YAML mapping serves as a machine-readable list of OPTiMaDe providers and their
-default database.
+As an example, for `exmpl` the custom string `_exmpl_` MUST be prefixed
+as discussed in [section '6.1.3: database-provider-specific properties'](#h.6.1.3)
 
 API implementations SHOULD NOT make up and use new prefixes not included in
 this standard, but SHOULD rather work to get such prefixes included in a future


### PR DESCRIPTION
Related to issue #46.

A PR for @giovannipizzi's and @ltalirz's [Proposal 1 - Keeping a list of APIs](https://github.com/Materials-Consortia/OPTiMaDe/issues/46#issuecomment-399545013), dealing with a machine-readable list of known OPTiMaDe APIs.

This PR updates **in short**:
 - Appendix 1's standard list of OPTiMaDe databases to a machine-readable YAML file, listing OPTiMaDe database providers.
 - Mentions of `database-specific` to `database-provider-specific` concerning entry property prefixes.

**In more detailed terms**:
The YAML file is a mapping of mappings, which when parsed into e.g. Python becomes a dict of dicts.
Keys of the parent mapping are the standard/reserved database provider names (without underscores), while their values are mappings with the keys `description` and `optimade_url`:
```YAML
exmpl:
  description: used for examples, not to be assigned to a real database
  optimade_url: null
```
Parsed into Python this becomes:
```python
{
    'exmpl': {
        'description': 'used for examples, not to be assigned to a real database',
        'optimade_url': None
    }
}
```
Descriptions have been transferred directly from the existing format, but should probably be updated to better reflect each database provider.
The key `optimade_url` has been given the `optimade` prefix to create a more future-friendly YAML file. Specifically, further keys may be favourable to introduce when tackling the remainder of issue #46 and related issues #44 and #22.

There are also minor syntactic changes. See the diff for details of these.