### PR TITLE
simple discovery

### DIFF
--- a/bootstrap/info
+++ b/bootstrap/info
@@ -12,6 +12,9 @@
             "type": "api",
             "api_base_uri": "https://raw.githubusercontent.com/Materials-Consortia/OPTiMaDe/simple-discovery/bootstrap/",
             "api_description":["Top level entry point to find optimade compatible apis"]
+            "provider_name": "Optimade",
+            "provider_description": "Root optimade provider",
+            "api_id": "root_db"
           }
         ]
         "formats": [

--- a/bootstrap/info
+++ b/bootstrap/info
@@ -1,0 +1,32 @@
+{
+  "data": [
+    {
+      "type": "info",
+      "id": "/",
+      "attributes": {
+        "api_version": "v0.9.8",
+        "available_api_versions": {
+        },
+        "acknowledged_apis":[
+          {
+            "type": "api",
+            "api_base_uri": "https://raw.githubusercontent.com/Materials-Consortia/OPTiMaDe/simple-discovery/bootstrap/",
+            "api_description":["Top level entry point to find optimade compatible apis"]
+          }
+        ]
+        "formats": [
+          "json"
+        ],
+        "entry_types_by_format": {
+          "json": []
+        },
+        "available_endpoints": [
+          "info"
+        ],
+        "info_description":[
+          "Top level entry point to find optimade compatible apis"
+        ]
+      }
+    }
+  ]
+}

--- a/optimade.md
+++ b/optimade.md
@@ -542,6 +542,11 @@ The response dictionary MUST include the following fields
 	        * **api\_base\_uri**: a string containing an url.
 	            The provided url MUST adhere to the rules of [section '3.1. Base URL'](#h.3.1).
 	        * **api\_description**: a list of strings providing a human readable description in markdown format of the content available through the API
+	        * **provider_name**: a short name for the database provider.
+	        * **provider_description**: a longer description of the database provider.
+	        * **provider_prefix**: an OPTIONAL field giving the database-provider-specific prefix as found in
+	            [appendix 1: Database-provider-specific namespace prefixes](#h.app1).
+	        * **api_id**: an OPTIONAL field containing the provider's local ID.
     * **formats**: a list of available output formats.
     * **entry\_types\_by\_format**: Available entry endpoints as a function of output formats.
     * **info\_description**: a list of strings providing a human readable description in markdown format of the content available through this API.

--- a/optimade.md
+++ b/optimade.md
@@ -545,7 +545,12 @@ The response dictionary MUST include the following fields
 	        * **provider_name**: a short name for the database provider.
 	        * **provider_description**: a longer description of the database provider.
 	        * **provider_prefix**: an OPTIONAL field giving the database-provider-specific prefix as found in
-	            [appendix 1: Database-provider-specific namespace prefixes](#h.app1).
+	            [appendix 1: Database-provider-specific namespace prefixes](#h.app1)
+	        * **provider_homepage**: OPTIONAL, a [JSON API Links object](http://jsonapi.org/format/#document-links)
+	            pointing to the homepage of the provider,  either directly as a string, or as a link object which
+	            can contain the following members:
+	                * `href`: a string containing the homepage URL.
+	                * `meta`: a meta object containing non-standard meta-information about the provider's homepage.
 	        * **api_id**: an OPTIONAL field containing the provider's local ID.
     * **formats**: a list of available output formats.
     * **entry\_types\_by\_format**: Available entry endpoints as a function of output formats.

--- a/optimade.md
+++ b/optimade.md
@@ -1,4 +1,4 @@
-# OPTIMADE API specification v0.9.7-develop
+# OPTIMADE API specification v0.9.8-develop
 
 [1. Introduction](#h.1)
 
@@ -534,8 +534,17 @@ The response dictionary MUST include the following fields
     * **available\_api\_versions**: a dictionary where values are the base URLs for the versions of the API that are supported, 
 	    and the keys are strings giving the full version number provided by that base URL. Provided base urls MUST
 		adhere to the rules in [section '3.1. Base URL'](#h.3.1).
+	* **acknowledged\_apis**: List of Optimade APIs that are aknowledged by the implementor of this API.
+	    These should not be just the known APIs, but somehow connected to the implementor of this API, for example managed by him.
+	    An entry describing the current API MIGHT be present.
+	    Each api is described by an oject with the following attributes:
+	        * **type**: optional, SHOULD be "api"
+	        * **api\_base\_uri**: a string containing an url.
+	            The provided url MUST adhere to the rules of [section '3.1. Base URL'](#h.3.1).
+	        * **api\_description**: a list of strings providing a human readable description in markdown format of the content available through the API
     * **formats**: a list of available output formats.
     * **entry\_types\_by\_format**: Available entry endpoints as a function of output formats.
+    * **info\_description**: a list of strings providing a human readable description in markdown format of the content available through this API.
 
 Example:
 


### PR DESCRIPTION
Add simple discovery of Optimade APIs

- an api can consist only of the info endpoint
- info endpoint  moves further toward discovery (already had discovery
of other versions). This looks like a better use of info, description
of endpoints is better done via swagger (standard, widely used)
- minimal change: aknowledged_apis attribute
- bootstrap directory in git is a valid api that can provide the first
link to the implementations (via gitlab raw access)
- discovery of sub-databases or other implementations with the same
mechanism

Notes
- names open for discussion
- aknowledged_apis could be extended to be a full info object and contain other aknowledged_apis (to return full trees with fewer requests)
- sorry branch name should have started with issue #22 