### PR TITLE
Forbidding values in field names

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -109,7 +109,8 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 * **Field**: A key of an associative-array-type data structure.
   A field MUST be a string, exclusively containing lowercase alphanumerics (`[a-z0-9]`) and underscores (`"_"`).
   A field MUST start with a lowercase letter (`[a-z]`) or an underscore (`"_"`).
-  MUST NOT match any of the entry names.
+  MUST NOT match any of the entry names. Specification-mandated fields are REQUIRED to be constant, i.e.,
+  not derived from values or indices.
 * **Property**: A field-value pair.
 * **Property value types**:
   * **string**, **integer**, **float**, **boolean**, **null value**: Base data


### PR DESCRIPTION
PR #127 redesigned `species` so as not to allow dynamic field names, effectively removing the last occurrence of such names from the specification. In order to fully implement the spirit of #112, this policy has to be hard-coded into the specification. Here I suggest adding a restricting sentence to the definition of the term **Field**.

Fixes #112.