### PR TITLE
Clarifying requirements for the entry resource object

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -1304,6 +1304,7 @@ This section defines standard entry types and their properties.
 ### <a name="h.6.1.2">6.1.2. type</a>
 
 * **Description**: the type of an entry.
+* **Requirements/Conventions**: MUST be an existing entry type.
 * **Example**: `structure`
 
 ### <a name="h.6.1.3">6.1.3. last\_modified</a>

--- a/optimade.md
+++ b/optimade.md
@@ -1306,7 +1306,12 @@ This section defines standard entry types and their properties.
 * **Example**: `"2007-04-05T14:30Z"`
 * **Querying**: Date-time queries are permitted ([RFC 3339](http://tools.ietf.org/html/rfc3339)).
 
-### <a name="h.6.1.3">6.1.3. database-provider-specific properties</a>
+### <a name="h.6.1.3">6.1.3. type</a>
+
+* **Description**: the type of an entry.
+* **Example**: `structure`
+
+### <a name="h.6.1.4">6.1.4. database-provider-specific properties</a>
 
 * **Description**: Database providers are allowed to insert database-provider-specific entries
   in the output of both standard entry types and database-provider-specific entry types.

--- a/optimade.md
+++ b/optimade.md
@@ -505,7 +505,7 @@ Examples:
 key. The value of this key MUST be a list containing dictionaries that
 represent individual entries. In the JSON API format every dictionary
 ([resource object](http://jsonapi.org/format/#document-resource-objects))
-needs the following fields:
+MUST have the following fields:
 
 * **type**: field containing the type of the entry
 * **id**: a string which together with the type uniquely identifies the object,

--- a/optimade.md
+++ b/optimade.md
@@ -40,8 +40,8 @@
 [6. Entry List](#h.6)  
 &nbsp;&nbsp;&nbsp;&nbsp;[6.1. Properties Used by Multiple Entry Types](#h.6.1)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.1.1. id](#h.6.1.1)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.1.2. last\_modified](#h.6.1.2)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.1.3. type](#h.6.1.3)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.1.2. type](#h.6.1.2)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.1.3. last\_modified](#h.6.1.3)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.1.4. database-provider-specific properties](#h.6.1.4)  
 &nbsp;&nbsp;&nbsp;&nbsp;[6.2. Structure Entries](#h.6.2)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.1. elements](#h.6.2.1)  
@@ -1301,17 +1301,17 @@ This section defines standard entry types and their properties.
   * `"nomad/L1234567890"`
   * `"42"`
 
-### <a name="h.6.1.2">6.1.2. last\_modified</a>
+### <a name="h.6.1.2">6.1.2. type</a>
+
+* **Description**: the type of an entry.
+* **Example**: `structure`
+
+### <a name="h.6.1.3">6.1.3. last\_modified</a>
 
 * **Description**: Date representing when the entry was last modified.
 * **Requirements/Conventions**: String with [ISO 8601](https://www.iso.org/standard/40874.html) format.
 * **Example**: `"2007-04-05T14:30Z"`
 * **Querying**: Date-time queries are permitted ([RFC 3339](http://tools.ietf.org/html/rfc3339)).
-
-### <a name="h.6.1.3">6.1.3. type</a>
-
-* **Description**: the type of an entry.
-* **Example**: `structure`
 
 ### <a name="h.6.1.4">6.1.4. database-provider-specific properties</a>
 

--- a/optimade.md
+++ b/optimade.md
@@ -1305,7 +1305,7 @@ This section defines standard entry types and their properties.
 
 * **Description**: the type of an entry.
 * **Requirements/Conventions**: MUST be an existing entry type.
-* **Example**: `structure`
+* **Example**: `"structure"`
 
 ### <a name="h.6.1.3">6.1.3. last\_modified</a>
 

--- a/optimade.md
+++ b/optimade.md
@@ -41,6 +41,8 @@
 &nbsp;&nbsp;&nbsp;&nbsp;[6.1. Properties Used by Multiple Entry Types](#h.6.1)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.1.1. id](#h.6.1.1)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.1.2. last\_modified](#h.6.1.2)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.1.3. type](#h.6.1.3)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.1.4. database-provider-specific properties](#h.6.1.4)  
 &nbsp;&nbsp;&nbsp;&nbsp;[6.2. Structure Entries](#h.6.2)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.1. elements](#h.6.2.1)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.2. nelements](#h.6.2.2)  


### PR DESCRIPTION
1. Defining `id`, `type` and `attributes` as MUST-have.
2. Describing `type` as property used by multiple entry types.