### PR TITLE
Adding AiiDA and improving description of Materials Cloud

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -2,6 +2,15 @@
   "data": [
     {
       "type": "provider",
+      "id": "aiida",
+      "attributes": {
+        "name": "AiiDA",
+        "description": "AiiDA: Automated Interactive Infrastructure and Database for Computational Science (http://www.aiida.net)",
+        "base_url": null
+      }
+    },
+    {
+      "type": "provider",
       "id": "aflow",
       "attributes": {
         "name": "aflow.org",
@@ -49,8 +58,8 @@
       "type": "provider",
       "id": "mcloud",
       "attributes": {
-        "name": "materialscloud.org",
-        "description": "",
+        "name": "Materials Cloud",
+        "description": "Materials Cloud: A platform for Open Science built for seamless sharing of resources in computational materials science (http://www.materialscloud.org)",
         "base_url": null
       }
     },


### PR DESCRIPTION
Similar to #143, where `httk` was added for the software
in parallel to `omdb` for the database, here we add `aiida`
as the prefix for the AiiDA software (www.aiida.net) in parallel
to the `mcloud` prefix for the Materials Cloud (www.materialscloud.org)
online database.

Moreover, I'm clarifying and improving the description of the
Materials Cloud entry.
