### PR TITLE
Filtering using nested property names and on relationships

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -1372,7 +1372,7 @@ For example: a client queries the `structures` endpoint with a filter that refer
 > For example, to find all structures with bibliographic references where one of the authors has the last name "Schmit" is performed by the following two steps:
 >
 > - Query the `references` endpoint with a filter `authors.lastname HAS "Schmit"` and store the `id` values of the returned entries. 
-> - Query the `structures` endpoint with a filter `references.id HAS ANY <list-of-IDs>`, where `<list-of-IDs>` is the IDs retrieved from the first query separated by commas. 
+> - Query the `structures` endpoint with a filter `references.id HAS ANY <list-of-IDs>`, where `<list-of-IDs>` are the IDs retrieved from the first query separated by commas. 
 >
 > (Note: the type of query discussed here corresponds to a "join"-type operation in a relational data model.)
 

--- a/optimade.md
+++ b/optimade.md
@@ -519,9 +519,9 @@ A query is performed using `filter` (see section [5. API Filtering Format Specif
 
 The API implementation MAY describe many-to-many relationships between entries along with OPTIONAL human-readable descriptions that describe each relationship. These relationships can be to the same, or to different, entry types.
 
-In responses that use the jsonapi format, such relationships MUST be communicated using the `"relationships"` field of the response encoded as jsonapi relationship objects in accordance with the [jsonapi specification](https://jsonapi.org/format/1.0/#document-resource-object-relationships). The OPTIONAL human-readable description is provided in the `"description"` field inside the `"meta"` dictionary of a relationship.
+In responses that use the JSON API response format, such relationships MUST be communicated using [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships) encoded in the `"relationships"` field of the response. The OPTIONAL human-readable description is provided in the `"description"` field inside the `"meta"` dictionary of a relationships object.
 
-Other response formats (e.g., ones using database-specific prefixes) have to encode these relationships in ways appropriate for each format. If the format has no dedicated mechanism to indicate relationships, it is suggested that they are encoded alongside other properties. For each entry type, the relationships with entries of that type can then be encoded in a field with the name of the entry type, which are to contain a list of the ids of the referenced entries alongside the respective human-readable description of the relationships. It is the intent that future versions of this standard uphold the viability of this encoding by not standardizing property names that overlap with the entry type names.
+Other response formats (e.g., ones using database-specific prefixes) have to encode these relationships in ways appropriate for each format. If the format has no dedicated mechanism to indicate relationships, it is suggested that they are encoded alongside other properties. For each entry type, the relationships with entries of that type can then be encoded in a field with the name of the entry type, which are to contain a list of the IDs of the referenced entries alongside the respective human-readable description of the relationships. It is the intent that future versions of this standard uphold the viability of this encoding by not standardizing property names that overlap with the entry type names.
 
 # <a name="h.4">4. API Endpoints</a>
 
@@ -1225,8 +1225,8 @@ All filtering expressions MUST follow the
 [EBNF](http://standards.iso.org/ittf/PubliclyAvailableStandards/s026153_ISO_IEC_14977_1996(E).zip)
 grammar of [Appendix 2](#h.app2) of this specification. The appendix
 contains a complete machine-readable EBNF, including the definition
-of the lexical tokens described above in [section '5.1. Lexical
-tokens'](#h.5.1). The EBNF is enclosed in special strings constructed
+of the lexical tokens described above in [5.1. Lexical
+tokens](#h.5.1). The EBNF is enclosed in special strings constructed
 as `BEGIN` and `END`, both followed by `EBNF GRAMMAR Filter`, to enable automatic
 extraction.
 
@@ -1348,7 +1348,7 @@ Examples:
 
 ### Nested property names
 
-Everywhere in a filter string where a property name is accepted, the API implementation MAY accept nested property names as described in [section '5.1. Lexical tokens'](#h.5.1), consisting of fields separated by periods ('.'). A filter on a nested property name consisting of two fields `field1.field2` matches if either one of these points are true:
+Everywhere in a filter string where a property name is accepted, the API implementation MAY accept nested property names as described in [5.1. Lexical tokens](#h.5.1), consisting of fields separated by periods ('.'). A filter on a nested property name consisting of two fields `field1.field2` matches if either one of these points are true:
 
 - `field1` references a dictionary-type property that contains as a field `field2` and the filter matches for the content of `field2`.
 
@@ -1362,18 +1362,19 @@ A nested property name that combines more than one list MUST, if accepted, be in
 As described in section [3.6. Relationships](#h.3.6), it is possible for the API implementation to describe relationships between entries of the same, or different, entry types. 
 The API implementation MAY support queries on relationships with an entry type `<entry type>` by using special nested property names:
 
-- `<entry type>.id` references a list of ids of relationships with entries of the type `<entry type>`.
+- `<entry type>.id` references a list of IDs of relationships with entries of the type `<entry type>`.
 - `<entry type>.description` references a correlated list of the human-readable descriptions of these relationships.
 
 Hence, the filter language acts as, for every entry type, there is a property with that name which contains a list of dictionaries with two fields, `id` and `description`.
 For example: a client queries the `structures` endpoint with a filter that references `calculations.id`. For a specific structures entry, the nested property may behave as the list `["calc-id-43", "calc-id-96"]` and would then, e.g., match the filter `calculations.id HAS "calc-id-96"`. This means that the structures entry has a relationship with the calculations entry of that id.
 
 > **Note:** formulating queries on relationships with entries that have specific property values is a multi-step process. 
-> For example, to find all structures with bibliographic references where one of the authors have the last name "Schmit" is performed by the following two steps:
+> For example, to find all structures with bibliographic references where one of the authors has the last name "Schmit" is performed by the following two steps:
 >
 > - Query the `references` endpoint with a filter `authors.lastname HAS "Schmit"` and store the `id` values of the returned entries. 
-> - Query the `structures` endpoint with a filter `references.id HAS ANY <list-of-ids>`, where `<list-of-ids>` is the ids retrieved from the first query separated by commas. 
-
+> - Query the `structures` endpoint with a filter `references.id HAS ANY <list-of-IDs>`, where `<list-of-IDs>` is the IDs retrieved from the first query separated by commas. 
+>
+> (Note: the type of query discussed here corresponds to a "join"-type operation in a relational data model.)
 
 ### Properties that can be unset
 
@@ -1421,7 +1422,7 @@ the property type. For example, `x > "0.0"` where x is a coordinate
 would be treated as numeric filter `x > 0`, and `s = 0` for a String
 parameter "s" would perform string comparison as in `s = "0"`.
 Strings are converted to numbers using the token syntax specified in
-[section '5.1. Lexical tokens'](#h.5.1), p. "Numeric values"; numbers
+[5.1. Lexical tokens](#h.5.1), p. "Numeric values"; numbers
 SHOULD be converted to strings using the libc "%g" format. If a
 conversion is performed, the API implementation SHOULD supply a
 warning in the response and specify the actual search values that were
@@ -1966,7 +1967,7 @@ in section [6.1. Properties Used by Multiple Entry Types](#h.6.1).
 
 ## <a name="h.6.6">6.6. Relationships Used by Multiple Entry Types</a>
 
-In accordance with section [3.6. Relationships](#h.3.6), all entry types may use
+In accordance with section [3.6. Relationships](#h.3.6), all entry types MAY use
 relationships to describe relations to other entries.
 
 ### <a name="h.6.6.1">6.6.1. References</a>

--- a/optimade.md
+++ b/optimade.md
@@ -517,7 +517,7 @@ A query is performed using `filter` (see section [5. API Filtering Format Specif
 
 ## <a name="h.3.6">3.6. Relationships</a>
 
-The API implementation MAY describe many-to-many relationships between entries along with OPTIONAL human-readable descriptions that describe the relationship. These relationships can be to the same, or to different, entry types.
+The API implementation MAY describe many-to-many relationships between entries along with OPTIONAL human-readable descriptions that describe each relationship. These relationships can be to the same, or to different, entry types.
 
 In responses that use the jsonapi format, such relationships MUST be communicated using the `"relationships"` field of the response encoded as jsonapi relationship objects in accordance with the [jsonapi specification](https://jsonapi.org/format/1.0/#document-resource-object-relationships). The OPTIONAL human-readable description is provided in the `"description"` field inside the `"meta"` dictionary of a relationship.
 
@@ -1348,13 +1348,14 @@ Examples:
 
 ### Nested property names
 
-Everywhere in a filter string where a property name is accepted, the API implementation MAY accept nested property names as described in [section '5.1. Lexical tokens'](#h.5.1), consisting of fields separated by periods ('.'). A filter on a nested property name consisting of two fields `field1.field2` matches if:
-- `field1` references a dictionary-type property that contains as a field `field2` and the filter matches for the content of `field2`.  
-OR
+Everywhere in a filter string where a property name is accepted, the API implementation MAY accept nested property names as described in [section '5.1. Lexical tokens'](#h.5.1), consisting of fields separated by periods ('.'). A filter on a nested property name consisting of two fields `field1.field2` matches if either one of these points are true:
+
+- `field1` references a dictionary-type property that contains as a field `field2` and the filter matches for the content of `field2`.
+
 - `field1` references a list of dictionaries that contain as a field `field2` and the filter matches for a flat list containing only the contents of `field2` for every dictionary in the list. E.g., if `field1` is the list `[{"field2":42, "field3":36}, {"field2":96, "field3":66}]`, then `field1.field2` is understood in the filter as the list `[42, 96]`.
 
 The API implementation MAY allow this notation to generalize to arbitary depth. 
-A nested property names that combines more than one list MUST, if accepted, be interpreted as a completely flattened list.
+A nested property name that combines more than one list MUST, if accepted, be interpreted as a completely flattened list.
 
 ### Relationships
 

--- a/optimade.md
+++ b/optimade.md
@@ -1366,7 +1366,7 @@ The API implementation MAY support queries on relationships with an entry type `
 - `<entry type>.description` references a correlated list of the human-readable descriptions of these relationships.
 
 Hence, the filter language acts as, for every entry type, there is a property with that name which contains a list of dictionaries with two fields, `id` and `description`.
-For example: a client queries the `structures` endpoint with a filter that references `calculations.id`. For a specific structures entry, the nested property may behave as the list `["calc-id-43", "calc-id-96"]` and would then, e.g., match the filter `calculations.id HAS "calc-id-96"`. This means that the structures entry has a relationship with the calculations entry of that id.
+For example: a client queries the `structures` endpoint with a filter that references `calculations.id`. For a specific structures entry, the nested property may behave as the list `["calc-id-43", "calc-id-96"]` and would then, e.g., match the filter `calculations.id HAS "calc-id-96"`. This means that the structures entry has a relationship with the calculations entry of that ID.
 
 > **Note:** formulating queries on relationships with entries that have specific property values is a multi-step process. 
 > For example, to find all structures with bibliographic references where one of the authors has the last name "Schmit" is performed by the following two steps:


### PR DESCRIPTION
This is the final remaining part of #116, with content that was agreed on in the final two days of the workshop and which I agreed on writing up. Sorry for the delay, but it wasn't so easy to write up. Closes #116.

In summary:
- Describes filtering on nested property names. Much of this was already present in the lexical tokens subsection. It is now moved alongside other discussion of filtering.
- Describes filtering on relationships. This was vaguely hinted at alongside the discussion on filters on nested property names, but is now in the filtering section and clarified.
- Some other cleanup with regards to relationships necessary to concisely formulate these parts. This includes disintegrating some jsonapi-response-format-specifics from the more abstract concept of relationships in OPTiMaDe (and existing also for other potential output formats.); including moving up the general discussion of relationships to section 3, rather than down in section 6. 
 