### PR TITLE
Change top-level response fields to be more JSON API compliant

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -190,7 +190,7 @@ Not only in response format, but also in, e.g., how content negotiation is imple
 
 ### <a name="h.3.3.2">3.3.2. JSON API Response Schema: Common Fields</a>
 
-Every response MUST contain the following fields:
+Every response SHOULD contain the following fields, and MUST contain at least one:
 
 * **meta**: a [JSON API meta member](https://jsonapi.org/format/1.0/#document-meta)
   that contains JSON API meta objects of non-standard meta-information.  
@@ -328,7 +328,7 @@ related to the primary data contained in `data`.
 A response with related resources under `included` are in the JSON API known as
 [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents).
 
-If there were errors in producing the response all other fields MAY be skipped, and the following field MUST be present
+If there were errors in producing the response all other fields MAY be present, but the top-level `data` field MUST be skipped, and the following field MUST be present:
 
 * **errors**: a list of [JSON API error objects](http://jsonapi.org/format/1.0/#error-objects).
 


### PR DESCRIPTION
### Overview
As suggested [here](https://github.com/Materials-Consortia/OPTiMaDe/pull/63#issuecomment-476124565), the common fields in an OPTiMaDe API response should be more JSON API-like, see [here](https://jsonapi.org/format/#document-top-level).

#### Changes
At least one of the fields MUST be included:
- `meta`
- `links`
- `data`

All of those fields SHOULD be included (instead of MUST).

If any errors: ONLY the field `errors` MUST be included.

#### Personal note
I think it is useful to *not* only return the `errors` field if errors occur, but this is the way JSON API specifies to do it.