### PR TITLE
update authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,9 +3,11 @@ participants of the workshops "Open Databases Integration for Materials
 Design", held at:
 - the Lorentz Center in Leiden, Netherlands from 2016-10-24 to 2016-10-28
 - the CECAM in Lausanne, Switzerland from 2018-06-11 to 2018-06-14
+- the CECAM in Lausanne, Switzerland from 2019-06-11 to 2019-06-14
 
-In alphabetical order:
+The OPTiMaDe development team in alphabetical order:
 
+Casper Andersen
 Thomas Archer
 Rossella Aversa
 Rickard Armiento
@@ -17,7 +19,10 @@ Claudia Draxl
 Shyam Dwaraknath
 Suleyman Er
 Matthew Evans
+Adam Fekete
 Marco Fornari
+Matteo Giantomassi
+Abhijith Gopakumar
 Marco Govoni
 Saulius Gražulis
 Geoffroy Hautier
@@ -36,13 +41,16 @@ Arash Mostofi
 Nicolas Mounet
 Corey Oses
 Guido Petretto
+Thomas Purcell
 Giovanni Pizzi
 Francesco Ricci
 Gian-Marco Rignanese
 Matthias Scheffler
 Markus Scheidgen
+Daniel Speckhard
 Leopold Talirz
 Cormac Toher
+Daniele Tomerini
 Martin Uhrin
 Pierre Villars
 David Waroquiers

--- a/AUTHORS
+++ b/AUTHORS
@@ -2,7 +2,7 @@ The initial release of the OPTIMADE API was developed by the
 participants of the workshops "Open Databases Integration for Materials
 Design", held at:
 - the Lorentz Center in Leiden, Netherlands from 2016-10-24 to 2016-10-28
-- the CECAM in Lausanne, Switzerland from 2018-06-11 to 2018-06-14
+- the CECAM in Lausanne, Switzerland from 2018-06-11 to 2018-06-15
 - the CECAM in Lausanne, Switzerland from 2019-06-11 to 2019-06-14
 
 The OPTiMaDe development team in alphabetical order:


### PR DESCRIPTION
 * update authors
 * add new workshop
 * add "optimade developers team" reference, which can be reused in
   repositories across the materials-consortia github organization