### PR TITLE
Fix available_api_versions so the same version can be at more than one URL

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -777,9 +777,11 @@ The single resource object's response dictionary MUST include the following fiel
 * **id**: `"/"`
 * **attributes**: Dictionary containing the following fields:
   * **api\_version**: Presently used version of the OPTiMaDe API.
-  * **available\_api\_versions**: Dictionary where values are the base URLs for the versions of the
-  API that are supported, and the keys are strings giving the full version number provided by that
-  base URL. Provided base URLs MUST adhere to the rules in section [3.1. Base URL](#h.3.1).
+  * **available\_api\_versions**: A list of URLs where the same data is served using different versions of this API.
+    It MUST be a list of dictionaries, each containing the fields:
+	* **url**: a string specifying a base URL that MUST adhere to the rules in section [3.1. Base URL](#h.3.1)
+	* **version**: a string containing the full version number of the API served at that base URL. 
+	  The version number string SHOULD NOT be prefixed by, e.g., "v".
   * **formats**: List of available output formats.
   * **entry\_types\_by\_format**: Available entry endpoints as a function of output formats.
   * **available\_endpoints**: List of available endpoints (i.e., the string to be appended to the
@@ -819,11 +821,12 @@ Example:
     "id": "/",
     "attributes": {
       "api_version": "v0.9",
-      "available_api_versions": {
-        "0.9.5": "http://db.example.com/optimade/v0.9/",
-        "0.9.2": "http://db.example.com/optimade/v0.9.2/",
-        "1.0.2": "http://db.example.com/optimade/v1.0/"
-      },
+      "available_api_versions": [
+	    {"url": "http://db.example.com/optimade/v0.9/", "version": "0.9.5"},
+        {"url": "http://db.example.com/optimade/v1.0/", "version": "1.0.2"},
+        {"url": "http://db.example.com/optimade/v0.9.2/", "version": "0.9.2"},
+        {"url": "http://db.example.com/optimade/v0.9.5/", "version": "0.9.5"}
+      }},
       "formats": [
         "json",
         "xml"

--- a/optimade.md
+++ b/optimade.md
@@ -777,11 +777,10 @@ The single resource object's response dictionary MUST include the following fiel
 * **id**: `"/"`
 * **attributes**: Dictionary containing the following fields:
   * **api\_version**: Presently used version of the OPTiMaDe API.
-  * **available\_api\_versions**: A list of URLs where the same data is served using different versions of this API.
-    It MUST be a list of dictionaries, each containing the fields:
+  * **available\_api\_versions**: MUST be a list of dictionaries, each containing the fields:
 	* **url**: a string specifying a base URL that MUST adhere to the rules in section [3.1. Base URL](#h.3.1)
 	* **version**: a string containing the full version number of the API served at that base URL. 
-	  The version number string SHOULD NOT be prefixed by, e.g., "v".
+	  The version number string MUST NOT be prefixed by, e.g., "v".
   * **formats**: List of available output formats.
   * **entry\_types\_by\_format**: Available entry endpoints as a function of output formats.
   * **available\_endpoints**: List of available endpoints (i.e., the string to be appended to the
@@ -826,7 +825,7 @@ Example:
         {"url": "http://db.example.com/optimade/v1.0/", "version": "1.0.2"},
         {"url": "http://db.example.com/optimade/v0.9.2/", "version": "0.9.2"},
         {"url": "http://db.example.com/optimade/v0.9.5/", "version": "0.9.5"}
-      }},
+      ],
       "formats": [
         "json",
         "xml"


### PR DESCRIPTION
Fixes #65 that at least I considered a release blocker for v0.10. 

(I'd really prefer not going back and messing with the version negotiation when implementations start to appear...)
