### PR TITLE
[WIP] Update README in master-branch to guide client/server developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ general common API for retrieving data from materials databases.
 
 * [optimade.md](optimade.md): The API specification.
 * [AUTHORS](AUTHORS): List of contributors.
+
+## For developers
+
+The latest "stable" version of the specification is found in the [master](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) branch.  
+The latest "in development" version is found in the [develop](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop) branch.
+
+If you are a **server** developer, it is _mandated_ to always implement the latest stable version, while it is _recommended_ to implement the latest version in development.
+This may be achieved by having a _master_ and _develop_ structure for your implementation, similar to the one used here.
+
+If you are a **client** developer, you are _encouraged_ to support at least the latest stable version, while it is _recommended_ to support the latest version in development.
+This may be achieved by having a _master_ and _develop_ structure for your client code, similar to the one used here.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ general common API for retrieving data from materials databases.
 The latest "stable" version of the specification is found in the [master](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) branch.  
 The latest "in development" version is found in the [develop](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop) branch.
 
-If you are a **server** developer, it is _mandated_ to always implement the latest stable version, while it is _recommended_ to implement the latest version in development.
-This may be achieved by having a _master_ and _develop_ structure for your implementation, similar to the one used here.
+If you are a **server** developer, it is _recommended_ to always implement the latest stable version. It is also _recommended_ to implement the latest version in development.
+You may want to use the same _master_ and _develop_ branch model employed here.
 
 If you are a **client** developer, you are _encouraged_ to support at least the latest stable version, while it is _recommended_ to support the latest version in development.
-This may be achieved by having a _master_ and _develop_ structure for your client code, similar to the one used here.
+You may want to use the same _master_ and _develop_ branch model employed here.


### PR DESCRIPTION
Fixes #76

Add section in README in the `master` branch, suggesting client and/or server developers to go to the `develop` branch.