### PR TITLE
Set operators

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -1300,7 +1300,7 @@ Examples:
 
 ### Comparisons of list properties
 
-In the following, `values` is one or more `value` separated by commas (","), i.e., strings or numbers. An implementation MAY also support property names and nested property names in `values`.
+In the following, `list` is a list-type property, and `values` is one or more `value` separated by commas (","), i.e., strings or numbers. An implementation MAY also support property names and nested property names in `values`.
 
 The following constructs MUST be supported:
 
@@ -1338,7 +1338,7 @@ values on the right-hand side MAY allow `<operator> value` in each
 place a value can appear. In that case, a match requires that the
 `<operator>` comparison is fulfilled instead of equality. Strictly,
 the definitions of the `HAS`, `HAS ALL`, `HAS ANY` and
-`HAS ONLY` operators as written above applies, but with the word
+`HAS ONLY` operators as written above apply, but with the word
 'equal' replaced with the `<operator>` comparison.
 
 For example:

--- a/optimade.md
+++ b/optimade.md
@@ -110,7 +110,7 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
   A field MUST be a string, exclusively containing lowercase alphanumerics (`[a-z0-9]`) and underscores (`"_"`).
   A field MUST start with a lowercase letter (`[a-z]`) or an underscore (`"_"`).
   MUST NOT match any of the entry names.
