### PR TITLE
(Re)define `property`

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -102,8 +102,8 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 * **Database**: An implementation that serves materials information.
 * **Entry**: A type of resource, over which a query can be formulated using the API
   (e.g., structure or calculation).
-* **Field**: A key in a JSON object.
-* **Property**: A field and the field's value collectively in a JSON object.
+* **Field**: A string key (similar to a key in a hash table, with the limitation that it MUST be a string).
+* **Property**: A field-value pair.
 * **Property Value Types**:
   * **string**, **integer**, **float**, **boolean**, **null value**: Base data
     types as defined in more detail in section [5.1. Lexical Tokens](#h.5.1).

--- a/optimade.md
+++ b/optimade.md
@@ -101,10 +101,19 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 * **Database**: An implementation that serves materials information.
 * **Entry**: A type of resource, over which a query can be formulated using the API
   (e.g., structure or calculation).
-* **Property**: Anything that can be in the filtering of results.
-* **Field**: A property that can be requested as partial output from the API.
+* **Field**: A key in a JSON object.
+* **Property**: A field and the field's value collectively in a JSON object.
+* **Property Value Types**:
+  * **string**, **integer**, **float**, **boolean**, **null value**: Base data
+    types as defined in more detail in section [5.1. Lexical Tokens](#h.5.1).
+  * **list**, **dictionary**: Collection of base types with the meaning they have in the JSON
+    data-interchange format, i.e., an ordered list of elements
+    (where each element can have a different type) or a hash table
+    (with the limitation that the hash key MUST be a string), respectively.
 * **Resource object**: Represent resources. MUST contain at least the following top-level fields:
   `id`, `type`.
+* **Resource property**: Special property for resource objects.
+  The only kind of property, whose field can be queried (using `filter`, see section [5. API Filtering Format Specification](#h.5)).
 * **ID**: A unique identifier referencing a specific resource in the database.
   Together with **Entry**, the ID MUST uniquely identify the **Resource object**.
   IDs MUST be URL-safe; in particular, they MUST NOT contain commas.
@@ -114,13 +123,6 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
   database that MUST be immutable.
 * **Reserved words**: The list of reserved words in this standard is:
   `info`.
-* **Property Types**:
-  * **string**, **integer**, **float**, **boolean**, **null value**: Base data
-    types as defined in more detail in section [5.1. Lexical Tokens](#h.5.1).
-  * **list**, **dictionary**: Collection of base types with the meaning they have in the JSON
-    data-interchange format, i.e., an ordered list of elements
-    (where each element can have a different type) or a hash table
-    (with the limitation that the hash key MUST be a string), respectively.
 
 # <a name="h.3">3. General API Requirements and Conventions</a>
 

--- a/optimade.md
+++ b/optimade.md
@@ -102,15 +102,15 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 * **Database**: An implementation that serves materials information.
 * **Entry**: A type of resource, over which a query can be formulated using the API
   (e.g., structure or calculation).
-* **Field**: A string key (similar to a key in a hash table, with the limitation that it MUST be a string).
+* **Field**: A key of an associative-array-type data structure.
+  A field MUST be a string, which MAY exclusively contain lowercase alphanumerics (`[a-z0-9]`) and underscores (`"_"`).
 * **Property**: A field-value pair.
-* **Property Value Types**:
+* **Property value types**:
   * **string**, **integer**, **float**, **boolean**, **null value**: Base data
     types as defined in more detail in section [5.1. Lexical Tokens](#h.5.1).
-  * **list**, **dictionary**: Collection of base types with the meaning they have in the JSON
-    data-interchange format, i.e., an ordered list of elements
-    (where each element can have a different type) or a hash table
-    (with the limitation that the hash key MUST be a string), respectively.
+  * **list**, **dictionary**: Collections of base types, defined in the samme manner as a JSON [array](https://json-schema.org/understanding-json-schema/reference/array.html) and [object](https://json-schema.org/understanding-json-schema/reference/object.html), respectively.
+* **Queryable property**: A property that can be in the filtering of results.
+  For more information see section [3.5. Queryable Properties](#h.3.5).
 * **Resource object**: Represents resources. MUST contain at least the following top-level fields:
   `id`, `type`.
 * **ID**: A unique identifier referencing a specific resource in the database.
@@ -489,10 +489,10 @@ The value for `is_index` MUST be `true`.
 
 ## <a name="h.3.5">3.5. Queryable Properties</a>
 
-Queryable properties are resource properties.
+_Only_ properties of resource objects can be queried.
 It is understood that when one queries a property, one queries on the property's field.
 In other words, one can _only_ query on property fields from resource objects' properties.  
-A query is performed using `filter` see section [5. API Filtering Format Specification](#h.5)).
+A query is performed using `filter` (see section [5. API Filtering Format Specification](#h.5)).
 
 > **For implementers**: To get an understanding of which properties MUST be queryable and which are RECOMMENDED, please see section [6. Entry List](#h.6).
 

--- a/optimade.md
+++ b/optimade.md
@@ -111,7 +111,7 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
     data-interchange format, i.e., an ordered list of elements
     (where each element can have a different type) or a hash table
     (with the limitation that the hash key MUST be a string), respectively.
-* **Resource object**: Represent resources. MUST contain at least the following top-level fields:
+* **Resource object**: Represents resources. MUST contain at least the following top-level fields:
   `id`, `type`.
 * **ID**: A unique identifier referencing a specific resource in the database.
   Together with **Entry**, the ID MUST uniquely identify the **Resource object**.

--- a/optimade.md
+++ b/optimade.md
@@ -14,6 +14,7 @@
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[3.3.4. Unset optional properties](#h.3.3.4)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[3.3.5. Warnings](#h.3.3.5)  
 &nbsp;&nbsp;&nbsp;&nbsp;[3.4. Index Meta-Database](#h.3.4)  
+&nbsp;&nbsp;&nbsp;&nbsp;[3.5. Queryable Properties](#h.3.5)  
 
 [4. API endpoints](#h.4)  
 &nbsp;&nbsp;&nbsp;&nbsp;[4.1. Entry Listing Endpoints](#h.4.1)  
@@ -112,8 +113,6 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
     (with the limitation that the hash key MUST be a string), respectively.
 * **Resource object**: Represent resources. MUST contain at least the following top-level fields:
   `id`, `type`.
-* **Resource property**: Special property for resource objects.
-  The only kind of property, whose field can be queried (using `filter`, see section [5. API Filtering Format Specification](#h.5)).
 * **ID**: A unique identifier referencing a specific resource in the database.
   Together with **Entry**, the ID MUST uniquely identify the **Resource object**.
   IDs MUST be URL-safe; in particular, they MUST NOT contain commas.
@@ -487,6 +486,15 @@ The value for `is_index` MUST be `true`.
 > **Note**: A list of database providers acknowledged by the
 > **Open Databases Integration for Materials Design** consortium can be found in [Appendix 1](#h.app1).
 > This list is also machine-readable, optimizing the automatic discoverability.
+
+## <a name="h.3.5">3.5. Queryable Properties</a>
+
+Queryable properties are resource properties.
+It is understood that when one queries a property, one queries on the property's field.
+In other words, one can _only_ query on property fields from resource objects' properties.  
+A query is performed using `filter` see section [5. API Filtering Format Specification](#h.5)).
+
+> **For implementers**: To get an understanding of which properties MUST be queryable and which are RECOMMENDED, please see section [6. Entry List](#h.6).
 
 # <a name="h.4">4. API Endpoints</a>
 

--- a/optimade.md
+++ b/optimade.md
@@ -103,12 +103,12 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 * **Entry**: A type of resource, over which a query can be formulated using the API
   (e.g., structure or calculation).
 * **Field**: A key of an associative-array-type data structure.
-  A field MUST be a string, which MAY exclusively contain lowercase alphanumerics (`[a-z0-9]`) and underscores (`"_"`).
+  A field MUST be a string, exclusively containing lowercase alphanumerics (`[a-z0-9]`) and underscores (`"_"`).
 * **Property**: A field-value pair.
 * **Property value types**:
   * **string**, **integer**, **float**, **boolean**, **null value**: Base data
     types as defined in more detail in section [5.1. Lexical Tokens](#h.5.1).
-  * **list**, **dictionary**: Collections of base types, defined in the samme manner as a JSON [array](https://json-schema.org/understanding-json-schema/reference/array.html) and [object](https://json-schema.org/understanding-json-schema/reference/object.html), respectively.
+  * **list**, **dictionary**: Collections of base types, defined in the same manner as a JSON [array](https://json-schema.org/understanding-json-schema/reference/array.html) and [object](https://json-schema.org/understanding-json-schema/reference/object.html), respectively.
 * **Queryable property**: A property that can be in the filtering of results.
   For more information see section [3.5. Queryable Properties](#h.3.5).
 * **Resource object**: Represents resources. MUST contain at least the following top-level fields:


### PR DESCRIPTION
Fixes #12.

This was originally intended to fix issue #109, however, the issue has been split into two PRs, one (re)defining `property` (this one) and one to define which resource property fields are queryable through `filter`.

Newly defined:
* Resource property

Redefined:
* Property
* Field

Extended name of `Property Types` to be `Property Value Types` in accordance with the new definition of `property`.