### PR TITLE
Fixes in type conversion rules

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -1449,7 +1449,7 @@ token.
 
 * If a comparison is provided between only constants of incompatible types,
 e.g., `5 < "13"`, the implementation MUST respond with an error. The same
-applies for comparisons of two properties, e.g. `nelements > chemical_formula_hill`.
+applies for comparisons of two properties of different type, e.g. `nelements > chemical_formula_hill`.
 
 * Given a timestamp property and a string token, the value of the latter
 MUST be parsed according to [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6).

--- a/optimade.md
+++ b/optimade.md
@@ -1455,7 +1455,7 @@ applies for comparisons of two properties of different type, e.g. `nelements > c
 MUST be the timestamp that would result from parsing the string according to [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6).
 
 * Comparison of a timestamp property and a numeric token MUST be
-reported as an error.
+reported with error `501 Not implemented`.
 
 If a conversion is performed, the API implementation SHOULD supply a
 warning in the response and specify the actual search values that were

--- a/optimade.md
+++ b/optimade.md
@@ -1448,7 +1448,7 @@ the latter MUST be converted to a float using conventions of stdlib's
 sequence of characters) of the latter MUST be used.
 
 * If a comparison is provided between only constants of incompatible types,
-e.g., `5 < "13"`, the implementation MUST respond with an error. The same
+e.g., `5 < "13"`, the implementation MUST respond with error `501 Not Implemented`. The same
 applies for comparisons of two properties of different type, e.g. `nelements > chemical_formula_hill`.
 
 * Given a timestamp property and a string token, the value of the latter

--- a/optimade.md
+++ b/optimade.md
@@ -1395,7 +1395,7 @@ types of the participating properties. Specifically:
 not match the type of the property, it is RECOMMENDED that the
 implementation makes a best-effort to convert the constant to match
 the property type. For example, `x > "0.0"` where x is a coordinate
-would be treated as numeric filter `x > 0`, and `s = 0` for a String
+would be treated as numeric filter `x > 0`, and `s = 0` for a string
 parameter "s" would perform string comparison as in `s = "0"`.
 Strings are converted to numbers using the token syntax specified in
 [section '5.1. Lexical tokens'](#h.5.1), p. "Numeric values"; numbers

--- a/optimade.md
+++ b/optimade.md
@@ -1398,7 +1398,8 @@ the property type. For example, `x > "0.0"` where x is a coordinate
 would be treated as numeric filter `x > 0`, and `s = 0` for a string
 parameter "s" would perform string comparison as in `s = "0"`.
 Strings are converted to numbers using the token syntax specified in
-[section '5.1. Lexical tokens'](#h.5.1), p. "Numeric values"; numbers
+[section '5.1. Lexical tokens'](#h.5.1), p. "Numeric values"; integers
+SHOULD be converted to strings in decimal notation (libc "%d"), floats
 SHOULD be converted to strings using the libc "%g" format. If a
 conversion is performed, the API implementation SHOULD supply a
 warning in the response and specify the actual search values that were

--- a/optimade.md
+++ b/optimade.md
@@ -1433,31 +1433,37 @@ their types. Similarly, for database-provider-specific properties,
 the database provider decides their types. In the syntactic
 constructs that can accommodate values of more than one type, 
 the semantics of the comparisons are controlled by the
-types of the participating properties. Specifically:
+types of the participating properties. The following conventions apply
+for comparisons of values of different types:
 
-* In a comparison of a property with a constant of a type that does
-not match the type of the property, it is RECOMMENDED that the
-implementation makes a best-effort to convert the constant to match
-the property type. For example, `x > "0.0"` where x is a coordinate
-would be treated as numeric filter `x > 0`, and `s = 0` for a string
-parameter "s" would perform string comparison as in `s = "0"`.
-Strings are converted to numbers using the token syntax specified in
-[5.1. Lexical tokens](#h.5.1), p. "Numeric values"; integers
-SHOULD be converted to strings in decimal notation (libc "%d"), floats
-SHOULD be converted to strings using the libc "%g" format. Conversions
-of numeric values to timestamps MUST NOT be performed. If a
-conversion is performed, the API implementation SHOULD supply a
+* Given an integer property and a numeric or string token, the value of
+the latter MUST be converted to an integer using conventions of stdlib's
+`atoi`.
+
+* Given a float property and a numeric or string token, the value of
+the latter MUST be converted to a float using conventions of stdlib's
+`atof`.
+
+* No conversion is needed for a string property and a numeric or string
+token.
+
+* If a comparison is provided between only constants of incompatible types,
+e.g., `5 < "13"`, the implementation MUST respond with an error. The same
+applies for comparisons of two properties, e.g. `nelements > chemical_formula_hill`.
+
+* Given a timestamp property and a string token, the value of the latter
+MUST be parsed according to [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6).
+
+* Comparison of a timestamp property and a numeric token MUST be
+reported as an error.
+
+If a conversion is performed, the API implementation SHOULD supply a
 warning in the response and specify the actual search values that were
 used. Alternatively, the implementation MAY instead respond with error
 `501 Not Implemented` with an explanation that specifies which
 comparison generated the type mismatch. The implementation MUST either
 make a conversion or respond with an error. It MUST NOT, e.g., silently
 treat such comparisons as always non-matching.
-
-* If a comparison is provided between only numerical constants of
-incompatible types, e.g., `5 < "13"`, the implementation MUST respond
-with an error. The same applies for comparisons of two properties, e.g.
-`nelements > chemical_formula_hill`.
 
 ### Optional filter features
 

--- a/optimade.md
+++ b/optimade.md
@@ -1452,7 +1452,7 @@ e.g., `5 < "13"`, the implementation MUST respond with error `501 Not Implemente
 applies for comparisons of two properties of different type, e.g. `nelements > chemical_formula_hill`.
 
 * Given a timestamp property and a string token, the value of the latter