-* **Property**: A field-value pair. 
+* **Property**: A field-value pair.
 * **Property value types**:
   * **string**, **integer**, **float**, **boolean**, **null value**: Base data
     types as defined in more detail in section [5.1. Lexical Tokens](#h.5.1).

--- a/optimade.md
+++ b/optimade.md
@@ -110,7 +110,7 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
   A field MUST be a string, exclusively containing lowercase alphanumerics (`[a-z0-9]`) and underscores (`"_"`).
   A field MUST start with a lowercase letter (`[a-z]`) or an underscore (`"_"`).
   MUST NOT match any of the entry names.
-* **Property**: A field-value pair.
+* **Property**: A field-value pair. The field is called the **property name**, the value is called the **property value**.
 * **Property value types**:
   * **string**, **integer**, **float**, **boolean**, **null value**: Base data
     types as defined in more detail in section [5.1. Lexical Tokens](#h.5.1).
@@ -1300,55 +1300,62 @@ Examples:
 
 ### Comparisons of list properties
 
-List properties can be thought of as lists or sets of strings or numbers. 
-In the following, a set of `values` is one or more strings or numbers separated by a comma (",").
-An implementation MAY also support identifiers in the value set.
+In the following, `values` is one or more `value` separated by commas (","), i.e., strings or numbers. An implementation MAY also support property names and nested property names in `values`.
 
 The following constructs MUST be supported:
 
-* `identifier HAS value`: matches if the given value is present in the list property (i.e., set operator IN).
-* `identifier HAS ALL values`: matches when all the values given are present in the list property (i.e., set operator >=).
-* `identifier HAS EXACTLY values`: matches when the property contains all the values given and none other (i.e., set operator =).
-* `identifier HAS ANY values`: matches when any one of the values given are present in the property (i.e., equivalent with a number of HAS separated by OR).
-* `LENGTH identifier <operator> value`: applies the numeric comparison operator for the number of items in the list property. 
+* `list HAS value`: matches if at least one element in `list` is equal to `value`. (If `list` has no duplicate elements, this implements the set operator IN.)
+* `list HAS ALL values`: matches if, for each `value`, there is at least one element in `list` equal to that value. (If both `list` and `values` do not contain duplicate values, this implements the set operator >=.)
+* `list HAS ANY values`: matches if at least one element in `list` is equal to at least one `value`. (This is equivalent to a number of HAS statements separated by OR.)
+
+* `LENGTH list <operator> value`: applies the numeric comparison `<operator>` for the number of items in the list property. 
 
 The following construct MAY be supported:
 
-* `identifier HAS ONLY values`: matches when the property only contains items from the given values (i.e., set operator <=)
+* `list HAS ONLY values`: matches if all elements in `list` are equal to at least one `value`. (If both `list` and `values` do not contain duplicate values, this implements the <= set operator.)
 
 This construct is OPTIONAL as it may be difficult to realize in some
 underlying database implementations. However, if the desired search is
 over a property that can only take on a finite set of values (e.g.,
 chemical elements) a client can formulate an equivalent search by inverting
-the list of values into `inverse` and express the filter as `NOT identifier HAS
+the list of values into `inverse` and express the filter as `NOT list HAS
 inverse`.
 
 Furthermore, there is a set of OPTIONAL constructs that allows
-searches to be formulated over the values in correlated positions in
-multiple list properties. This type of filter may be useful if
-one, e.g., has one list property of elements and another of an
-element count.
+filters to be formulated over the values in *correlated positions* in
+multiple list properties. An implementation MAY support this syntax 
+selectively only for specific properties. This type of filter is useful 
+for, e.g., filtering on elements and correlated element counts available
+as two separate list properties.
 
-* `id1:id2:... HAS val1:val2:...`
-* `id1:id2:... HAS ALL val1:val2:...`
-* `id1:id2:... HAS EXACTLY val1:val2:...`
-* `id1:id2:... HAS ANY val1:val2:...`
-* `id1:id2:... HAS ONLY val1:val2:...`
+* `list1:list2:... HAS val1:val2:...`
+* `list1:list2:... HAS ALL val1:val2:...`
+* `list1:list2:... HAS ANY val1:val2:...`
+* `list1:list2:... HAS ONLY val1:val2:...`
 
 Finally, all the above constructs that allow a value or lists of
-values on the right-hand side MAY allow `<operator> value`
-in each place a value can appear. In that case, a match requires that
-the equality or inequality is fulfilled. For example:
+values on the right-hand side MAY allow `<operator> value` in each
+place a value can appear. In that case, a match requires that the
+`<operator>` comparison is fulfilled instead of equality. Strictly,
+the definitions of the `HAS`, `HAS ALL`, `HAS ANY` and
+`HAS ONLY` operators as written above applies, but with the word
+'equal' replaced with the `<operator>` comparison.
 
-* `identifier HAS < 3`: matches all entries for which "identifier" contains at least one element that is less than three.
-* `identifier HAS ALL < 3, > 3`: matches only those entries for which "identifier" simultaneously 
+For example:
+
+* `list HAS < 3`: matches all entries for which `list` contains at least one element that is less than three.
+* `list HAS ALL < 3, > 3`: matches only those entries for which `list` simultaneously 
    contains at least one element less than three and one element greater than three.
 
-Examples:
+An implementation MAY support combining the operator syntax with the syntax for correlated lists in particularly on a list correlated with itself. For example:
 
-* `elements HAS "H" AND elements HAS ALL "H","He","Ga","Ta" AND elements HAS EXACTLY "H","He","Ga","Ta" AND elements HAS ANY "H", "He", "Ga", "Ta"`
+* `list:list HAS >=2:<=5`: matches all entries for which `list` contains at least one element that is between the values 2 and 5.
+
+Further examples of various comparisons of list properties:
+
+* `elements HAS "H" AND elements HAS ALL "H","He","Ga","Ta" AND elements HAS ONLY "H","He","Ga","Ta" AND elements HAS ANY "H", "He", "Ga", "Ta"`
 * OPTIONAL: `elements HAS ONLY "H","He","Ga","Ta"`
-* OPTIONAL: `elements:_exmpl_element_counts HAS "H":6 AND elements:_exmpl_element_counts HAS ALL "H":6,"He":7 AND elements:_exmpl_element_counts HAS EXACTLY "H":6 AND elements:_exmpl_element_counts HAS ANY "H":6,"He":7 AND elements:_exmpl_element_counts HAS ONLY "H":6,"He":7`
+* OPTIONAL: `elements:_exmpl_element_counts HAS "H":6 AND elements:_exmpl_element_counts HAS ALL "H":6,"He":7 AND elements:_exmpl_element_counts HAS ONLY "H":6 AND elements:_exmpl_element_counts HAS ANY "H":6,"He":7 AND elements:_exmpl_element_counts HAS ONLY "H":6,"He":7`
 * OPTIONAL: `_exmpl_element_counts HAS < 3 AND _exmpl_element_counts HAS ANY > 3, = 6, 4, != 8` (note: specifying the = operator after HAS ANY is redundant here, if no operator is given, the test is for equality.)
 * OPTIONAL: `elements:_exmpl_element_counts:_exmpl_element_weights HAS ANY > 3:"He":>55.3 , = 6:>"Ti":<37.6 , 8:<"Ga":0`
 
@@ -1482,8 +1489,8 @@ This section defines standard entry types and their properties.
 * **Querying**: 
     * A filter that matches all records of structures that contain Si, Al **and** O, 
       and possibly other elements: `elements HAS ALL "Si", "Al", "O"`. 
-    * To match exactly these three elements, use `elements HAS EXACTLY "Si", "Al", "O"` or alternatively
-      add `AND LENGTH elements = 3`.
+    * To match structures with exactly these three elements, 
+	  use `elements HAS ALL "Si", "Al", "O" AND LENGTH elements = 3`.
 
 ### <a name="h.6.2.2">6.2.2. nelements</a>
 
@@ -2106,11 +2113,11 @@ KnownOpRhs = IS, ( KNOWN | UNKNOWN ) ;
 
 FuzzyStringOpRhs = CONTAINS, String | STARTS, [ WITH ], String | ENDS, [ WITH ], String ;
 
-SetOpRhs = HAS, ( [ Operator ], Value | ALL, ValueList | EXACTLY, ValueList | ANY, ValueList | ONLY, ValueList ) ;
+SetOpRhs = HAS, ( [ Operator ], Value | ALL, ValueList | ANY, ValueList | ONLY, ValueList ) ;
 (* Note: support for ONLY in SetOpRhs is OPTIONAL *)
 (* Note: support for [ Operator ] in SetOpRhs is OPTIONAL *)
 
-SetZipOpRhs = PropertyZipAddon, HAS, ( ValueZip | ONLY, ValueZipList | ALL, ValueZipList | EXACTLY, ValueZipList | ANY, ValueZipList ) ;
+SetZipOpRhs = PropertyZipAddon, HAS, ( ValueZip | ONLY, ValueZipList | ALL, ValueZipList | ANY, ValueZipList ) ;
 
 LengthComparison = LENGTH, Property, Operator, Value ;
 
@@ -2150,7 +2157,6 @@ LENGTH = 'L', 'E', 'N', 'G', 'T', 'H', [Spaces] ;
 HAS = 'H', 'A', 'S', [Spaces] ;
 ALL = 'A', 'L', 'L', [Spaces] ;
 ONLY = 'O', 'N', 'L', 'Y', [Spaces] ;
-EXACTLY = 'E', 'X', 'A', 'C', 'T', 'L', 'Y', [Spaces] ;
 ANY = 'A', 'N', 'Y', [Spaces] ;
 
 (* OperatorComparison operator tokens: *)

--- a/optimade.md
+++ b/optimade.md
@@ -110,7 +110,7 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
   A field MUST be a string, exclusively containing lowercase alphanumerics (`[a-z0-9]`) and underscores (`"_"`).
   A field MUST start with a lowercase letter (`[a-z]`) or an underscore (`"_"`).
   MUST NOT match any of the entry names.
-* **Property**: A field-value pair. The field is called the **property name**, the value is called the **property value**.
+* **Property**: A field-value pair. 
 * **Property value types**:
   * **string**, **integer**, **float**, **boolean**, **null value**: Base data
     types as defined in more detail in section [5.1. Lexical Tokens](#h.5.1).

--- a/tests/inputs/set.filter
+++ b/tests/inputs/set.filter
@@ -1,1 +1,1 @@
-elements HAS "H" AND elements HAS ALL "H","He","Ga","Ta" AND elements HAS EXACTLY "H","He","Ga","Ta" AND elements HAS ANY "H", "He", "Ga", "Ta" AND elements HAS ONLY "H","He","Ga","Ta"
+elements HAS "H" AND elements HAS ALL "H","He","Ga","Ta" AND elements HAS ONLY "H","He","Ga","Ta" AND elements HAS ANY "H", "He", "Ga", "Ta" AND elements HAS ONLY "H","He","Ga","Ta"

--- a/tests/inputs/set2.filter
+++ b/tests/inputs/set2.filter
@@ -1,1 +1,1 @@
-elements HAS "H" AND elements HAS ALL "H" AND elements HAS EXACTLY "H" AND elements HAS ANY "H" AND elements HAS ONLY "H"
+elements HAS "H" AND elements HAS ALL "H" AND elements HAS ONLY "H" AND elements HAS ANY "H" AND elements HAS ONLY "H"

--- a/tests/inputs/set3.filter
+++ b/tests/inputs/set3.filter
@@ -1,1 +1,1 @@
-elements HAS "H" AND elements HAS ALL "H","He","Ga","Ta" AND elements HAS EXACTLY "H","He","Ga","Ta" AND elements HAS ANY "H", "He", "Ga", "Ta"
+elements HAS "H" AND elements HAS ALL "H","He","Ga","Ta" AND elements HAS ONLY "H","He","Ga","Ta" AND elements HAS ANY "H", "He", "Ga", "Ta"

--- a/tests/inputs/set4.filter
+++ b/tests/inputs/set4.filter
@@ -1,1 +1,1 @@
-elements:_exmpl_element_counts HAS "H":6 AND elements:_exmpl_element_counts HAS ALL "H":6,"He":7 AND elements:_exmpl_element_counts HAS EXACTLY "H":6 AND elements:_exmpl_element_counts HAS ANY "H":6,"He":7 AND elements:_exmpl_element_counts HAS ONLY "H":6,"He":7
+elements:_exmpl_element_counts HAS "H":6 AND elements:_exmpl_element_counts HAS ALL "H":6,"He":7 AND elements:_exmpl_element_counts HAS ONLY "H":6 AND elements:_exmpl_element_counts HAS ANY "H":6,"He":7 AND elements:_exmpl_element_counts HAS ONLY "H":6,"He":7

--- a/tests/inputs/setzip-spaces.filter
+++ b/tests/inputs/setzip-spaces.filter
@@ -1,1 +1,1 @@
-elements :element_counts HAS "H": 6 AND elements : element_counts HAS ALL "H" : 6,"He": 7 AND elements: element_counts HAS EXACTLY "H" :6 AND elements:element_counts HAS ANY "H"  :   6,"He" : 7 AND elements   :   element_counts HAS ONLY "H" :6,"He": 7
+elements :element_counts HAS "H": 6 AND elements : element_counts HAS ALL "H" : 6,"He": 7 AND elements: element_counts HAS ONLY "H" :6 AND elements:element_counts HAS ANY "H"  :   6,"He" : 7 AND elements   :   element_counts HAS ONLY "H" :6,"He": 7

--- a/tests/inputs/setzip.filter
+++ b/tests/inputs/setzip.filter
@@ -1,1 +1,1 @@
-elements:element_counts HAS "H":6 AND elements:element_counts HAS ALL "H":6,"He":7 AND elements:element_counts HAS EXACTLY "H":6 AND elements:element_counts HAS ANY "H":6,"He":7 AND elements:element_counts HAS ONLY "H":6,"He":7
+elements:element_counts HAS "H":6 AND elements:element_counts HAS ALL "H":6,"He":7 AND elements:element_counts HAS ONLY "H":6 AND elements:element_counts HAS ANY "H":6,"He":7 AND elements:element_counts HAS ONLY "H":6,"He":7

--- a/tests/outputs/Filter_032.out
+++ b/tests/outputs/Filter_032.out
@@ -39,7 +39,7 @@ Error: in tests/cases/Filter_032.inp: line 1:
     "+", "-", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".",
     "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
     "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
-    "_", "A", "E", or "O"
+    "_", "A", or "O"
 
 elements HAS IS "H"
              ^

--- a/tests/outputs/Filter_033.out
+++ b/tests/outputs/Filter_033.out
@@ -146,37 +146,34 @@ Filter(9999)
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 59
-                  EXACTLY(9999)
-                    TOKEN_37(9999): "E", line: 1, col: 60
-                    TOKEN_56(9999): "X", line: 1, col: 61
-                    TOKEN_33(9999): "A", line: 1, col: 62
-                    TOKEN_35(9999): "C", line: 1, col: 63
-                    TOKEN_52(9999): "T", line: 1, col: 64
-                    TOKEN_44(9999): "L", line: 1, col: 65
-                    TOKEN_57(9999): "Y", line: 1, col: 66
+                  ONLY(9999)
+                    TOKEN_47(9999): "O", line: 1, col: 60
+                    TOKEN_46(9999): "N", line: 1, col: 61
+                    TOKEN_44(9999): "L", line: 1, col: 62
+                    TOKEN_57(9999): "Y", line: 1, col: 63
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 67
+                        TOKEN_1(9999): " ", line: 1, col: 64
                   ValueList(9999)
                     Value(9999)
                       String(9999)
-                        TOKEN_3(9999): """, line: 1, col: 68
+                        TOKEN_3(9999): """, line: 1, col: 65
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 69
-                        TOKEN_3(9999): """, line: 1, col: 70
+                                TOKEN_40(9999): "H", line: 1, col: 66
+                        TOKEN_3(9999): """, line: 1, col: 67
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 71
+                            TOKEN_1(9999): " ", line: 1, col: 68
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 72
-            TOKEN_46(9999): "N", line: 1, col: 73
-            TOKEN_36(9999): "D", line: 1, col: 74
+            TOKEN_33(9999): "A", line: 1, col: 69
+            TOKEN_46(9999): "N", line: 1, col: 70
+            TOKEN_36(9999): "D", line: 1, col: 71
             Spaces(9999)
               Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 75
+                TOKEN_1(9999): " ", line: 1, col: 72
           ExpressionClause(9999)
             ExpressionPhrase(9999)
               Comparison(9999)
@@ -184,59 +181,59 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 76
+                        TOKEN_69(9999): "e", line: 1, col: 73
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 77
+                        TOKEN_76(9999): "l", line: 1, col: 74
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 78
+                        TOKEN_69(9999): "e", line: 1, col: 75
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 79
+                        TOKEN_77(9999): "m", line: 1, col: 76
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 80
+                        TOKEN_69(9999): "e", line: 1, col: 77
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 81
+                        TOKEN_78(9999): "n", line: 1, col: 78
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 82
+                        TOKEN_84(9999): "t", line: 1, col: 79
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 83
+                        TOKEN_83(9999): "s", line: 1, col: 80
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 84
+                          TOKEN_1(9999): " ", line: 1, col: 81
                   SetOpRhs(9999)
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 85
-                      TOKEN_33(9999): "A", line: 1, col: 86
-                      TOKEN_51(9999): "S", line: 1, col: 87
+                      TOKEN_40(9999): "H", line: 1, col: 82
+                      TOKEN_33(9999): "A", line: 1, col: 83
+                      TOKEN_51(9999): "S", line: 1, col: 84
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 88
+                          TOKEN_1(9999): " ", line: 1, col: 85
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 89
-                      TOKEN_46(9999): "N", line: 1, col: 90
-                      TOKEN_57(9999): "Y", line: 1, col: 91
+                      TOKEN_33(9999): "A", line: 1, col: 86
+                      TOKEN_46(9999): "N", line: 1, col: 87
+                      TOKEN_57(9999): "Y", line: 1, col: 88
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 92
+                          TOKEN_1(9999): " ", line: 1, col: 89
                     ValueList(9999)
                       Value(9999)
                         String(9999)
-                          TOKEN_3(9999): """, line: 1, col: 93
+                          TOKEN_3(9999): """, line: 1, col: 90
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 94
-                          TOKEN_3(9999): """, line: 1, col: 95
+                                  TOKEN_40(9999): "H", line: 1, col: 91
+                          TOKEN_3(9999): """, line: 1, col: 92
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 96
+                              TOKEN_1(9999): " ", line: 1, col: 93
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 97
-              TOKEN_46(9999): "N", line: 1, col: 98
-              TOKEN_36(9999): "D", line: 1, col: 99
+              TOKEN_33(9999): "A", line: 1, col: 94
+              TOKEN_46(9999): "N", line: 1, col: 95
+              TOKEN_36(9999): "D", line: 1, col: 96
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 100
+                  TOKEN_1(9999): " ", line: 1, col: 97
             ExpressionClause(9999)
               ExpressionPhrase(9999)
                 Comparison(9999)
@@ -244,47 +241,47 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 101
+                          TOKEN_69(9999): "e", line: 1, col: 98
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 102
+                          TOKEN_76(9999): "l", line: 1, col: 99
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 103
+                          TOKEN_69(9999): "e", line: 1, col: 100
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 104
+                          TOKEN_77(9999): "m", line: 1, col: 101
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 105
+                          TOKEN_69(9999): "e", line: 1, col: 102
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 106
+                          TOKEN_78(9999): "n", line: 1, col: 103
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 107
+                          TOKEN_84(9999): "t", line: 1, col: 104
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 108
+                          TOKEN_83(9999): "s", line: 1, col: 105
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 109
+                            TOKEN_1(9999): " ", line: 1, col: 106
                     SetOpRhs(9999)
                       HAS(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 110
-                        TOKEN_33(9999): "A", line: 1, col: 111
-                        TOKEN_51(9999): "S", line: 1, col: 112
+                        TOKEN_40(9999): "H", line: 1, col: 107
+                        TOKEN_33(9999): "A", line: 1, col: 108
+                        TOKEN_51(9999): "S", line: 1, col: 109
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 113
+                            TOKEN_1(9999): " ", line: 1, col: 110
                       ONLY(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 114
-                        TOKEN_46(9999): "N", line: 1, col: 115
-                        TOKEN_44(9999): "L", line: 1, col: 116
-                        TOKEN_57(9999): "Y", line: 1, col: 117
+                        TOKEN_47(9999): "O", line: 1, col: 111
+                        TOKEN_46(9999): "N", line: 1, col: 112
+                        TOKEN_44(9999): "L", line: 1, col: 113
+                        TOKEN_57(9999): "Y", line: 1, col: 114
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 118
+                            TOKEN_1(9999): " ", line: 1, col: 115
                       ValueList(9999)
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 119
+                            TOKEN_3(9999): """, line: 1, col: 116
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 120
-                            TOKEN_3(9999): """, line: 1, col: 121
+                                    TOKEN_40(9999): "H", line: 1, col: 117
+                            TOKEN_3(9999): """, line: 1, col: 118

--- a/tests/outputs/Filter_035.out
+++ b/tests/outputs/Filter_035.out
@@ -194,85 +194,82 @@ Filter(9999)
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 74
-                  EXACTLY(9999)
-                    TOKEN_37(9999): "E", line: 1, col: 75
-                    TOKEN_56(9999): "X", line: 1, col: 76
-                    TOKEN_33(9999): "A", line: 1, col: 77
-                    TOKEN_35(9999): "C", line: 1, col: 78
-                    TOKEN_52(9999): "T", line: 1, col: 79
-                    TOKEN_44(9999): "L", line: 1, col: 80
-                    TOKEN_57(9999): "Y", line: 1, col: 81
+                  ONLY(9999)
+                    TOKEN_47(9999): "O", line: 1, col: 75
+                    TOKEN_46(9999): "N", line: 1, col: 76
+                    TOKEN_44(9999): "L", line: 1, col: 77
+                    TOKEN_57(9999): "Y", line: 1, col: 78
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 82
+                        TOKEN_1(9999): " ", line: 1, col: 79
                   ValueList(9999)
                     Value(9999)
                       String(9999)
-                        TOKEN_3(9999): """, line: 1, col: 83
+                        TOKEN_3(9999): """, line: 1, col: 80
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 84
-                        TOKEN_3(9999): """, line: 1, col: 85
+                                TOKEN_40(9999): "H", line: 1, col: 81
+                        TOKEN_3(9999): """, line: 1, col: 82
                     Comma(9999)
-                      TOKEN_12(9999): ",", line: 1, col: 86
+                      TOKEN_12(9999): ",", line: 1, col: 83
                     Value(9999)
                       String(9999)
+                        TOKEN_3(9999): """, line: 1, col: 84
+                        EscapedChar(9999)
+                          UnescapedChar(9999)
+                            Letter(9999)
+                              UppercaseLetter(9999)
+                                TOKEN_40(9999): "H", line: 1, col: 85
+                        EscapedChar(9999)
+                          UnescapedChar(9999)
+                            Letter(9999)
+                              LowercaseLetter(9999)
+                                TOKEN_69(9999): "e", line: 1, col: 86
                         TOKEN_3(9999): """, line: 1, col: 87
+                    Comma(9999)
+                      TOKEN_12(9999): ",", line: 1, col: 88
+                    Value(9999)
+                      String(9999)
+                        TOKEN_3(9999): """, line: 1, col: 89
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 88
+                                TOKEN_39(9999): "G", line: 1, col: 90
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_69(9999): "e", line: 1, col: 89
-                        TOKEN_3(9999): """, line: 1, col: 90
-                    Comma(9999)
-                      TOKEN_12(9999): ",", line: 1, col: 91
-                    Value(9999)
-                      String(9999)
+                                TOKEN_65(9999): "a", line: 1, col: 91
                         TOKEN_3(9999): """, line: 1, col: 92
-                        EscapedChar(9999)
-                          UnescapedChar(9999)
-                            Letter(9999)
-                              UppercaseLetter(9999)
-                                TOKEN_39(9999): "G", line: 1, col: 93
-                        EscapedChar(9999)
-                          UnescapedChar(9999)
-                            Letter(9999)
-                              LowercaseLetter(9999)
-                                TOKEN_65(9999): "a", line: 1, col: 94
-                        TOKEN_3(9999): """, line: 1, col: 95
                     Comma(9999)
-                      TOKEN_12(9999): ",", line: 1, col: 96
+                      TOKEN_12(9999): ",", line: 1, col: 93
                     Value(9999)
                       String(9999)
-                        TOKEN_3(9999): """, line: 1, col: 97
+                        TOKEN_3(9999): """, line: 1, col: 94
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_52(9999): "T", line: 1, col: 98
+                                TOKEN_52(9999): "T", line: 1, col: 95
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_65(9999): "a", line: 1, col: 99
-                        TOKEN_3(9999): """, line: 1, col: 100
+                                TOKEN_65(9999): "a", line: 1, col: 96
+                        TOKEN_3(9999): """, line: 1, col: 97
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 101
+                            TOKEN_1(9999): " ", line: 1, col: 98
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 102
-            TOKEN_46(9999): "N", line: 1, col: 103
-            TOKEN_36(9999): "D", line: 1, col: 104
+            TOKEN_33(9999): "A", line: 1, col: 99
+            TOKEN_46(9999): "N", line: 1, col: 100
+            TOKEN_36(9999): "D", line: 1, col: 101
             Spaces(9999)
               Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 105
+                TOKEN_1(9999): " ", line: 1, col: 102
           ExpressionClause(9999)
             ExpressionPhrase(9999)
               Comparison(9999)
@@ -280,116 +277,116 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 106
+                        TOKEN_69(9999): "e", line: 1, col: 103
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 107
+                        TOKEN_76(9999): "l", line: 1, col: 104
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 108
+                        TOKEN_69(9999): "e", line: 1, col: 105
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 109
+                        TOKEN_77(9999): "m", line: 1, col: 106
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 110
+                        TOKEN_69(9999): "e", line: 1, col: 107
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 111
+                        TOKEN_78(9999): "n", line: 1, col: 108
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 112
+                        TOKEN_84(9999): "t", line: 1, col: 109
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 113
+                        TOKEN_83(9999): "s", line: 1, col: 110
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 114
+                          TOKEN_1(9999): " ", line: 1, col: 111
                   SetOpRhs(9999)
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 115
-                      TOKEN_33(9999): "A", line: 1, col: 116
-                      TOKEN_51(9999): "S", line: 1, col: 117
+                      TOKEN_40(9999): "H", line: 1, col: 112
+                      TOKEN_33(9999): "A", line: 1, col: 113
+                      TOKEN_51(9999): "S", line: 1, col: 114
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 118
+                          TOKEN_1(9999): " ", line: 1, col: 115
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 119
-                      TOKEN_46(9999): "N", line: 1, col: 120
-                      TOKEN_57(9999): "Y", line: 1, col: 121
+                      TOKEN_33(9999): "A", line: 1, col: 116
+                      TOKEN_46(9999): "N", line: 1, col: 117
+                      TOKEN_57(9999): "Y", line: 1, col: 118
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 122
+                          TOKEN_1(9999): " ", line: 1, col: 119
                     ValueList(9999)
                       Value(9999)
                         String(9999)
-                          TOKEN_3(9999): """, line: 1, col: 123
+                          TOKEN_3(9999): """, line: 1, col: 120
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 124
+                                  TOKEN_40(9999): "H", line: 1, col: 121
+                          TOKEN_3(9999): """, line: 1, col: 122
+                      Comma(9999)
+                        TOKEN_12(9999): ",", line: 1, col: 123
+                        Spaces(9999)
+                          Space(9999)
+                            TOKEN_1(9999): " ", line: 1, col: 124
+                      Value(9999)
+                        String(9999)
                           TOKEN_3(9999): """, line: 1, col: 125
-                      Comma(9999)
-                        TOKEN_12(9999): ",", line: 1, col: 126
-                        Spaces(9999)
-                          Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 127
-                      Value(9999)
-                        String(9999)
+                          EscapedChar(9999)
+                            UnescapedChar(9999)
+                              Letter(9999)
+                                UppercaseLetter(9999)
+                                  TOKEN_40(9999): "H", line: 1, col: 126
+                          EscapedChar(9999)
+                            UnescapedChar(9999)
+                              Letter(9999)
+                                LowercaseLetter(9999)
+                                  TOKEN_69(9999): "e", line: 1, col: 127
                           TOKEN_3(9999): """, line: 1, col: 128
-                          EscapedChar(9999)
-                            UnescapedChar(9999)
-                              Letter(9999)
-                                UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 129
-                          EscapedChar(9999)
-                            UnescapedChar(9999)
-                              Letter(9999)
-                                LowercaseLetter(9999)
-                                  TOKEN_69(9999): "e", line: 1, col: 130
+                      Comma(9999)
+                        TOKEN_12(9999): ",", line: 1, col: 129
+                        Spaces(9999)
+                          Space(9999)
+                            TOKEN_1(9999): " ", line: 1, col: 130
+                      Value(9999)
+                        String(9999)
                           TOKEN_3(9999): """, line: 1, col: 131
-                      Comma(9999)
-                        TOKEN_12(9999): ",", line: 1, col: 132
-                        Spaces(9999)
-                          Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 133
-                      Value(9999)
-                        String(9999)
+                          EscapedChar(9999)
+                            UnescapedChar(9999)
+                              Letter(9999)
+                                UppercaseLetter(9999)
+                                  TOKEN_39(9999): "G", line: 1, col: 132
+                          EscapedChar(9999)
+                            UnescapedChar(9999)
+                              Letter(9999)
+                                LowercaseLetter(9999)
+                                  TOKEN_65(9999): "a", line: 1, col: 133
                           TOKEN_3(9999): """, line: 1, col: 134
-                          EscapedChar(9999)
-                            UnescapedChar(9999)
-                              Letter(9999)
-                                UppercaseLetter(9999)
-                                  TOKEN_39(9999): "G", line: 1, col: 135
-                          EscapedChar(9999)
-                            UnescapedChar(9999)
-                              Letter(9999)
-                                LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 136
-                          TOKEN_3(9999): """, line: 1, col: 137
                       Comma(9999)
-                        TOKEN_12(9999): ",", line: 1, col: 138
+                        TOKEN_12(9999): ",", line: 1, col: 135
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 139
+                            TOKEN_1(9999): " ", line: 1, col: 136
                       Value(9999)
                         String(9999)
-                          TOKEN_3(9999): """, line: 1, col: 140
+                          TOKEN_3(9999): """, line: 1, col: 137
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_52(9999): "T", line: 1, col: 141
+                                  TOKEN_52(9999): "T", line: 1, col: 138
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 142
-                          TOKEN_3(9999): """, line: 1, col: 143
+                                  TOKEN_65(9999): "a", line: 1, col: 139
+                          TOKEN_3(9999): """, line: 1, col: 140
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 144
+                              TOKEN_1(9999): " ", line: 1, col: 141
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 145
-              TOKEN_46(9999): "N", line: 1, col: 146
-              TOKEN_36(9999): "D", line: 1, col: 147
+              TOKEN_33(9999): "A", line: 1, col: 142
+              TOKEN_46(9999): "N", line: 1, col: 143
+              TOKEN_36(9999): "D", line: 1, col: 144
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 148
+                  TOKEN_1(9999): " ", line: 1, col: 145
             ExpressionClause(9999)
               ExpressionPhrase(9999)
                 Comparison(9999)
@@ -397,99 +394,99 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 149
+                          TOKEN_69(9999): "e", line: 1, col: 146
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 150
+                          TOKEN_76(9999): "l", line: 1, col: 147
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 151
+                          TOKEN_69(9999): "e", line: 1, col: 148
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 152
+                          TOKEN_77(9999): "m", line: 1, col: 149
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 153
+                          TOKEN_69(9999): "e", line: 1, col: 150
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 154
+                          TOKEN_78(9999): "n", line: 1, col: 151
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 155
+                          TOKEN_84(9999): "t", line: 1, col: 152
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 156
+                          TOKEN_83(9999): "s", line: 1, col: 153
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 157
+                            TOKEN_1(9999): " ", line: 1, col: 154
                     SetOpRhs(9999)
                       HAS(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 158
-                        TOKEN_33(9999): "A", line: 1, col: 159
-                        TOKEN_51(9999): "S", line: 1, col: 160
+                        TOKEN_40(9999): "H", line: 1, col: 155
+                        TOKEN_33(9999): "A", line: 1, col: 156
+                        TOKEN_51(9999): "S", line: 1, col: 157
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 161
+                            TOKEN_1(9999): " ", line: 1, col: 158
                       ONLY(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 162
-                        TOKEN_46(9999): "N", line: 1, col: 163
-                        TOKEN_44(9999): "L", line: 1, col: 164
-                        TOKEN_57(9999): "Y", line: 1, col: 165
+                        TOKEN_47(9999): "O", line: 1, col: 159
+                        TOKEN_46(9999): "N", line: 1, col: 160
+                        TOKEN_44(9999): "L", line: 1, col: 161
+                        TOKEN_57(9999): "Y", line: 1, col: 162
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 166
+                            TOKEN_1(9999): " ", line: 1, col: 163
                       ValueList(9999)
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 167
+                            TOKEN_3(9999): """, line: 1, col: 164
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 168
-                            TOKEN_3(9999): """, line: 1, col: 169
+                                    TOKEN_40(9999): "H", line: 1, col: 165
+                            TOKEN_3(9999): """, line: 1, col: 166
                         Comma(9999)
-                          TOKEN_12(9999): ",", line: 1, col: 170
+                          TOKEN_12(9999): ",", line: 1, col: 167
                         Value(9999)
                           String(9999)
+                            TOKEN_3(9999): """, line: 1, col: 168
+                            EscapedChar(9999)
+                              UnescapedChar(9999)
+                                Letter(9999)
+                                  UppercaseLetter(9999)
+                                    TOKEN_40(9999): "H", line: 1, col: 169
+                            EscapedChar(9999)
+                              UnescapedChar(9999)
+                                Letter(9999)
+                                  LowercaseLetter(9999)
+                                    TOKEN_69(9999): "e", line: 1, col: 170
                             TOKEN_3(9999): """, line: 1, col: 171
+                        Comma(9999)
+                          TOKEN_12(9999): ",", line: 1, col: 172
+                        Value(9999)
+                          String(9999)
+                            TOKEN_3(9999): """, line: 1, col: 173
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 172
+                                    TOKEN_39(9999): "G", line: 1, col: 174
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 173
-                            TOKEN_3(9999): """, line: 1, col: 174
-                        Comma(9999)
-                          TOKEN_12(9999): ",", line: 1, col: 175
-                        Value(9999)
-                          String(9999)
+                                    TOKEN_65(9999): "a", line: 1, col: 175
                             TOKEN_3(9999): """, line: 1, col: 176
-                            EscapedChar(9999)
-                              UnescapedChar(9999)
-                                Letter(9999)
-                                  UppercaseLetter(9999)
-                                    TOKEN_39(9999): "G", line: 1, col: 177
-                            EscapedChar(9999)
-                              UnescapedChar(9999)
-                                Letter(9999)
-                                  LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 178
-                            TOKEN_3(9999): """, line: 1, col: 179
                         Comma(9999)
-                          TOKEN_12(9999): ",", line: 1, col: 180
+                          TOKEN_12(9999): ",", line: 1, col: 177
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 181
+                            TOKEN_3(9999): """, line: 1, col: 178
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_52(9999): "T", line: 1, col: 182
+                                    TOKEN_52(9999): "T", line: 1, col: 179
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 183
-                            TOKEN_3(9999): """, line: 1, col: 184
+                                    TOKEN_65(9999): "a", line: 1, col: 180
+                            TOKEN_3(9999): """, line: 1, col: 181
                             Spaces(9999)
                               Space(9999)
                                 nl(9999)
-                                  SPECIAL_1(9999): "(...)", line: 1, col: 185
+                                  SPECIAL_1(9999): "(...)", line: 1, col: 182

--- a/tests/outputs/Filter_037.out
+++ b/tests/outputs/Filter_037.out
@@ -72,7 +72,7 @@ Error: in tests/cases/Filter_037.inp: line 1:
     "+", "-", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".",
     "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
     "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
-    "_", "O", "A", or "E"
+    "_", "O", or "A"
 
 elements:element_counts HAS IS 'H':6,'He':7
                             ^

--- a/tests/outputs/Filter_039.out
+++ b/tests/outputs/Filter_039.out
@@ -285,45 +285,42 @@ Filter(9999)
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 115
-                  EXACTLY(9999)
-                    TOKEN_37(9999): "E", line: 1, col: 116
-                    TOKEN_56(9999): "X", line: 1, col: 117
-                    TOKEN_33(9999): "A", line: 1, col: 118
-                    TOKEN_35(9999): "C", line: 1, col: 119
-                    TOKEN_52(9999): "T", line: 1, col: 120
-                    TOKEN_44(9999): "L", line: 1, col: 121
-                    TOKEN_57(9999): "Y", line: 1, col: 122
+                  ONLY(9999)
+                    TOKEN_47(9999): "O", line: 1, col: 116
+                    TOKEN_46(9999): "N", line: 1, col: 117
+                    TOKEN_44(9999): "L", line: 1, col: 118
+                    TOKEN_57(9999): "Y", line: 1, col: 119
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 123
+                        TOKEN_1(9999): " ", line: 1, col: 120
                   ValueZipList(9999)
                     ValueZip(9999)
                       Value(9999)
                         String(9999)
-                          TOKEN_3(9999): """, line: 1, col: 124
+                          TOKEN_3(9999): """, line: 1, col: 121
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 125
-                          TOKEN_3(9999): """, line: 1, col: 126
+                                  TOKEN_40(9999): "H", line: 1, col: 122
+                          TOKEN_3(9999): """, line: 1, col: 123
                       Colon(9999)
-                        TOKEN_26(9999): ":", line: 1, col: 127
+                        TOKEN_26(9999): ":", line: 1, col: 124
                       Value(9999)
                         Number(9999)
                           Digits(9999)
                             Digit(9999)
-                              TOKEN_22(9999): "6", line: 1, col: 128
+                              TOKEN_22(9999): "6", line: 1, col: 125
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 129
+                              TOKEN_1(9999): " ", line: 1, col: 126
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 130
-            TOKEN_46(9999): "N", line: 1, col: 131
-            TOKEN_36(9999): "D", line: 1, col: 132
+            TOKEN_33(9999): "A", line: 1, col: 127
+            TOKEN_46(9999): "N", line: 1, col: 128
+            TOKEN_36(9999): "D", line: 1, col: 129
             Spaces(9999)
               Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 133
+                TOKEN_1(9999): " ", line: 1, col: 130
           ExpressionClause(9999)
             ExpressionPhrase(9999)
               Comparison(9999)
@@ -331,124 +328,124 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 134
+                        TOKEN_69(9999): "e", line: 1, col: 131
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 135
+                        TOKEN_76(9999): "l", line: 1, col: 132
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 136
+                        TOKEN_69(9999): "e", line: 1, col: 133
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 137
+                        TOKEN_77(9999): "m", line: 1, col: 134
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 138
+                        TOKEN_69(9999): "e", line: 1, col: 135
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 139
+                        TOKEN_78(9999): "n", line: 1, col: 136
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 140
+                        TOKEN_84(9999): "t", line: 1, col: 137
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 141
+                        TOKEN_83(9999): "s", line: 1, col: 138
                   SetZipOpRhs(9999)
                     PropertyZipAddon(9999)
                       Colon(9999)
-                        TOKEN_26(9999): ":", line: 1, col: 142
+                        TOKEN_26(9999): ":", line: 1, col: 139
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 143
+                            TOKEN_69(9999): "e", line: 1, col: 140
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 144
+                            TOKEN_76(9999): "l", line: 1, col: 141
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 145
+                            TOKEN_69(9999): "e", line: 1, col: 142
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 146
+                            TOKEN_77(9999): "m", line: 1, col: 143
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 147
+                            TOKEN_69(9999): "e", line: 1, col: 144
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 148
+                            TOKEN_78(9999): "n", line: 1, col: 145
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 149
+                            TOKEN_84(9999): "t", line: 1, col: 146
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 150
+                            TOKEN_63(9999): "_", line: 1, col: 147
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 151
+                            TOKEN_67(9999): "c", line: 1, col: 148
                           LowercaseLetter(9999)
-                            TOKEN_79(9999): "o", line: 1, col: 152
+                            TOKEN_79(9999): "o", line: 1, col: 149
                           LowercaseLetter(9999)
-                            TOKEN_85(9999): "u", line: 1, col: 153
+                            TOKEN_85(9999): "u", line: 1, col: 150
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 154
+                            TOKEN_78(9999): "n", line: 1, col: 151
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 155
+                            TOKEN_84(9999): "t", line: 1, col: 152
                           LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 156
+                            TOKEN_83(9999): "s", line: 1, col: 153
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 157
+                              TOKEN_1(9999): " ", line: 1, col: 154
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 158
-                      TOKEN_33(9999): "A", line: 1, col: 159
-                      TOKEN_51(9999): "S", line: 1, col: 160
+                      TOKEN_40(9999): "H", line: 1, col: 155
+                      TOKEN_33(9999): "A", line: 1, col: 156
+                      TOKEN_51(9999): "S", line: 1, col: 157
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 161
+                          TOKEN_1(9999): " ", line: 1, col: 158
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 162
-                      TOKEN_46(9999): "N", line: 1, col: 163
-                      TOKEN_57(9999): "Y", line: 1, col: 164
+                      TOKEN_33(9999): "A", line: 1, col: 159
+                      TOKEN_46(9999): "N", line: 1, col: 160
+                      TOKEN_57(9999): "Y", line: 1, col: 161
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 165
+                          TOKEN_1(9999): " ", line: 1, col: 162
                     ValueZipList(9999)
                       ValueZip(9999)
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 166
+                            TOKEN_3(9999): """, line: 1, col: 163
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 167
-                            TOKEN_3(9999): """, line: 1, col: 168
+                                    TOKEN_40(9999): "H", line: 1, col: 164
+                            TOKEN_3(9999): """, line: 1, col: 165
                         Colon(9999)
-                          TOKEN_26(9999): ":", line: 1, col: 169
+                          TOKEN_26(9999): ":", line: 1, col: 166
                         Value(9999)
                           Number(9999)
                             Digits(9999)
                               Digit(9999)
-                                TOKEN_22(9999): "6", line: 1, col: 170
+                                TOKEN_22(9999): "6", line: 1, col: 167
                       Comma(9999)
-                        TOKEN_12(9999): ",", line: 1, col: 171
+                        TOKEN_12(9999): ",", line: 1, col: 168
                       ValueZip(9999)
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 172
+                            TOKEN_3(9999): """, line: 1, col: 169
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 173
+                                    TOKEN_40(9999): "H", line: 1, col: 170
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 174
-                            TOKEN_3(9999): """, line: 1, col: 175
+                                    TOKEN_69(9999): "e", line: 1, col: 171
+                            TOKEN_3(9999): """, line: 1, col: 172
                         Colon(9999)
-                          TOKEN_26(9999): ":", line: 1, col: 176
+                          TOKEN_26(9999): ":", line: 1, col: 173
                         Value(9999)
                           Number(9999)
                             Digits(9999)
                               Digit(9999)
-                                TOKEN_23(9999): "7", line: 1, col: 177
+                                TOKEN_23(9999): "7", line: 1, col: 174
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 178
+                                TOKEN_1(9999): " ", line: 1, col: 175
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 179
-              TOKEN_46(9999): "N", line: 1, col: 180
-              TOKEN_36(9999): "D", line: 1, col: 181
+              TOKEN_33(9999): "A", line: 1, col: 176
+              TOKEN_46(9999): "N", line: 1, col: 177
+              TOKEN_36(9999): "D", line: 1, col: 178
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 182
+                  TOKEN_1(9999): " ", line: 1, col: 179
             ExpressionClause(9999)
               ExpressionPhrase(9999)
                 Comparison(9999)
@@ -456,112 +453,112 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 183
+                          TOKEN_69(9999): "e", line: 1, col: 180
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 184
+                          TOKEN_76(9999): "l", line: 1, col: 181
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 185
+                          TOKEN_69(9999): "e", line: 1, col: 182
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 186
+                          TOKEN_77(9999): "m", line: 1, col: 183
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 187
+                          TOKEN_69(9999): "e", line: 1, col: 184
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 188
+                          TOKEN_78(9999): "n", line: 1, col: 185
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 189
+                          TOKEN_84(9999): "t", line: 1, col: 186
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 190
+                          TOKEN_83(9999): "s", line: 1, col: 187
                     SetZipOpRhs(9999)
                       PropertyZipAddon(9999)
                         Colon(9999)
-                          TOKEN_26(9999): ":", line: 1, col: 191
+                          TOKEN_26(9999): ":", line: 1, col: 188
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 192
+                              TOKEN_69(9999): "e", line: 1, col: 189
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 193
+                              TOKEN_76(9999): "l", line: 1, col: 190
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 194
+                              TOKEN_69(9999): "e", line: 1, col: 191
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 195
+                              TOKEN_77(9999): "m", line: 1, col: 192
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 196
+                              TOKEN_69(9999): "e", line: 1, col: 193
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 197
+                              TOKEN_78(9999): "n", line: 1, col: 194
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 198
+                              TOKEN_84(9999): "t", line: 1, col: 195
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 199
+                              TOKEN_63(9999): "_", line: 1, col: 196
                             LowercaseLetter(9999)
-                              TOKEN_67(9999): "c", line: 1, col: 200
+                              TOKEN_67(9999): "c", line: 1, col: 197
                             LowercaseLetter(9999)
-                              TOKEN_79(9999): "o", line: 1, col: 201
+                              TOKEN_79(9999): "o", line: 1, col: 198
                             LowercaseLetter(9999)
-                              TOKEN_85(9999): "u", line: 1, col: 202
+                              TOKEN_85(9999): "u", line: 1, col: 199
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 203
+                              TOKEN_78(9999): "n", line: 1, col: 200
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 204
+                              TOKEN_84(9999): "t", line: 1, col: 201
                             LowercaseLetter(9999)
-                              TOKEN_83(9999): "s", line: 1, col: 205
+                              TOKEN_83(9999): "s", line: 1, col: 202
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 206
+                                TOKEN_1(9999): " ", line: 1, col: 203
                       HAS(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 207
-                        TOKEN_33(9999): "A", line: 1, col: 208
-                        TOKEN_51(9999): "S", line: 1, col: 209
+                        TOKEN_40(9999): "H", line: 1, col: 204
+                        TOKEN_33(9999): "A", line: 1, col: 205
+                        TOKEN_51(9999): "S", line: 1, col: 206
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 210
+                            TOKEN_1(9999): " ", line: 1, col: 207
                       ONLY(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 211
-                        TOKEN_46(9999): "N", line: 1, col: 212
-                        TOKEN_44(9999): "L", line: 1, col: 213
-                        TOKEN_57(9999): "Y", line: 1, col: 214
+                        TOKEN_47(9999): "O", line: 1, col: 208
+                        TOKEN_46(9999): "N", line: 1, col: 209
+                        TOKEN_44(9999): "L", line: 1, col: 210
+                        TOKEN_57(9999): "Y", line: 1, col: 211
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 215
+                            TOKEN_1(9999): " ", line: 1, col: 212
                       ValueZipList(9999)
                         ValueZip(9999)
                           Value(9999)
                             String(9999)
-                              TOKEN_3(9999): """, line: 1, col: 216
+                              TOKEN_3(9999): """, line: 1, col: 213
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 217
-                              TOKEN_3(9999): """, line: 1, col: 218
+                                      TOKEN_40(9999): "H", line: 1, col: 214
+                              TOKEN_3(9999): """, line: 1, col: 215
                           Colon(9999)
-                            TOKEN_26(9999): ":", line: 1, col: 219
+                            TOKEN_26(9999): ":", line: 1, col: 216
                           Value(9999)
                             Number(9999)
                               Digits(9999)
                                 Digit(9999)
-                                  TOKEN_22(9999): "6", line: 1, col: 220
+                                  TOKEN_22(9999): "6", line: 1, col: 217
                         Comma(9999)
-                          TOKEN_12(9999): ",", line: 1, col: 221
+                          TOKEN_12(9999): ",", line: 1, col: 218
                         ValueZip(9999)
                           Value(9999)
                             String(9999)
-                              TOKEN_3(9999): """, line: 1, col: 222
+                              TOKEN_3(9999): """, line: 1, col: 219
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 223
+                                      TOKEN_40(9999): "H", line: 1, col: 220
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_69(9999): "e", line: 1, col: 224
-                              TOKEN_3(9999): """, line: 1, col: 225
+                                      TOKEN_69(9999): "e", line: 1, col: 221
+                              TOKEN_3(9999): """, line: 1, col: 222
                           Colon(9999)
-                            TOKEN_26(9999): ":", line: 1, col: 226
+                            TOKEN_26(9999): ":", line: 1, col: 223
                           Value(9999)
                             Number(9999)
                               Digits(9999)
                                 Digit(9999)
-                                  TOKEN_23(9999): "7", line: 1, col: 227
+                                  TOKEN_23(9999): "7", line: 1, col: 224

--- a/tests/outputs/Filter_054.out
+++ b/tests/outputs/Filter_054.out
@@ -194,85 +194,82 @@ Filter(9999)
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 74
-                  EXACTLY(9999)
-                    TOKEN_37(9999): "E", line: 1, col: 75
-                    TOKEN_56(9999): "X", line: 1, col: 76
-                    TOKEN_33(9999): "A", line: 1, col: 77
-                    TOKEN_35(9999): "C", line: 1, col: 78
-                    TOKEN_52(9999): "T", line: 1, col: 79
-                    TOKEN_44(9999): "L", line: 1, col: 80
-                    TOKEN_57(9999): "Y", line: 1, col: 81
+                  ONLY(9999)
+                    TOKEN_47(9999): "O", line: 1, col: 75
+                    TOKEN_46(9999): "N", line: 1, col: 76
+                    TOKEN_44(9999): "L", line: 1, col: 77
+                    TOKEN_57(9999): "Y", line: 1, col: 78
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 82
+                        TOKEN_1(9999): " ", line: 1, col: 79
                   ValueList(9999)
                     Value(9999)
                       String(9999)
-                        TOKEN_3(9999): """, line: 1, col: 83
+                        TOKEN_3(9999): """, line: 1, col: 80
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 84
-                        TOKEN_3(9999): """, line: 1, col: 85
+                                TOKEN_40(9999): "H", line: 1, col: 81
+                        TOKEN_3(9999): """, line: 1, col: 82
                     Comma(9999)
-                      TOKEN_12(9999): ",", line: 1, col: 86
+                      TOKEN_12(9999): ",", line: 1, col: 83
                     Value(9999)
                       String(9999)
+                        TOKEN_3(9999): """, line: 1, col: 84
+                        EscapedChar(9999)
+                          UnescapedChar(9999)
+                            Letter(9999)
+                              UppercaseLetter(9999)
+                                TOKEN_40(9999): "H", line: 1, col: 85
+                        EscapedChar(9999)
+                          UnescapedChar(9999)
+                            Letter(9999)
+                              LowercaseLetter(9999)
+                                TOKEN_69(9999): "e", line: 1, col: 86
                         TOKEN_3(9999): """, line: 1, col: 87
+                    Comma(9999)
+                      TOKEN_12(9999): ",", line: 1, col: 88
+                    Value(9999)
+                      String(9999)
+                        TOKEN_3(9999): """, line: 1, col: 89
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 88
+                                TOKEN_39(9999): "G", line: 1, col: 90
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_69(9999): "e", line: 1, col: 89
-                        TOKEN_3(9999): """, line: 1, col: 90
-                    Comma(9999)
-                      TOKEN_12(9999): ",", line: 1, col: 91
-                    Value(9999)
-                      String(9999)
+                                TOKEN_65(9999): "a", line: 1, col: 91
                         TOKEN_3(9999): """, line: 1, col: 92
-                        EscapedChar(9999)
-                          UnescapedChar(9999)
-                            Letter(9999)
-                              UppercaseLetter(9999)
-                                TOKEN_39(9999): "G", line: 1, col: 93
-                        EscapedChar(9999)
-                          UnescapedChar(9999)
-                            Letter(9999)
-                              LowercaseLetter(9999)
-                                TOKEN_65(9999): "a", line: 1, col: 94
-                        TOKEN_3(9999): """, line: 1, col: 95
                     Comma(9999)
-                      TOKEN_12(9999): ",", line: 1, col: 96
+                      TOKEN_12(9999): ",", line: 1, col: 93
                     Value(9999)
                       String(9999)
-                        TOKEN_3(9999): """, line: 1, col: 97
+                        TOKEN_3(9999): """, line: 1, col: 94
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_52(9999): "T", line: 1, col: 98
+                                TOKEN_52(9999): "T", line: 1, col: 95
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_65(9999): "a", line: 1, col: 99
-                        TOKEN_3(9999): """, line: 1, col: 100
+                                TOKEN_65(9999): "a", line: 1, col: 96
+                        TOKEN_3(9999): """, line: 1, col: 97
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 101
+                            TOKEN_1(9999): " ", line: 1, col: 98
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 102
-            TOKEN_46(9999): "N", line: 1, col: 103
-            TOKEN_36(9999): "D", line: 1, col: 104
+            TOKEN_33(9999): "A", line: 1, col: 99
+            TOKEN_46(9999): "N", line: 1, col: 100
+            TOKEN_36(9999): "D", line: 1, col: 101
             Spaces(9999)
               Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 105
+                TOKEN_1(9999): " ", line: 1, col: 102
           ExpressionClause(9999)
             ExpressionPhrase(9999)
               Comparison(9999)
@@ -280,103 +277,103 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 106
+                        TOKEN_69(9999): "e", line: 1, col: 103
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 107
+                        TOKEN_76(9999): "l", line: 1, col: 104
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 108
+                        TOKEN_69(9999): "e", line: 1, col: 105
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 109
+                        TOKEN_77(9999): "m", line: 1, col: 106
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 110
+                        TOKEN_69(9999): "e", line: 1, col: 107
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 111
+                        TOKEN_78(9999): "n", line: 1, col: 108
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 112
+                        TOKEN_84(9999): "t", line: 1, col: 109
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 113
+                        TOKEN_83(9999): "s", line: 1, col: 110
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 114
+                          TOKEN_1(9999): " ", line: 1, col: 111
                   SetOpRhs(9999)
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 115
-                      TOKEN_33(9999): "A", line: 1, col: 116
-                      TOKEN_51(9999): "S", line: 1, col: 117
+                      TOKEN_40(9999): "H", line: 1, col: 112
+                      TOKEN_33(9999): "A", line: 1, col: 113
+                      TOKEN_51(9999): "S", line: 1, col: 114
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 118
+                          TOKEN_1(9999): " ", line: 1, col: 115
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 119
-                      TOKEN_46(9999): "N", line: 1, col: 120
-                      TOKEN_57(9999): "Y", line: 1, col: 121
+                      TOKEN_33(9999): "A", line: 1, col: 116
+                      TOKEN_46(9999): "N", line: 1, col: 117
+                      TOKEN_57(9999): "Y", line: 1, col: 118
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 122
+                          TOKEN_1(9999): " ", line: 1, col: 119
                     ValueList(9999)
                       Value(9999)
                         String(9999)
-                          TOKEN_3(9999): """, line: 1, col: 123
+                          TOKEN_3(9999): """, line: 1, col: 120
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 124
+                                  TOKEN_40(9999): "H", line: 1, col: 121
+                          TOKEN_3(9999): """, line: 1, col: 122
+                      Comma(9999)
+                        TOKEN_12(9999): ",", line: 1, col: 123
+                        Spaces(9999)
+                          Space(9999)
+                            TOKEN_1(9999): " ", line: 1, col: 124
+                      Value(9999)
+                        String(9999)
                           TOKEN_3(9999): """, line: 1, col: 125
-                      Comma(9999)
-                        TOKEN_12(9999): ",", line: 1, col: 126
-                        Spaces(9999)
-                          Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 127
-                      Value(9999)
-                        String(9999)
+                          EscapedChar(9999)
+                            UnescapedChar(9999)
+                              Letter(9999)
+                                UppercaseLetter(9999)
+                                  TOKEN_40(9999): "H", line: 1, col: 126
+                          EscapedChar(9999)
+                            UnescapedChar(9999)
+                              Letter(9999)
+                                LowercaseLetter(9999)
+                                  TOKEN_69(9999): "e", line: 1, col: 127
                           TOKEN_3(9999): """, line: 1, col: 128
-                          EscapedChar(9999)
-                            UnescapedChar(9999)
-                              Letter(9999)
-                                UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 129
-                          EscapedChar(9999)
-                            UnescapedChar(9999)
-                              Letter(9999)
-                                LowercaseLetter(9999)
-                                  TOKEN_69(9999): "e", line: 1, col: 130
+                      Comma(9999)
+                        TOKEN_12(9999): ",", line: 1, col: 129
+                        Spaces(9999)
+                          Space(9999)
+                            TOKEN_1(9999): " ", line: 1, col: 130
+                      Value(9999)
+                        String(9999)
                           TOKEN_3(9999): """, line: 1, col: 131
-                      Comma(9999)
-                        TOKEN_12(9999): ",", line: 1, col: 132
-                        Spaces(9999)
-                          Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 133
-                      Value(9999)
-                        String(9999)
+                          EscapedChar(9999)
+                            UnescapedChar(9999)
+                              Letter(9999)
+                                UppercaseLetter(9999)
+                                  TOKEN_39(9999): "G", line: 1, col: 132
+                          EscapedChar(9999)
+                            UnescapedChar(9999)
+                              Letter(9999)
+                                LowercaseLetter(9999)
+                                  TOKEN_65(9999): "a", line: 1, col: 133
                           TOKEN_3(9999): """, line: 1, col: 134
-                          EscapedChar(9999)
-                            UnescapedChar(9999)
-                              Letter(9999)
-                                UppercaseLetter(9999)
-                                  TOKEN_39(9999): "G", line: 1, col: 135
-                          EscapedChar(9999)
-                            UnescapedChar(9999)
-                              Letter(9999)
-                                LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 136
-                          TOKEN_3(9999): """, line: 1, col: 137
                       Comma(9999)
-                        TOKEN_12(9999): ",", line: 1, col: 138
+                        TOKEN_12(9999): ",", line: 1, col: 135
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 139
+                            TOKEN_1(9999): " ", line: 1, col: 136
                       Value(9999)
                         String(9999)
-                          TOKEN_3(9999): """, line: 1, col: 140
+                          TOKEN_3(9999): """, line: 1, col: 137
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_52(9999): "T", line: 1, col: 141
+                                  TOKEN_52(9999): "T", line: 1, col: 138
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 142
-                          TOKEN_3(9999): """, line: 1, col: 143
+                                  TOKEN_65(9999): "a", line: 1, col: 139
+                          TOKEN_3(9999): """, line: 1, col: 140

--- a/tests/outputs/Filter_055.out
+++ b/tests/outputs/Filter_055.out
@@ -327,45 +327,42 @@ Filter(9999)
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 136
-                  EXACTLY(9999)
-                    TOKEN_37(9999): "E", line: 1, col: 137
-                    TOKEN_56(9999): "X", line: 1, col: 138
-                    TOKEN_33(9999): "A", line: 1, col: 139
-                    TOKEN_35(9999): "C", line: 1, col: 140
-                    TOKEN_52(9999): "T", line: 1, col: 141
-                    TOKEN_44(9999): "L", line: 1, col: 142
-                    TOKEN_57(9999): "Y", line: 1, col: 143
+                  ONLY(9999)
+                    TOKEN_47(9999): "O", line: 1, col: 137
+                    TOKEN_46(9999): "N", line: 1, col: 138
+                    TOKEN_44(9999): "L", line: 1, col: 139
+                    TOKEN_57(9999): "Y", line: 1, col: 140
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 144
+                        TOKEN_1(9999): " ", line: 1, col: 141
                   ValueZipList(9999)
                     ValueZip(9999)
                       Value(9999)
                         String(9999)
-                          TOKEN_3(9999): """, line: 1, col: 145
+                          TOKEN_3(9999): """, line: 1, col: 142
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 146
-                          TOKEN_3(9999): """, line: 1, col: 147
+                                  TOKEN_40(9999): "H", line: 1, col: 143
+                          TOKEN_3(9999): """, line: 1, col: 144
                       Colon(9999)
-                        TOKEN_26(9999): ":", line: 1, col: 148
+                        TOKEN_26(9999): ":", line: 1, col: 145
                       Value(9999)
                         Number(9999)
                           Digits(9999)
                             Digit(9999)
-                              TOKEN_22(9999): "6", line: 1, col: 149
+                              TOKEN_22(9999): "6", line: 1, col: 146
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 150
+                              TOKEN_1(9999): " ", line: 1, col: 147
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 151
-            TOKEN_46(9999): "N", line: 1, col: 152
-            TOKEN_36(9999): "D", line: 1, col: 153
+            TOKEN_33(9999): "A", line: 1, col: 148
+            TOKEN_46(9999): "N", line: 1, col: 149
+            TOKEN_36(9999): "D", line: 1, col: 150
             Spaces(9999)
               Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 154
+                TOKEN_1(9999): " ", line: 1, col: 151
           ExpressionClause(9999)
             ExpressionPhrase(9999)
               Comparison(9999)
@@ -373,138 +370,138 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 155
+                        TOKEN_69(9999): "e", line: 1, col: 152
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 156
+                        TOKEN_76(9999): "l", line: 1, col: 153
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 157
+                        TOKEN_69(9999): "e", line: 1, col: 154
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 158
+                        TOKEN_77(9999): "m", line: 1, col: 155
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 159
+                        TOKEN_69(9999): "e", line: 1, col: 156
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 160
+                        TOKEN_78(9999): "n", line: 1, col: 157
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 161
+                        TOKEN_84(9999): "t", line: 1, col: 158
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 162
+                        TOKEN_83(9999): "s", line: 1, col: 159
                   SetZipOpRhs(9999)
                     PropertyZipAddon(9999)
                       Colon(9999)
-                        TOKEN_26(9999): ":", line: 1, col: 163
+                        TOKEN_26(9999): ":", line: 1, col: 160
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 164
+                            TOKEN_63(9999): "_", line: 1, col: 161
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 165
+                            TOKEN_69(9999): "e", line: 1, col: 162
                           LowercaseLetter(9999)
-                            TOKEN_88(9999): "x", line: 1, col: 166
+                            TOKEN_88(9999): "x", line: 1, col: 163
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 167
+                            TOKEN_77(9999): "m", line: 1, col: 164
                           LowercaseLetter(9999)
-                            TOKEN_80(9999): "p", line: 1, col: 168
+                            TOKEN_80(9999): "p", line: 1, col: 165
+                          LowercaseLetter(9999)
+                            TOKEN_76(9999): "l", line: 1, col: 166
+                          LowercaseLetter(9999)
+                            TOKEN_63(9999): "_", line: 1, col: 167
+                          LowercaseLetter(9999)
+                            TOKEN_69(9999): "e", line: 1, col: 168
                           LowercaseLetter(9999)
                             TOKEN_76(9999): "l", line: 1, col: 169
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 170
+                            TOKEN_69(9999): "e", line: 1, col: 170
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 171
+                            TOKEN_77(9999): "m", line: 1, col: 171
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 172
+                            TOKEN_69(9999): "e", line: 1, col: 172
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 173
+                            TOKEN_78(9999): "n", line: 1, col: 173
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 174
+                            TOKEN_84(9999): "t", line: 1, col: 174
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 175
+                            TOKEN_63(9999): "_", line: 1, col: 175
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 176
+                            TOKEN_67(9999): "c", line: 1, col: 176
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 177
+                            TOKEN_79(9999): "o", line: 1, col: 177
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 178
+                            TOKEN_85(9999): "u", line: 1, col: 178
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 179
+                            TOKEN_78(9999): "n", line: 1, col: 179
                           LowercaseLetter(9999)
-                            TOKEN_79(9999): "o", line: 1, col: 180
+                            TOKEN_84(9999): "t", line: 1, col: 180
                           LowercaseLetter(9999)
-                            TOKEN_85(9999): "u", line: 1, col: 181
-                          LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 182
-                          LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 183
-                          LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 184
+                            TOKEN_83(9999): "s", line: 1, col: 181
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 185
+                              TOKEN_1(9999): " ", line: 1, col: 182
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 186
-                      TOKEN_33(9999): "A", line: 1, col: 187
-                      TOKEN_51(9999): "S", line: 1, col: 188
+                      TOKEN_40(9999): "H", line: 1, col: 183
+                      TOKEN_33(9999): "A", line: 1, col: 184
+                      TOKEN_51(9999): "S", line: 1, col: 185
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 189
+                          TOKEN_1(9999): " ", line: 1, col: 186
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 190
-                      TOKEN_46(9999): "N", line: 1, col: 191
-                      TOKEN_57(9999): "Y", line: 1, col: 192
+                      TOKEN_33(9999): "A", line: 1, col: 187
+                      TOKEN_46(9999): "N", line: 1, col: 188
+                      TOKEN_57(9999): "Y", line: 1, col: 189
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 193
+                          TOKEN_1(9999): " ", line: 1, col: 190
                     ValueZipList(9999)
                       ValueZip(9999)
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 194
+                            TOKEN_3(9999): """, line: 1, col: 191
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 195
-                            TOKEN_3(9999): """, line: 1, col: 196
+                                    TOKEN_40(9999): "H", line: 1, col: 192
+                            TOKEN_3(9999): """, line: 1, col: 193
                         Colon(9999)
-                          TOKEN_26(9999): ":", line: 1, col: 197
+                          TOKEN_26(9999): ":", line: 1, col: 194
                         Value(9999)
                           Number(9999)
                             Digits(9999)
                               Digit(9999)
-                                TOKEN_22(9999): "6", line: 1, col: 198
+                                TOKEN_22(9999): "6", line: 1, col: 195
                       Comma(9999)
-                        TOKEN_12(9999): ",", line: 1, col: 199
+                        TOKEN_12(9999): ",", line: 1, col: 196
                       ValueZip(9999)
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 200
+                            TOKEN_3(9999): """, line: 1, col: 197
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 201
+                                    TOKEN_40(9999): "H", line: 1, col: 198
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 202
-                            TOKEN_3(9999): """, line: 1, col: 203
+                                    TOKEN_69(9999): "e", line: 1, col: 199
+                            TOKEN_3(9999): """, line: 1, col: 200
                         Colon(9999)
-                          TOKEN_26(9999): ":", line: 1, col: 204
+                          TOKEN_26(9999): ":", line: 1, col: 201
                         Value(9999)
                           Number(9999)
                             Digits(9999)
                               Digit(9999)
-                                TOKEN_23(9999): "7", line: 1, col: 205
+                                TOKEN_23(9999): "7", line: 1, col: 202
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 206
+                                TOKEN_1(9999): " ", line: 1, col: 203
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 207
-              TOKEN_46(9999): "N", line: 1, col: 208
-              TOKEN_36(9999): "D", line: 1, col: 209
+              TOKEN_33(9999): "A", line: 1, col: 204
+              TOKEN_46(9999): "N", line: 1, col: 205
+              TOKEN_36(9999): "D", line: 1, col: 206
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 210
+                  TOKEN_1(9999): " ", line: 1, col: 207
             ExpressionClause(9999)
               ExpressionPhrase(9999)
                 Comparison(9999)
@@ -512,126 +509,126 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 211
+                          TOKEN_69(9999): "e", line: 1, col: 208
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 212
+                          TOKEN_76(9999): "l", line: 1, col: 209
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 213
+                          TOKEN_69(9999): "e", line: 1, col: 210
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 214
+                          TOKEN_77(9999): "m", line: 1, col: 211
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 215
+                          TOKEN_69(9999): "e", line: 1, col: 212
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 216
+                          TOKEN_78(9999): "n", line: 1, col: 213
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 217
+                          TOKEN_84(9999): "t", line: 1, col: 214
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 218
+                          TOKEN_83(9999): "s", line: 1, col: 215
                     SetZipOpRhs(9999)
                       PropertyZipAddon(9999)
                         Colon(9999)
-                          TOKEN_26(9999): ":", line: 1, col: 219
+                          TOKEN_26(9999): ":", line: 1, col: 216
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 220
+                              TOKEN_63(9999): "_", line: 1, col: 217
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 221
+                              TOKEN_69(9999): "e", line: 1, col: 218
                             LowercaseLetter(9999)
-                              TOKEN_88(9999): "x", line: 1, col: 222
+                              TOKEN_88(9999): "x", line: 1, col: 219
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 223
+                              TOKEN_77(9999): "m", line: 1, col: 220
                             LowercaseLetter(9999)
-                              TOKEN_80(9999): "p", line: 1, col: 224
+                              TOKEN_80(9999): "p", line: 1, col: 221
+                            LowercaseLetter(9999)
+                              TOKEN_76(9999): "l", line: 1, col: 222
+                            LowercaseLetter(9999)
+                              TOKEN_63(9999): "_", line: 1, col: 223
+                            LowercaseLetter(9999)
+                              TOKEN_69(9999): "e", line: 1, col: 224
                             LowercaseLetter(9999)
                               TOKEN_76(9999): "l", line: 1, col: 225
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 226
+                              TOKEN_69(9999): "e", line: 1, col: 226
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 227
+                              TOKEN_77(9999): "m", line: 1, col: 227
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 228
+                              TOKEN_69(9999): "e", line: 1, col: 228
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 229
+                              TOKEN_78(9999): "n", line: 1, col: 229
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 230
+                              TOKEN_84(9999): "t", line: 1, col: 230
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 231
+                              TOKEN_63(9999): "_", line: 1, col: 231
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 232
+                              TOKEN_67(9999): "c", line: 1, col: 232
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 233
+                              TOKEN_79(9999): "o", line: 1, col: 233
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 234
+                              TOKEN_85(9999): "u", line: 1, col: 234
                             LowercaseLetter(9999)
-                              TOKEN_67(9999): "c", line: 1, col: 235
+                              TOKEN_78(9999): "n", line: 1, col: 235
                             LowercaseLetter(9999)
-                              TOKEN_79(9999): "o", line: 1, col: 236
+                              TOKEN_84(9999): "t", line: 1, col: 236
                             LowercaseLetter(9999)
-                              TOKEN_85(9999): "u", line: 1, col: 237
-                            LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 238
-                            LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 239
-                            LowercaseLetter(9999)
-                              TOKEN_83(9999): "s", line: 1, col: 240
+                              TOKEN_83(9999): "s", line: 1, col: 237
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 241
+                                TOKEN_1(9999): " ", line: 1, col: 238
                       HAS(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 242
-                        TOKEN_33(9999): "A", line: 1, col: 243
-                        TOKEN_51(9999): "S", line: 1, col: 244
+                        TOKEN_40(9999): "H", line: 1, col: 239
+                        TOKEN_33(9999): "A", line: 1, col: 240
+                        TOKEN_51(9999): "S", line: 1, col: 241
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 245
+                            TOKEN_1(9999): " ", line: 1, col: 242
                       ONLY(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 246
-                        TOKEN_46(9999): "N", line: 1, col: 247
-                        TOKEN_44(9999): "L", line: 1, col: 248
-                        TOKEN_57(9999): "Y", line: 1, col: 249
+                        TOKEN_47(9999): "O", line: 1, col: 243
+                        TOKEN_46(9999): "N", line: 1, col: 244
+                        TOKEN_44(9999): "L", line: 1, col: 245
+                        TOKEN_57(9999): "Y", line: 1, col: 246
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 250
+                            TOKEN_1(9999): " ", line: 1, col: 247
                       ValueZipList(9999)
                         ValueZip(9999)
                           Value(9999)
                             String(9999)
-                              TOKEN_3(9999): """, line: 1, col: 251
+                              TOKEN_3(9999): """, line: 1, col: 248
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 252
-                              TOKEN_3(9999): """, line: 1, col: 253
+                                      TOKEN_40(9999): "H", line: 1, col: 249
+                              TOKEN_3(9999): """, line: 1, col: 250
                           Colon(9999)
-                            TOKEN_26(9999): ":", line: 1, col: 254
+                            TOKEN_26(9999): ":", line: 1, col: 251
                           Value(9999)
                             Number(9999)
                               Digits(9999)
                                 Digit(9999)
-                                  TOKEN_22(9999): "6", line: 1, col: 255
+                                  TOKEN_22(9999): "6", line: 1, col: 252
                         Comma(9999)
-                          TOKEN_12(9999): ",", line: 1, col: 256
+                          TOKEN_12(9999): ",", line: 1, col: 253
                         ValueZip(9999)
                           Value(9999)
                             String(9999)
-                              TOKEN_3(9999): """, line: 1, col: 257
+                              TOKEN_3(9999): """, line: 1, col: 254
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 258
+                                      TOKEN_40(9999): "H", line: 1, col: 255
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_69(9999): "e", line: 1, col: 259
-                              TOKEN_3(9999): """, line: 1, col: 260
+                                      TOKEN_69(9999): "e", line: 1, col: 256
+                              TOKEN_3(9999): """, line: 1, col: 257
                           Colon(9999)
-                            TOKEN_26(9999): ":", line: 1, col: 261
+                            TOKEN_26(9999): ":", line: 1, col: 258
                           Value(9999)
                             Number(9999)
                               Digits(9999)
                                 Digit(9999)
-                                  TOKEN_23(9999): "7", line: 1, col: 262
+                                  TOKEN_23(9999): "7", line: 1, col: 259

--- a/tests/outputs/Filter_068.out
+++ b/tests/outputs/Filter_068.out
@@ -309,48 +309,45 @@ Filter(9999)
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 123
-                  EXACTLY(9999)
-                    TOKEN_37(9999): "E", line: 1, col: 124
-                    TOKEN_56(9999): "X", line: 1, col: 125
-                    TOKEN_33(9999): "A", line: 1, col: 126
-                    TOKEN_35(9999): "C", line: 1, col: 127
-                    TOKEN_52(9999): "T", line: 1, col: 128
-                    TOKEN_44(9999): "L", line: 1, col: 129
-                    TOKEN_57(9999): "Y", line: 1, col: 130
+                  ONLY(9999)
+                    TOKEN_47(9999): "O", line: 1, col: 124
+                    TOKEN_46(9999): "N", line: 1, col: 125
+                    TOKEN_44(9999): "L", line: 1, col: 126
+                    TOKEN_57(9999): "Y", line: 1, col: 127
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 131
+                        TOKEN_1(9999): " ", line: 1, col: 128
                   ValueZipList(9999)
                     ValueZip(9999)
                       Value(9999)
                         String(9999)
-                          TOKEN_3(9999): """, line: 1, col: 132
+                          TOKEN_3(9999): """, line: 1, col: 129
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 133
-                          TOKEN_3(9999): """, line: 1, col: 134
+                                  TOKEN_40(9999): "H", line: 1, col: 130
+                          TOKEN_3(9999): """, line: 1, col: 131
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 135
+                              TOKEN_1(9999): " ", line: 1, col: 132
                       Colon(9999)
-                        TOKEN_26(9999): ":", line: 1, col: 136
+                        TOKEN_26(9999): ":", line: 1, col: 133
                       Value(9999)
                         Number(9999)
                           Digits(9999)
                             Digit(9999)
-                              TOKEN_22(9999): "6", line: 1, col: 137
+                              TOKEN_22(9999): "6", line: 1, col: 134
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 138
+                              TOKEN_1(9999): " ", line: 1, col: 135
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 139
-            TOKEN_46(9999): "N", line: 1, col: 140
-            TOKEN_36(9999): "D", line: 1, col: 141
+            TOKEN_33(9999): "A", line: 1, col: 136
+            TOKEN_46(9999): "N", line: 1, col: 137
+            TOKEN_36(9999): "D", line: 1, col: 138
             Spaces(9999)
               Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 142
+                TOKEN_1(9999): " ", line: 1, col: 139
           ExpressionClause(9999)
             ExpressionPhrase(9999)
               Comparison(9999)
@@ -358,142 +355,142 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 143
+                        TOKEN_69(9999): "e", line: 1, col: 140
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 144
+                        TOKEN_76(9999): "l", line: 1, col: 141
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 145
+                        TOKEN_69(9999): "e", line: 1, col: 142
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 146
+                        TOKEN_77(9999): "m", line: 1, col: 143
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 147
+                        TOKEN_69(9999): "e", line: 1, col: 144
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 148
+                        TOKEN_78(9999): "n", line: 1, col: 145
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 149
+                        TOKEN_84(9999): "t", line: 1, col: 146
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 150
+                        TOKEN_83(9999): "s", line: 1, col: 147
                   SetZipOpRhs(9999)
                     PropertyZipAddon(9999)
                       Colon(9999)
-                        TOKEN_26(9999): ":", line: 1, col: 151
+                        TOKEN_26(9999): ":", line: 1, col: 148
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 152
+                            TOKEN_69(9999): "e", line: 1, col: 149
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 153
+                            TOKEN_76(9999): "l", line: 1, col: 150
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 154
+                            TOKEN_69(9999): "e", line: 1, col: 151
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 155
+                            TOKEN_77(9999): "m", line: 1, col: 152
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 156
+                            TOKEN_69(9999): "e", line: 1, col: 153
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 157
+                            TOKEN_78(9999): "n", line: 1, col: 154
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 158
+                            TOKEN_84(9999): "t", line: 1, col: 155
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 159
+                            TOKEN_63(9999): "_", line: 1, col: 156
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 160
+                            TOKEN_67(9999): "c", line: 1, col: 157
                           LowercaseLetter(9999)
-                            TOKEN_79(9999): "o", line: 1, col: 161
+                            TOKEN_79(9999): "o", line: 1, col: 158
                           LowercaseLetter(9999)
-                            TOKEN_85(9999): "u", line: 1, col: 162
+                            TOKEN_85(9999): "u", line: 1, col: 159
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 163
+                            TOKEN_78(9999): "n", line: 1, col: 160
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 164
+                            TOKEN_84(9999): "t", line: 1, col: 161
                           LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 165
+                            TOKEN_83(9999): "s", line: 1, col: 162
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 166
+                              TOKEN_1(9999): " ", line: 1, col: 163
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 167
-                      TOKEN_33(9999): "A", line: 1, col: 168
-                      TOKEN_51(9999): "S", line: 1, col: 169
+                      TOKEN_40(9999): "H", line: 1, col: 164
+                      TOKEN_33(9999): "A", line: 1, col: 165
+                      TOKEN_51(9999): "S", line: 1, col: 166
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 170
+                          TOKEN_1(9999): " ", line: 1, col: 167
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 171
-                      TOKEN_46(9999): "N", line: 1, col: 172
-                      TOKEN_57(9999): "Y", line: 1, col: 173
+                      TOKEN_33(9999): "A", line: 1, col: 168
+                      TOKEN_46(9999): "N", line: 1, col: 169
+                      TOKEN_57(9999): "Y", line: 1, col: 170
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 174
+                          TOKEN_1(9999): " ", line: 1, col: 171
                     ValueZipList(9999)
                       ValueZip(9999)
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 175
+                            TOKEN_3(9999): """, line: 1, col: 172
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 176
-                            TOKEN_3(9999): """, line: 1, col: 177
+                                    TOKEN_40(9999): "H", line: 1, col: 173
+                            TOKEN_3(9999): """, line: 1, col: 174
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 178
+                                TOKEN_1(9999): " ", line: 1, col: 175
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 179
+                                TOKEN_1(9999): " ", line: 1, col: 176
                         Colon(9999)
-                          TOKEN_26(9999): ":", line: 1, col: 180
+                          TOKEN_26(9999): ":", line: 1, col: 177
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 181
+                              TOKEN_1(9999): " ", line: 1, col: 178
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 182
+                              TOKEN_1(9999): " ", line: 1, col: 179
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 183
+                              TOKEN_1(9999): " ", line: 1, col: 180
                         Value(9999)
                           Number(9999)
                             Digits(9999)
                               Digit(9999)
-                                TOKEN_22(9999): "6", line: 1, col: 184
+                                TOKEN_22(9999): "6", line: 1, col: 181
                       Comma(9999)
-                        TOKEN_12(9999): ",", line: 1, col: 185
+                        TOKEN_12(9999): ",", line: 1, col: 182
                       ValueZip(9999)
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 186
+                            TOKEN_3(9999): """, line: 1, col: 183
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 187
+                                    TOKEN_40(9999): "H", line: 1, col: 184
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 188
-                            TOKEN_3(9999): """, line: 1, col: 189
+                                    TOKEN_69(9999): "e", line: 1, col: 185
+                            TOKEN_3(9999): """, line: 1, col: 186
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 190
+                                TOKEN_1(9999): " ", line: 1, col: 187
                         Colon(9999)
-                          TOKEN_26(9999): ":", line: 1, col: 191
+                          TOKEN_26(9999): ":", line: 1, col: 188
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 192
+                              TOKEN_1(9999): " ", line: 1, col: 189
                         Value(9999)
                           Number(9999)
                             Digits(9999)
                               Digit(9999)
-                                TOKEN_23(9999): "7", line: 1, col: 193
+                                TOKEN_23(9999): "7", line: 1, col: 190
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 194
+                                TOKEN_1(9999): " ", line: 1, col: 191
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 195
-              TOKEN_46(9999): "N", line: 1, col: 196
-              TOKEN_36(9999): "D", line: 1, col: 197
+              TOKEN_33(9999): "A", line: 1, col: 192
+              TOKEN_46(9999): "N", line: 1, col: 193
+              TOKEN_36(9999): "D", line: 1, col: 194
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 198
+                  TOKEN_1(9999): " ", line: 1, col: 195
             ExpressionClause(9999)
               ExpressionPhrase(9999)
                 Comparison(9999)
@@ -501,136 +498,136 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 199
+                          TOKEN_69(9999): "e", line: 1, col: 196
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 200
+                          TOKEN_76(9999): "l", line: 1, col: 197
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 201
+                          TOKEN_69(9999): "e", line: 1, col: 198
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 202
+                          TOKEN_77(9999): "m", line: 1, col: 199
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 203
+                          TOKEN_69(9999): "e", line: 1, col: 200
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 204
+                          TOKEN_78(9999): "n", line: 1, col: 201
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 205
+                          TOKEN_84(9999): "t", line: 1, col: 202
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 206
+                          TOKEN_83(9999): "s", line: 1, col: 203
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 207
+                            TOKEN_1(9999): " ", line: 1, col: 204
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 208
+                            TOKEN_1(9999): " ", line: 1, col: 205
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 209
+                            TOKEN_1(9999): " ", line: 1, col: 206
                     SetZipOpRhs(9999)
                       PropertyZipAddon(9999)
                         Colon(9999)
-                          TOKEN_26(9999): ":", line: 1, col: 210
+                          TOKEN_26(9999): ":", line: 1, col: 207
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 211
+                              TOKEN_1(9999): " ", line: 1, col: 208
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 212
+                              TOKEN_1(9999): " ", line: 1, col: 209
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 213
+                              TOKEN_1(9999): " ", line: 1, col: 210
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 214
+                              TOKEN_69(9999): "e", line: 1, col: 211
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 215
+                              TOKEN_76(9999): "l", line: 1, col: 212
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 216
+                              TOKEN_69(9999): "e", line: 1, col: 213
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 217
+                              TOKEN_77(9999): "m", line: 1, col: 214
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 218
+                              TOKEN_69(9999): "e", line: 1, col: 215
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 219
+                              TOKEN_78(9999): "n", line: 1, col: 216
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 220
+                              TOKEN_84(9999): "t", line: 1, col: 217
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 221
+                              TOKEN_63(9999): "_", line: 1, col: 218
                             LowercaseLetter(9999)
-                              TOKEN_67(9999): "c", line: 1, col: 222
+                              TOKEN_67(9999): "c", line: 1, col: 219
                             LowercaseLetter(9999)
-                              TOKEN_79(9999): "o", line: 1, col: 223
+                              TOKEN_79(9999): "o", line: 1, col: 220
                             LowercaseLetter(9999)
-                              TOKEN_85(9999): "u", line: 1, col: 224
+                              TOKEN_85(9999): "u", line: 1, col: 221
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 225
+                              TOKEN_78(9999): "n", line: 1, col: 222
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 226
+                              TOKEN_84(9999): "t", line: 1, col: 223
                             LowercaseLetter(9999)
-                              TOKEN_83(9999): "s", line: 1, col: 227
+                              TOKEN_83(9999): "s", line: 1, col: 224
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 228
+                                TOKEN_1(9999): " ", line: 1, col: 225
                       HAS(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 229
-                        TOKEN_33(9999): "A", line: 1, col: 230
-                        TOKEN_51(9999): "S", line: 1, col: 231
+                        TOKEN_40(9999): "H", line: 1, col: 226
+                        TOKEN_33(9999): "A", line: 1, col: 227
+                        TOKEN_51(9999): "S", line: 1, col: 228
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 232
+                            TOKEN_1(9999): " ", line: 1, col: 229
                       ONLY(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 233
-                        TOKEN_46(9999): "N", line: 1, col: 234
-                        TOKEN_44(9999): "L", line: 1, col: 235
-                        TOKEN_57(9999): "Y", line: 1, col: 236
+                        TOKEN_47(9999): "O", line: 1, col: 230
+                        TOKEN_46(9999): "N", line: 1, col: 231
+                        TOKEN_44(9999): "L", line: 1, col: 232
+                        TOKEN_57(9999): "Y", line: 1, col: 233
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 237
+                            TOKEN_1(9999): " ", line: 1, col: 234
                       ValueZipList(9999)
                         ValueZip(9999)
                           Value(9999)
                             String(9999)
-                              TOKEN_3(9999): """, line: 1, col: 238
+                              TOKEN_3(9999): """, line: 1, col: 235
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 239
-                              TOKEN_3(9999): """, line: 1, col: 240
+                                      TOKEN_40(9999): "H", line: 1, col: 236
+                              TOKEN_3(9999): """, line: 1, col: 237
                               Spaces(9999)
                                 Space(9999)
-                                  TOKEN_1(9999): " ", line: 1, col: 241
+                                  TOKEN_1(9999): " ", line: 1, col: 238
                           Colon(9999)
-                            TOKEN_26(9999): ":", line: 1, col: 242
+                            TOKEN_26(9999): ":", line: 1, col: 239
                           Value(9999)
                             Number(9999)
                               Digits(9999)
                                 Digit(9999)
-                                  TOKEN_22(9999): "6", line: 1, col: 243
+                                  TOKEN_22(9999): "6", line: 1, col: 240
                         Comma(9999)
-                          TOKEN_12(9999): ",", line: 1, col: 244
+                          TOKEN_12(9999): ",", line: 1, col: 241
                         ValueZip(9999)
                           Value(9999)
                             String(9999)
-                              TOKEN_3(9999): """, line: 1, col: 245
+                              TOKEN_3(9999): """, line: 1, col: 242
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 246
+                                      TOKEN_40(9999): "H", line: 1, col: 243
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_69(9999): "e", line: 1, col: 247
-                              TOKEN_3(9999): """, line: 1, col: 248
+                                      TOKEN_69(9999): "e", line: 1, col: 244
+                              TOKEN_3(9999): """, line: 1, col: 245
                           Colon(9999)
-                            TOKEN_26(9999): ":", line: 1, col: 249
+                            TOKEN_26(9999): ":", line: 1, col: 246
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 250
+                                TOKEN_1(9999): " ", line: 1, col: 247
                           Value(9999)
                             Number(9999)
                               Digits(9999)
                                 Digit(9999)
-                                  TOKEN_23(9999): "7", line: 1, col: 251
+                                  TOKEN_23(9999): "7", line: 1, col: 248
                               Spaces(9999)
                                 Space(9999)
                                   nl(9999)
-                                    SPECIAL_1(9999): "(...)", line: 1, col: 252
+                                    SPECIAL_1(9999): "(...)", line: 1, col: 249


### PR DESCRIPTION
This PR fixes #117.

Summary:
- Rephrase definitions of HAS operators to be logically consistent for duplicate matches.
- Remove `HAS EXACTLY` (including in grammar tests)
- Clarify in the phrase definitions what a `property name` is, because I needed it (but I also see it was used throughout the spec.)

During discussions on the workshop it became clear that we phrased the definitions of the HAS operators in the filer language with sets in mind. But, the specification has evolved to be very explicit about that these operators work on 'lists' and also the operator syntax, e.g., `HAS < 3`, means multiple elements may match even in a set. So, our formulations have to be improved so it is unambiguously clear how these operators work when multiple matches are present. This PR rewrites the definitions to do that.

However, it appears "HAS EXACTLY" is troublesome in this case. I don't think there is a single definition of "HAS EXACTLY" that is self-evident when multiple matches are present. Some attempts may be to define it as:
- `list HAS EXACTLY 3,4,5` := `list HAS ALL 3,4,5 AND list LENGTH 3` - This works for sets, but, e.g., with `list=[3,4,5]` do you expect `list HAS ALL 3,3,5` to match?
- `list HAS EXACTLY 3,4,5` := `list HAS ALL 3,4,5 AND list HAS ONLY 3,4,5` - This is probably the most logically consistent definition, **however** if API implementations are supposed to implement it this way, they need `HAS ONLY`, which is optional. `EXACTLY` was marked as mandatory.

So, for now, with < 1 week left to the planned release of OPTiMaDe v0.10 I think it is better for now to remove `HAS EXACTLY` from the specification completely and revisit it later to possibly bring it back. No functionality is lost, as a client can phrase their queries using one of the two constructs above.