### PR TITLE
Additions to providers.json

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -20,15 +20,6 @@
     },
     {
       "type": "provider",
-      "id": "cif",
-      "attributes": {
-        "name": "Crystallographic Information File",
-        "description": "Prefix for use of cif dictionary names as OPTiMaDe property identifiers, standardized for the Crystallographic Information File (CIF) at https://www.iucr.org/resources/cif/dictionaries. CIF dictionary names are used without the initial underscore. Loop data is represented as OPTiMaDe correlated lists.",
-	"base_url": null
-      }
-    },
-    {
-      "type": "provider",
       "id": "cod",
       "attributes": {
         "name": "Crystallography open database",

--- a/providers.json
+++ b/providers.json
@@ -20,6 +20,15 @@
     },
     {
       "type": "provider",
+      "id": "cif",
+      "attributes": {
+        "name": "Crystallographic Information File",
+        "description": "Prefix for use of cif dictionary names as OPTiMaDe property identifiers, standardized for the Crystallographic Information File (CIF) at https://www.iucr.org/resources/cif/dictionaries. CIF dictionary names are used without the initial underscore. Loop data is represented as OPTiMaDe correlated lists.",
+	"base_url": null
+      }
+    },
+    {
+      "type": "provider",
       "id": "cod",
       "attributes": {
         "name": "Crystallography open database",
@@ -34,6 +43,15 @@
         "name": "Example provider",
         "description": "Provider used for examples, not to be assigned to a real database",
         "base_url": "http://example.com/optimade/index"
+      }
+    },
+    {
+      "type": "provider",
+      "id": "httk",
+      "attributes": {
+        "name": "The High-Throughput Toolkit",
+        "description": "Prefix for implementation-specific identifiers used in the httk implementation at http://httk.org/",
+	"base_url": null
       }
     },
     {
@@ -79,6 +97,15 @@
         "name": "open materials database",
         "description": "",
         "base_url": null
+      }
+    },
+    {
+      "type": "provider",
+      "id": "optimade",
+      "attributes": {
+        "name": "OPTiMaDe implementations and libraries",
+        "description": "Prefix for implementation-specific identifiers used in API implementations and libraries provided at https://github.com/Materials-Consortia",
+	"base_url": null
       }
     },
     {


### PR DESCRIPTION
I'd like to add provider 'httk' in providers.json, even though it is more of a framework than a database ("my" database is 'omdb'). I need this for providing 'httk'-specific features under an `_httk_` prefix namespace that will be common to everyone who uses httk, which is separate from the namespace `_omdb_` that I'll use completely local to the omdb database.

I see a similar need for our optimade implementations and libraries. So, it probably does not hurt to reserve the `_optimade_` prefix for us. So that is also in this PR.

Furthermore, and this I suppose can be more controversial, we might want to also reserve `_cif_` as a common standard for embedding cif filelds inside OPTiMaDe. (But if there is opposition to this, I'm fine with take it out or extract it into a separate PR.)