-MUST be parsed according to [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6).
+MUST be the timestamp that would result from parsing the string according to [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6).
 
 * Comparison of a timestamp property and a numeric token MUST be
 reported as an error.

--- a/optimade.md
+++ b/optimade.md
@@ -1436,23 +1436,24 @@ the semantics of the comparisons are controlled by the
 types of the participating properties. The following conventions apply
 for comparisons of values of different types:
 
-* Given an integer property and a numeric or string token, the value of
-the latter MUST be converted to an integer using conventions of stdlib's
-`atoi`.
+* In a comparison with an integer property, a numeric or string token
+represents the integer value that would result from a conversion using the
+conventions of stdlib's `atoi`.
 
-* Given a float property and a numeric or string token, the value of
-the latter MUST be converted to a float using conventions of stdlib's
-`atof`.
+* In a comparison with a float property, a numeric or string token represents
+the float value that would result from a conversion using the
+conventions of stdlib's `atof`.
 
-* Given a string property and a numeric token, the string value (verbatim
-sequence of characters) of the latter MUST be used.
+* In a comparison with a string property, a numeric token represents its
+string value (verbatim sequence of characters comprising its token).
 
 * If a comparison is provided between only constants of incompatible types,
 e.g., `5 < "13"`, the implementation MUST respond with error `501 Not Implemented`. The same
 applies for comparisons of two properties of different type, e.g. `nelements > chemical_formula_hill`.
 
-* Given a timestamp property and a string token, the value of the latter
-MUST be the timestamp that would result from parsing the string according to [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6).
+* In a comparison with a timestamp property, a string token represents a
+timestamp value that would result from parsing the string according to
+[RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6).
 
 * Comparison of a timestamp property and a numeric token MUST be
 reported with error `501 Not implemented`.

--- a/optimade.md
+++ b/optimade.md
@@ -1406,7 +1406,7 @@ warning in the response and specify the actual search values that were
 used. Alternatively, the implementation MAY instead respond with error
 `501 Not Implemented` with an explanation that specifies which
 comparison generated the type mismatch. The implementation MUST either
-make a conversion or respond with an error. It may not, e.g., silently
+make a conversion or respond with an error. It MUST NOT, e.g., silently
 treat such comparisons as always non-matching.
 
 * If a comparison is provided between only numerical constants of

--- a/optimade.md
+++ b/optimade.md
@@ -1444,8 +1444,8 @@ the latter MUST be converted to an integer using conventions of stdlib's
 the latter MUST be converted to a float using conventions of stdlib's
 `atof`.
 
-* No conversion is needed for a string property and a numeric or string
-token.
+* Given a string property and a numeric token, the string value (verbatim
+sequence of characters) of the latter MUST be used.
 
 * If a comparison is provided between only constants of incompatible types,
 e.g., `5 < "13"`, the implementation MUST respond with an error. The same

--- a/optimade.md
+++ b/optimade.md
@@ -1431,40 +1431,19 @@ Examples:
 The definitions of specific properties in this standard define
 their types. Similarly, for database-provider-specific properties,
 the database provider decides their types. In the syntactic
-constructs that can accommodate values of more than one type, 
-the semantics of the comparisons are controlled by the
-types of the participating properties. The following conventions apply
-for comparisons of values of different types:
+constructs that can accommodate values of more than one type, types of
+all participating values are REQUIRED to match, with a single exception
+of timestamps (see below). Different types of values MUST be reported
+as `501 Not Implemented` errors, meaning that type conversion is not
+implemented in the specification.
 
-* In a comparison with an integer property, a numeric or string token
-represents the integer value that would result from a conversion using the
-conventions of stdlib's `atoi`.
-
-* In a comparison with a float property, a numeric or string token represents
-the float value that would result from a conversion using the
-conventions of stdlib's `atof`.
-
-* In a comparison with a string property, a numeric token represents its
-string value (verbatim sequence of characters comprising its token).
-
-* If a comparison is provided between only constants of incompatible types,
-e.g., `5 < "13"`, the implementation MUST respond with error `501 Not Implemented`. The same
-applies for comparisons of two properties of different type, e.g. `nelements > chemical_formula_hill`.
-
-* In a comparison with a timestamp property, a string token represents a
-timestamp value that would result from parsing the string according to
+As the filter language syntax does not define a lexical token for
+timestamps, values of this type are expressed using string tokens in
 [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6).
-
-* Comparison of a timestamp property and a numeric token MUST be
-reported with error `501 Not implemented`.
-
-If a conversion is performed, the API implementation SHOULD supply a
-warning in the response and specify the actual search values that were
-used. Alternatively, the implementation MAY instead respond with error
-`501 Not Implemented` with an explanation that specifies which
-comparison generated the type mismatch. The implementation MUST either
-make a conversion or respond with an error. It MUST NOT, e.g., silently
-treat such comparisons as always non-matching.
+In a comparison with a timestamp property, a string token represents a
+timestamp value that would result from parsing the string according to
+RFC 3339 Internet Date/Time Format. Interpretation failures MUST be
+reported with error `400 Bad Request`.
 
 ### Optional filter features
 


### PR DESCRIPTION
Fixes:
1. separates rules for `integer` and `float` conversion to `string`. Previously, all numeric types were recommended to be converted using `libc`s `"%g"`, which unnaturally represents integers:

    `printf "%g", 1234567` -> `1.23457e+06`

2. an example of unwanted behavior was qualified with "may not", I've changed that to "MUST NOT".