### PR TITLE
Update HTTP Response Status Codes according to JSON API

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -361,21 +361,27 @@ An example of a full response:
 }
 ```
 
-### 3.3.4. HTTP Response Status Codes
+### <a name="h.3.3.3">3.3.3. HTTP Response Status Codes</a>
 
-| Code | Message                                                               |
-|:----:|:--------------------------------------------------------------------- |
-| 200  | OK (Successful operation)                                             |
-| 400  | Bad request (e.g., mistyped URL)                                       |
-| 401  | User does not have permission                                         |
-| 403  | Forbidden (the request was understood but not authorized)             |
-| 404  | Not found (e.g., database not found)                                   |
-| 408  | Request timeout because it is taking too long to process the query    |
-| 410  | The database has been moved                                           |
-| 413  | The response is too large                                             |
-| 414  | The requested URI contains more than 2048 characters                  |
-| 418  | Asked for a non-existent keyword                                      |
-| 422  | Database returned (200) but the translator failed                     |
+All HTTP response status codes MUST conform to [RFC 7231: HTTP Semantics](http://tools.ietf.org/html/rfc7231).
+The code registry is maintained by IANA and can be found [here](http://www.iana.org/assignments/http-status-codes).
+
+A non-exhaustive table of codes (taken from IANA) for the most common HTTP response codes may be found here:
+
+| Code | Description           |
+|:----:|:--------------------- |
+| 200  | OK                    |
+| 400  | Bad Request           |
+| 401  | Unauthorized          |
+| 403  | Forbidden             |
+| 404  | Not Found             |
+| 408  | Request Timeout       |
+| 410  | Gone                  |
+| 413  | Payload Too Large     |
+| 414  | URI Too Long          |
+| 422  | Unprocessable Entity  |
+
+See also the JSON API definitions of responses when [fetching](https://jsonapi.org/format/#fetching) data, i.e., sending a `GET` request.
 
 **Notes**:
 If a client receives an unexpected 404 error when making a query to a base URL,

--- a/optimade.md
+++ b/optimade.md
@@ -366,24 +366,9 @@ An example of a full response:
 All HTTP response status codes MUST conform to [RFC 7231: HTTP Semantics](http://tools.ietf.org/html/rfc7231).
 The code registry is maintained by IANA and can be found [here](http://www.iana.org/assignments/http-status-codes).
 
-A non-exhaustive table of codes (taken from IANA) for the most common HTTP response codes may be found here:
-
-| Code | Description           |
-|:----:|:--------------------- |
-| 200  | OK                    |
-| 400  | Bad Request           |
-| 401  | Unauthorized          |
-| 403  | Forbidden             |
-| 404  | Not Found             |
-| 408  | Request Timeout       |
-| 410  | Gone                  |
-| 413  | Payload Too Large     |
-| 414  | URI Too Long          |
-| 422  | Unprocessable Entity  |
-
 See also the JSON API definitions of responses when [fetching](https://jsonapi.org/format/#fetching) data, i.e., sending a `GET` request.
 
-**Notes**:
+**Important**:
 If a client receives an unexpected 404 error when making a query to a base URL,
 and is aware of the index meta-database that belongs to the database provider
 (as described in [3.4. Index Meta-Database](#h.3.4)),


### PR DESCRIPTION
Fixes #71

Removed code 418 (which is an unassaigned code, used (in)famously for [I am a teapot](https://www.google.com/teapot)).
Removed all parentheses in the description of codes.

Referencing [IANA](http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml) and [RFC7231](https://tools.ietf.org/html/rfc7231) for codes and their definitions.