### PR TITLE
Adding support for unknown coordinates

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -1467,8 +1467,8 @@ an atom, or a placeholder for a virtual mixture of atoms (e.g., in a virtual cry
     e.g., the [6.2.10.`assemblies`](#h.6.2.10) property).
   * If a component of the position is unknown, the `null` value should be provided instead. 
     Otherwise, it should be a float value, expressed in angstrom. Note that if at least one
-    of the coordinates is unknown, the correct flag in the 
-    [`structure_features`](#h.6.2.11) list MUST be set.
+    of the coordinates is unknown, the correct flag MUST be set
+    in the list `structure_features` (see section [6.2.11 `structure_features`](#h.6.2.11)).
 * **Notes**: (for implementers) While this is unrelated to this OPTiMaDe specification:
   if you decide to store internally the `cartesian_site_positions` as a float array,
   you might want to replace `null` values with `NaN` values, the latter being valid float numbers
@@ -1509,14 +1509,15 @@ by multiple chemical elements.
   * This property is REQUIRED.
   * It MUST be a dictionary, where keys represent the species' name, and values are themselves
   dictionaries with the following keys:
-    * **chemical\_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing this species. 
-      *  It MUST be one of the following:
+    * **chemical\_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing this species.
+      * It MUST be one of the following:
         * a valid chemical-element name, or
         * the special value `"X"` to represent a non-chemical element, or
         * the special value `"vacancy"` to represent that this site has a non-zero probability of having
         a vacancy (the respective probability is indicated in the `concentration` list, see below).
       * If any one entry in the `species` list has a `chemical_symbols` list that 
-        is longer than 1 element, the correct flag in the [`structure_features`](#h.6.2.11) list MUST be set.
+        is longer than 1 element, the correct flag MUST be set
+        in the list `structure_features` (see section [6.2.11 `structure_features`](#h.6.2.11)).
   
 
     * **concentration**: REQUIRED; MUST be a list of floats, with same length as `chemical_symbols`.
@@ -1567,8 +1568,8 @@ by multiple chemical elements.
 * **Description**: A description of groups of sites that are statistically correlated.
 * **Requirements/Conventions**:
   * This key is OPTIONAL (it is absent if there are no partial occupancies).
-  * If present, the correct flag in the 
-    [`structure_features`](#h.6.2.11) list MUST be set.
+  * If present, the correct flag MUST be set
+    in the list `structure_features` (see section [6.2.11 `structure_features`](#h.6.2.11)).
   * Client implementations MUST check its presence (as its presence changes the
     interpretation of the structure).
   * If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have
@@ -1676,7 +1677,7 @@ by multiple chemical elements.
 * **Requirements/Conventions**: 
   * This property is REQUIRED.
   * This property MUST be returned as an empty list if no special features are used.
-  * This list MUST be sorted.  
+  * This list MUST be sorted alphabetically.  
   * If a special feature listed below is used, the corresponding string MUST be set.
   * If a special feature listed below is not used, the corresponding string MUST NOT be set. 
 * **List of special structure features**:

--- a/optimade.md
+++ b/optimade.md
@@ -49,9 +49,10 @@
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.5. dimension\_types](#h.6.2.5)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.6. lattice\_vectors](#h.6.2.6)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.7. cartesian\_site\_positions](#h.6.2.7)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.8. species\_at\_sites](#h.6.2.8)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.9. species](#h.6.2.9)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.10. assemblies](#h.6.2.10)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.8. all\_coordinates\_known](#h.6.2.8)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.9. species\_at\_sites](#h.6.2.9)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.10. species](#h.6.2.10)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.11. assemblies](#h.6.2.11)  
 &nbsp;&nbsp;&nbsp;&nbsp;[6.3. Calculation Entries](#h.6.3)  
 
 [Appendix 1: Database-Provider-Specific Namespace Prefixes](#h.app1)  
@@ -1414,21 +1415,35 @@ an atom, or a placeholder for a virtual mixture of atoms (e.g., in a virtual cry
   * This property is REQUIRED.
   * It MUST be a list of length N times 3, where N is the number of sites in the structure.
   * An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see
-  e.g., the [6.2.10.`assemblies`](#h.6.2.10) property).
+    e.g., the [6.2.11.`assemblies`](#h.6.2.11) property).
+  * If a component of the position is unknown, the `null` value should be provided instead. 
+    Otherwise, it should be a float value, expressed in angstrom. (See also the property `all_coordinates_known`.)
+* **Notes**: (for implementers) While this is unrelated to this OPTiMaDe specification:
+  if you decide to store internally the `cartesian_site_positions` as a float array,
+  you might want to replace `null` values with `NaN` values, the latter being valid float numbers
+  in the IEEE 754 standard in [IEEE 754-1985](https://doi.org/10.1109/IEEESTD.1985.82928) and in the updated
+  version [IEEE 754-2008](https://doi.org/10.1109/IEEESTD.2008.4610935).
 * **Examples**:
   * `[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along
   the (positive) `z` axis, 2 Å away from the origin.
 
-### <a name="h.6.2.8">6.2.8. species\_at\_sites</a>
+### <a name="h.6.2.8">6.2.8. all\_coordinates\_known</a>
+* **Description**: A boolean indicating if all coordinates are known and specified in the `cartesian_site_positions` list.
+* **Requirements/Conventions**: 
+  * This property is REQUIRED.
+  * If at least one component of the `cartesian_site_positions` list of lists has value `null`, 
+    then the `all_coordinates_known` property MUST be set to `false`, otherwise it MUST be set to `true`.
+
+### <a name="h.6.2.9">6.2.9. species\_at\_sites</a>
 
 * **Description**: Name of the species at each site (where values for sites are specified with the
 same order of the [6.2.7. `cartesian_site_positions`](#h.6.2.7) property). The properties of the
-species are found in the [6.2.9. `species`](#h.6.2.9) property.
+species are found in the [6.2.10. `species`](#h.6.2.10) property.
 * **Requirements/Conventions**:
   * This property is REQUIRED.
   * It MUST be a list of strings, which MUST have length equal to the number of sites in the structure
     (first dimension of the [6.2.7. `cartesian_site_positions`](#h.6.2.7) list).
-  * Each string MUST be a valid key of the dictionary specified by the [6.2.9. `species`](#h.6.2.9)
+  * Each string MUST be a valid key of the dictionary specified by the [6.2.10. `species`](#h.6.2.10)
     property. The requirements on this string are the same as for property names, i.e., it can be of any
     length, may use upper and lower case letters, underscore, and digits 0-9, but MUST NOT begin with a
     digit.
@@ -1441,7 +1456,7 @@ species are found in the [6.2.9. `species`](#h.6.2.9) property.
   * `["Ti","O2"]` indicates that the first site is hosting a species labeled `"Ti"` and the second a
   species labeled `"O2"`.
 
-### <a name="h.6.2.9">6.2.9. species</a>
+### <a name="h.6.2.10">6.2.10. species</a>
 
 * **Description**: Dictionary describing the species of the sites of this structure. Species can be
 pure chemical elements, or virtual-crystal atoms representing a statistical occupation of a given site
@@ -1476,7 +1491,7 @@ by multiple chemical elements.
     Note: With regards to "source database", we refer to the immediate source being queried via the
     OPTiMaDe API implemention. The main use of this field is for source databases that use species
     names, containing characters that are not allowed (see description of the
-    [6.2.8. `species_at_sites`](#h.6.2.8) list).
+    [6.2.9. `species_at_sites`](#h.6.2.9) list).
 
   * For systems that have only species formed by a single chemical symbol, and that have at most one
   species per chemical symbol, SHOULD use the chemical symbol as species name (e.g., `"Ti"` for
@@ -1500,7 +1515,7 @@ by multiple chemical elements.
   * `"C13": {"chemical_symbols": ["C"], "concentration": [1.0], "mass": 13.}`: any site with this
   species is occupied by a carbon isotope with mass 13.
 
-### <a name="h.6.2.10">6.2.10. assemblies</a>
+### <a name="h.6.2.11">6.2.11. assemblies</a>
 
 * **Description**: A description of groups of sites that are statistically correlated.
 * **Requirements/Conventions**:
@@ -1516,7 +1531,7 @@ by multiple chemical elements.
     `sites_in_groups`. It SHOULD sum to one. See below for examples of how to specify the probability
     of the occurrence of a vacancy. The possible reasons for the values not to sum to one are the same
     as already specified above for the `concentration` of each `species`, see section
-    [6.2.9. `species`](#h.6.2.9).
+    [6.2.10. `species`](#h.6.2.10).
   * If a site is not present in any group, it means that is is present with 100 % probability (as if
   no assembly was specified).
   * A site MUST NOT appear in more than one group.

--- a/optimade.md
+++ b/optimade.md
@@ -50,10 +50,10 @@
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.5. dimension\_types](#h.6.2.5)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.6. lattice\_vectors](#h.6.2.6)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.7. cartesian\_site\_positions](#h.6.2.7)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.8. all\_coordinates\_known](#h.6.2.8)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.9. species\_at\_sites](#h.6.2.9)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.10. species](#h.6.2.10)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.11. assemblies](#h.6.2.11)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.8. species\_at\_sites](#h.6.2.8)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.9. species](#h.6.2.9)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.10. assemblies](#h.6.2.10)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[6.2.11. structure\_features](#h.6.2.11)  
 &nbsp;&nbsp;&nbsp;&nbsp;[6.3. Calculation Entries](#h.6.3)  
 &nbsp;&nbsp;&nbsp;&nbsp;[6.4. Database-Provider-Specific Entry Types](#h.6.4)  
 
@@ -1464,9 +1464,11 @@ an atom, or a placeholder for a virtual mixture of atoms (e.g., in a virtual cry
   * This property is REQUIRED.
   * It MUST be a list of length N times 3, where N is the number of sites in the structure.
   * An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see
-    e.g., the [6.2.11.`assemblies`](#h.6.2.11) property).
+    e.g., the [6.2.10.`assemblies`](#h.6.2.10) property).
   * If a component of the position is unknown, the `null` value should be provided instead. 
-    Otherwise, it should be a float value, expressed in angstrom. (See also the property `all_coordinates_known`.)
+    Otherwise, it should be a float value, expressed in angstrom. Note that if at least one
+    of the coordinates is unknown, the correct flag in the 
+    [`structure_features`](#h.6.2.11) list MUST be set.
 * **Notes**: (for implementers) While this is unrelated to this OPTiMaDe specification:
   if you decide to store internally the `cartesian_site_positions` as a float array,
   you might want to replace `null` values with `NaN` values, the latter being valid float numbers
@@ -1476,23 +1478,16 @@ an atom, or a placeholder for a virtual mixture of atoms (e.g., in a virtual cry
   * `[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along
   the (positive) `z` axis, 2 Å away from the origin.
 
-### <a name="h.6.2.8">6.2.8. all\_coordinates\_known</a>
-* **Description**: A boolean indicating if all coordinates are known and specified in the `cartesian_site_positions` list.
-* **Requirements/Conventions**: 
-  * This property is REQUIRED.
-  * If at least one component of the `cartesian_site_positions` list of lists has value `null`, 
-    then the `all_coordinates_known` property MUST be set to `false`, otherwise it MUST be set to `true`.
-
-### <a name="h.6.2.9">6.2.9. species\_at\_sites</a>
+### <a name="h.6.2.8">6.2.8. species\_at\_sites</a>
 
 * **Description**: Name of the species at each site (where values for sites are specified with the
 same order of the [6.2.7. `cartesian_site_positions`](#h.6.2.7) property). The properties of the
-species are found in the [6.2.10. `species`](#h.6.2.10) property.
+species are found in the [6.2.9. `species`](#h.6.2.9) property.
 * **Requirements/Conventions**:
   * This property is REQUIRED.
   * It MUST be a list of strings, which MUST have length equal to the number of sites in the structure
     (first dimension of the [6.2.7. `cartesian_site_positions`](#h.6.2.7) list).
-  * Each string MUST be a valid key of the dictionary specified by the [6.2.10. `species`](#h.6.2.10)
+  * Each string MUST be a valid key of the dictionary specified by the [6.2.9. `species`](#h.6.2.9)
     property. The requirements on this string are the same as for property names, i.e., it can be of any
     length, may use upper and lower case letters, underscore, and digits 0-9, but MUST NOT begin with a
     digit.
@@ -1505,7 +1500,7 @@ species are found in the [6.2.10. `species`](#h.6.2.10) property.
   * `["Ti","O2"]` indicates that the first site is hosting a species labeled `"Ti"` and the second a
   species labeled `"O2"`.
 
-### <a name="h.6.2.10">6.2.10. species</a>
+### <a name="h.6.2.9">6.2.9. species</a>
 
 * **Description**: Dictionary describing the species of the sites of this structure. Species can be
 pure chemical elements, or virtual-crystal atoms representing a statistical occupation of a given site
@@ -1514,12 +1509,15 @@ by multiple chemical elements.
   * This property is REQUIRED.
   * It MUST be a dictionary, where keys represent the species' name, and values are themselves
   dictionaries with the following keys:
-    * **chemical\_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing
-    this species. It MUST be one of the following:
-      * a valid chemical-element name, or
-      * the special value `"X"` to represent a non-chemical element, or
-      * the special value `"vacancy"` to represent that this site has a non-zero probability of having
-      a vacancy (the respective probability is indicated in the `concentration` list, see below).
+    * **chemical\_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing this species. 
+      *  It MUST be one of the following:
+        * a valid chemical-element name, or
+        * the special value `"X"` to represent a non-chemical element, or
+        * the special value `"vacancy"` to represent that this site has a non-zero probability of having
+        a vacancy (the respective probability is indicated in the `concentration` list, see below).
+      * If any one entry in the `species` list has a `chemical_symbols` list that 
+        is longer than 1 element, the correct flag in the [`structure_features`](#h.6.2.11) list MUST be set.
+  
 
     * **concentration**: REQUIRED; MUST be a list of floats, with same length as `chemical_symbols`.
     The numbers represent the relative concentration of the corresponding chemical symbol in this
@@ -1540,7 +1538,7 @@ by multiple chemical elements.
     Note: With regards to "source database", we refer to the immediate source being queried via the
     OPTiMaDe API implemention. The main use of this field is for source databases that use species
     names, containing characters that are not allowed (see description of the
-    [6.2.9. `species_at_sites`](#h.6.2.9) list).
+    [6.2.8. `species_at_sites`](#h.6.2.8) list).
 
   * For systems that have only species formed by a single chemical symbol, and that have at most one
   species per chemical symbol, SHOULD use the chemical symbol as species name (e.g., `"Ti"` for
@@ -1564,13 +1562,15 @@ by multiple chemical elements.
   * `"C13": {"chemical_symbols": ["C"], "concentration": [1.0], "mass": 13.}`: any site with this
   species is occupied by a carbon isotope with mass 13.
 
-### <a name="h.6.2.11">6.2.11. assemblies</a>
+### <a name="h.6.2.10">6.2.10. assemblies</a>
 
 * **Description**: A description of groups of sites that are statistically correlated.
 * **Requirements/Conventions**:
   * This key is OPTIONAL (it is absent if there are no partial occupancies).
-  * Client implementations MUST check its presence (as its presence changes the interpretation of the
-  structure).
+  * If present, the correct flag in the 
+    [`structure_features`](#h.6.2.11) list MUST be set.
+  * Client implementations MUST check its presence (as its presence changes the
+    interpretation of the structure).
   * If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have
   the following two keys:
     * **sites\_in\_groups**: Index of the sites (0-based) that belong to each group for each assembly.  
@@ -1580,7 +1580,7 @@ by multiple chemical elements.
     `sites_in_groups`. It SHOULD sum to one. See below for examples of how to specify the probability
     of the occurrence of a vacancy. The possible reasons for the values not to sum to one are the same
     as already specified above for the `concentration` of each `species`, see section
-    [6.2.10. `species`](#h.6.2.10).
+    [6.2.9. `species`](#h.6.2.9).
   * If a site is not present in any group, it means that is is present with 100 % probability (as if
   no assembly was specified).
   * A site MUST NOT appear in more than one group.
@@ -1669,6 +1669,29 @@ by multiple chemical elements.
     of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2\*0.3 = 6 %
     probability; the pair (0, 3) with 0.2\*0.7 = 14 % probability; the pair (1, 2) with
     0.8\*0.3 = 24 % probability; and the pair (1, 3) with 0.8\*0.7 = 56 % probability).
+
+### <a name="h.6.2.11">6.2.11. structure\_features</a>
+* **Description**: A list of strings, flagging which special features are used by
+  the structure.
+* **Requirements/Conventions**: 
+  * This property is REQUIRED.
+  * This property MUST be returned as an empty list if no special features are used.
+  * This list MUST be sorted.  
+  * If a special feature listed below is used, the corresponding string MUST be set.
+  * If a special feature listed below is not used, the corresponding string MUST NOT be set. 
+* **List of special structure features**:
+  * `disorder`: This flag MUST be present if any one entry in the `species` list has a 
+    `chemical_symbols` list that is longer than 1 element.
+  * `unknown_positions`: This flag MUST be present if at least one component of the
+    `cartesian_site_positions` list of lists has value `null`.
+  * `assemblies`: This flag MUST be present if the [`assemblies`](#h.6.2.10)
+    list is present.  
+* **Querying**: This property MUST be queryable.
+* **Examples**: A structure having unknown positions and using assemblies:
+
+  ```json
+  ["assemblies", "unknown_positions"]
+  ```
 
 ## <a name="h.6.3">6.3. Calculation Entries</a>
 


### PR DESCRIPTION
This fixes #50 and #93 

This also adds the `all_coordinates_known` property as discussed
in #50.

I did also some section renumbering because I felt that
it is better to keep `all_coordinates_known` close to the
`cartesian_site_positions` section.

I also added a note for implementers for `NaN`s vs `null`s.
