### PR TITLE
Permitting rhs properties in filters

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -2232,8 +2232,11 @@ ValueOpRhs = Operator, Value ;
 
 KnownOpRhs = IS, ( KNOWN | UNKNOWN ) ; 
 
-FuzzyStringOpRhs = CONTAINS, String | STARTS, [ WITH ], String | ENDS, [ WITH ], String |
-                   LIKE, String | NOT, LIKE, String | UNLIKE, String ;
+StringProperty = String | Property ;
+(* Support for Property tokens in StringProperty is optional *)
+
+FuzzyStringOpRhs = CONTAINS, StringProperty | STARTS, [ WITH ], StringProperty | ENDS, [ WITH ], StringProperty |
+                   LIKE, StringProperty | NOT, LIKE, StringProperty | UNLIKE, StringProperty ;
 
 SetOpRhs = HAS, ( [ Operator ], Value | ALL, ValueList | ANY, ValueList | ONLY, ValueList ) ;
 (* Note: support for ONLY in SetOpRhs is OPTIONAL *)

--- a/optimade.md
+++ b/optimade.md
@@ -1298,7 +1298,21 @@ In addition to the standard equality and inequality operators, matching of parti
 
 OPTIONAL features: 
 
+The following comparison operators are OPTIONAL:
+
+* `identfier LIKE x`
+
+* `identfier UNLIKE x`
+
 * Support for x to be an identifier, rather than a string is OPTIONAL.
+
+If implemented, the "LIKE" operator MUST behave as the correspoding standard SQL operator. In particular,
+The `x` string MUST be interpreted as a pattern where an underscore character ('_', ASCII DEC 95, HEX 5F)
+matches any single character and a percent character ('%', ASCII DEC 37, HEX 25) matches an arbitrary
+sequence of characters (including zero characters).
+
+If operator "UNLIKE" is supported, the bahavior of this oprtator MUST be the negation of the "LIKE" operator; i.e.
+an expression `(property UNLIKE "value")" must behave exactly as `(NOT (property LIKE "value"))`.
 
 Examples:
 
@@ -2218,7 +2232,8 @@ ValueOpRhs = Operator, Value ;
 
 KnownOpRhs = IS, ( KNOWN | UNKNOWN ) ; 
 
-FuzzyStringOpRhs = CONTAINS, String | STARTS, [ WITH ], String | ENDS, [ WITH ], String ;
+FuzzyStringOpRhs = CONTAINS, String | STARTS, [ WITH ], String | ENDS, [ WITH ], String |
+                   LIKE, String | NOT, LIKE, String | UNLIKE, String ;
 
 SetOpRhs = HAS, ( [ Operator ], Value | ALL, ValueList | ANY, ValueList | ONLY, ValueList ) ;
 (* Note: support for ONLY in SetOpRhs is OPTIONAL *)
@@ -2265,6 +2280,9 @@ HAS = 'H', 'A', 'S', [Spaces] ;
 ALL = 'A', 'L', 'L', [Spaces] ;
 ONLY = 'O', 'N', 'L', 'Y', [Spaces] ;
 ANY = 'A', 'N', 'Y', [Spaces] ;
+
+LIKE = 'L', 'I', 'K', 'E', [Spaces];
+UNLIKE = 'U', 'N', 'L', 'I', 'K', 'E', [Spaces];
 
 (* OperatorComparison operator tokens: *)
 

--- a/tests/cases/Filter_072.inp
+++ b/tests/cases/Filter_072.inp
@@ -1,0 +1,1 @@
+chemical_formula LIKE "H2 O2"

--- a/tests/cases/Filter_072.opt
+++ b/tests/cases/Filter_072.opt
@@ -1,0 +1,1 @@
+Filter_001.opt

--- a/tests/cases/Filter_073.inp
+++ b/tests/cases/Filter_073.inp
@@ -1,0 +1,1 @@
+chemical_formula NOT LIKE "C6 H12 O6"

--- a/tests/cases/Filter_073.opt
+++ b/tests/cases/Filter_073.opt
@@ -1,0 +1,1 @@
+Filter_001.opt

--- a/tests/cases/Filter_074.inp
+++ b/tests/cases/Filter_074.inp
@@ -1,0 +1,1 @@
+chemical_formula UNLIKE "C6 H12 O6"

--- a/tests/cases/Filter_074.opt
+++ b/tests/cases/Filter_074.opt
@@ -1,0 +1,1 @@
+Filter_001.opt

--- a/tests/cases/Filter_075.inp
+++ b/tests/cases/Filter_075.inp
@@ -1,0 +1,2 @@
+chemical_formula UNLIKE another_formula
+

--- a/tests/cases/Filter_075.opt
+++ b/tests/cases/Filter_075.opt
@@ -1,0 +1,1 @@
+Filter_001.opt

--- a/tests/cases/Filter_076.inp
+++ b/tests/cases/Filter_076.inp
@@ -1,0 +1,1 @@
+"C2 H2" LIKE formula

--- a/tests/cases/Filter_076.opt
+++ b/tests/cases/Filter_076.opt
@@ -1,0 +1,1 @@
+Filter_001.opt

--- a/tests/outputs/Filter_019.out
+++ b/tests/outputs/Filter_019.out
@@ -56,7 +56,9 @@ Filter(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 26
 Error: in tests/cases/Filter_019.inp: line 1:
-    unexpected token "4", expected """
+    unexpected token "4", expected one of """, "a", "b", "c", "d",
+    "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q",
+    "r", "s", "t", "u", "v", "w", "x", "y", "z", or "_"
 
 chemical_formula CONTAINS 42
                           ^

--- a/tests/outputs/Filter_020.out
+++ b/tests/outputs/Filter_020.out
@@ -56,7 +56,9 @@ Filter(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 26
 Error: in tests/cases/Filter_020.inp: line 1:
-    unexpected token "S", expected """
+    unexpected token "S", expected one of """, "a", "b", "c", "d",
+    "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q",
+    "r", "s", "t", "u", "v", "w", "x", "y", "z", or "_"
 
 chemical_formula CONTAINS STARTS "Al"
                           ^

--- a/tests/outputs/Filter_021.out
+++ b/tests/outputs/Filter_021.out
@@ -55,22 +55,23 @@ Filter(9999)
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 26
-              String(9999)
-                TOKEN_3(9999): """, line: 1, col: 27
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_33(9999): "A", line: 1, col: 28
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 29
-                TOKEN_3(9999): """, line: 1, col: 30
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 31
+              StringProperty(9999)
+                String(9999)
+                  TOKEN_3(9999): """, line: 1, col: 27
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_33(9999): "A", line: 1, col: 28
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_76(9999): "l", line: 1, col: 29
+                  TOKEN_3(9999): """, line: 1, col: 30
+                  Spaces(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 31
       AND(9999)
         TOKEN_33(9999): "A", line: 1, col: 32
         TOKEN_46(9999): "N", line: 1, col: 33
@@ -130,22 +131,23 @@ Filter(9999)
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 59
-                String(9999)
-                  TOKEN_3(9999): """, line: 1, col: 60
-                  EscapedChar(9999)
-                    UnescapedChar(9999)
-                      Letter(9999)
-                        UppercaseLetter(9999)
-                          TOKEN_33(9999): "A", line: 1, col: 61
-                  EscapedChar(9999)
-                    UnescapedChar(9999)
-                      Letter(9999)
-                        LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 62
-                  TOKEN_3(9999): """, line: 1, col: 63
-                  Spaces(9999)
-                    Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 64
+                StringProperty(9999)
+                  String(9999)
+                    TOKEN_3(9999): """, line: 1, col: 60
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        Letter(9999)
+                          UppercaseLetter(9999)
+                            TOKEN_33(9999): "A", line: 1, col: 61
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        Letter(9999)
+                          LowercaseLetter(9999)
+                            TOKEN_76(9999): "l", line: 1, col: 62
+                    TOKEN_3(9999): """, line: 1, col: 63
+                    Spaces(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 64
         AND(9999)
           TOKEN_33(9999): "A", line: 1, col: 65
           TOKEN_46(9999): "N", line: 1, col: 66
@@ -203,20 +205,21 @@ Filter(9999)
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 90
-                  String(9999)
-                    TOKEN_3(9999): """, line: 1, col: 91
-                    EscapedChar(9999)
-                      UnescapedChar(9999)
-                        Letter(9999)
-                          UppercaseLetter(9999)
-                            TOKEN_33(9999): "A", line: 1, col: 92
-                    EscapedChar(9999)
-                      UnescapedChar(9999)
-                        Letter(9999)
-                          LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 93
-                    TOKEN_3(9999): """, line: 1, col: 94
-                    Spaces(9999)
-                      Space(9999)
-                        nl(9999)
-                          SPECIAL_1(9999): "(...)", line: 1, col: 95
+                  StringProperty(9999)
+                    String(9999)
+                      TOKEN_3(9999): """, line: 1, col: 91
+                      EscapedChar(9999)
+                        UnescapedChar(9999)
+                          Letter(9999)
+                            UppercaseLetter(9999)
+                              TOKEN_33(9999): "A", line: 1, col: 92
+                      EscapedChar(9999)
+                        UnescapedChar(9999)
+                          Letter(9999)
+                            LowercaseLetter(9999)
+                              TOKEN_76(9999): "l", line: 1, col: 93
+                      TOKEN_3(9999): """, line: 1, col: 94
+                      Spaces(9999)
+                        Space(9999)
+                          nl(9999)
+                            SPECIAL_1(9999): "(...)", line: 1, col: 95

--- a/tests/outputs/Filter_022.out
+++ b/tests/outputs/Filter_022.out
@@ -44,9 +44,12 @@ Filter(9999)
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 18
+            FuzzyStringOpRhs(9999)
+              UNLIKE(9999)
+                TOKEN_53(9999): "U", line: 1, col: 19
+                TOKEN_46(9999): "N", line: 1, col: 20
 Error: in tests/cases/Filter_022.inp: line 1:
-    unexpected token "U", expected one of "<", ">", "=", "!", "I",
-    "C", "S", "E", "H", or ":"
+    unexpected token "K", expected "L"
 
 prototype_formula UNKNOWN
-                  ^
+                    ^

--- a/tests/outputs/Filter_023.out
+++ b/tests/outputs/Filter_023.out
@@ -28,7 +28,7 @@ Filter(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
 Error: in tests/cases/Filter_023.inp: line 1:
     unexpected token "f", expected one of "<", ">", "=", "!", "I",
-    "C", "S", "E", "H", or ":"
+    "C", "S", "E", "L", "N", "U", "H", or ":"
 
 chemical formula IS KNOWN 42
          ^

--- a/tests/outputs/Filter_024.out
+++ b/tests/outputs/Filter_024.out
@@ -44,7 +44,7 @@ Filter(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17
 Error: in tests/cases/Filter_024.inp: line 1:
     unexpected token "K", expected one of "<", ">", "=", "!", "I",
-    "C", "S", "E", "H", or ":"
+    "C", "S", "E", "L", "N", "U", "H", or ":"
 
 chemical_formula KNOWN
                  ^

--- a/tests/outputs/Filter_028.out
+++ b/tests/outputs/Filter_028.out
@@ -26,9 +26,11 @@ Filter(9999)
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
+            FuzzyStringOpRhs(9999)
+              LIKE(9999)
+                TOKEN_44(9999): "L", line: 1, col: 10
 Error: in tests/cases/Filter_028.inp: line 1:
-    unexpected token "L", expected one of "<", ">", "=", "!", "I",
-    "C", "S", "E", "H", or ":"
+    unexpected token "E", expected "I"
 
 elements LENGTH 42
-         ^
+          ^

--- a/tests/outputs/Filter_059.out
+++ b/tests/outputs/Filter_059.out
@@ -57,21 +57,22 @@ Filter(9999)
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 27
-              String(9999)
-                TOKEN_3(9999): """, line: 1, col: 28
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_35(9999): "C", line: 1, col: 29
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_18(9999): "2", line: 1, col: 30
-                TOKEN_3(9999): """, line: 1, col: 31
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 32
+              StringProperty(9999)
+                String(9999)
+                  TOKEN_3(9999): """, line: 1, col: 28
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_35(9999): "C", line: 1, col: 29
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_18(9999): "2", line: 1, col: 30
+                  TOKEN_3(9999): """, line: 1, col: 31
+                  Spaces(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 32
       AND(9999)
         TOKEN_33(9999): "A", line: 1, col: 33
         TOKEN_46(9999): "N", line: 1, col: 34
@@ -141,15 +142,16 @@ Filter(9999)
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 66
-                String(9999)
-                  TOKEN_3(9999): """, line: 1, col: 67
-                  EscapedChar(9999)
-                    UnescapedChar(9999)
-                      Letter(9999)
-                        UppercaseLetter(9999)
-                          TOKEN_33(9999): "A", line: 1, col: 68
-                  EscapedChar(9999)
-                    UnescapedChar(9999)
-                      Digit(9999)
-                        TOKEN_18(9999): "2", line: 1, col: 69
-                  TOKEN_3(9999): """, line: 1, col: 70
+                StringProperty(9999)
+                  String(9999)
+                    TOKEN_3(9999): """, line: 1, col: 67
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        Letter(9999)
+                          UppercaseLetter(9999)
+                            TOKEN_33(9999): "A", line: 1, col: 68
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        Digit(9999)
+                          TOKEN_18(9999): "2", line: 1, col: 69
+                    TOKEN_3(9999): """, line: 1, col: 70

--- a/tests/outputs/Filter_060.out
+++ b/tests/outputs/Filter_060.out
@@ -55,21 +55,22 @@ Filter(9999)
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 25
-              String(9999)
-                TOKEN_3(9999): """, line: 1, col: 26
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_34(9999): "B", line: 1, col: 27
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_18(9999): "2", line: 1, col: 28
-                TOKEN_3(9999): """, line: 1, col: 29
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 30
+              StringProperty(9999)
+                String(9999)
+                  TOKEN_3(9999): """, line: 1, col: 26
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_34(9999): "B", line: 1, col: 27
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_18(9999): "2", line: 1, col: 28
+                  TOKEN_3(9999): """, line: 1, col: 29
+                  Spaces(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 30
       AND(9999)
         TOKEN_33(9999): "A", line: 1, col: 31
         TOKEN_46(9999): "N", line: 1, col: 32
@@ -137,15 +138,16 @@ Filter(9999)
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 62
-                String(9999)
-                  TOKEN_3(9999): """, line: 1, col: 63
-                  EscapedChar(9999)
-                    UnescapedChar(9999)
-                      Letter(9999)
-                        UppercaseLetter(9999)
-                          TOKEN_36(9999): "D", line: 1, col: 64
-                  EscapedChar(9999)
-                    UnescapedChar(9999)
-                      Digit(9999)
-                        TOKEN_18(9999): "2", line: 1, col: 65
-                  TOKEN_3(9999): """, line: 1, col: 66
+                StringProperty(9999)
+                  String(9999)
+                    TOKEN_3(9999): """, line: 1, col: 63
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        Letter(9999)
+                          UppercaseLetter(9999)
+                            TOKEN_36(9999): "D", line: 1, col: 64
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        Digit(9999)
+                          TOKEN_18(9999): "2", line: 1, col: 65
+                    TOKEN_3(9999): """, line: 1, col: 66

--- a/tests/outputs/Filter_064.out
+++ b/tests/outputs/Filter_064.out
@@ -74,22 +74,23 @@ Filter(9999)
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 35
-              String(9999)
-                TOKEN_3(9999): """, line: 1, col: 36
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_33(9999): "A", line: 1, col: 37
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 38
-                TOKEN_3(9999): """, line: 1, col: 39
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 40
+              StringProperty(9999)
+                String(9999)
+                  TOKEN_3(9999): """, line: 1, col: 36
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_33(9999): "A", line: 1, col: 37
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_76(9999): "l", line: 1, col: 38
+                  TOKEN_3(9999): """, line: 1, col: 39
+                  Spaces(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 40
       AND(9999)
         TOKEN_33(9999): "A", line: 1, col: 41
         TOKEN_46(9999): "N", line: 1, col: 42
@@ -149,22 +150,23 @@ Filter(9999)
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 68
-                String(9999)
-                  TOKEN_3(9999): """, line: 1, col: 69
-                  EscapedChar(9999)
-                    UnescapedChar(9999)
-                      Letter(9999)
-                        UppercaseLetter(9999)
-                          TOKEN_33(9999): "A", line: 1, col: 70
-                  EscapedChar(9999)
-                    UnescapedChar(9999)
-                      Letter(9999)
-                        LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 71
-                  TOKEN_3(9999): """, line: 1, col: 72
-                  Spaces(9999)
-                    Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 73
+                StringProperty(9999)
+                  String(9999)
+                    TOKEN_3(9999): """, line: 1, col: 69
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        Letter(9999)
+                          UppercaseLetter(9999)
+                            TOKEN_33(9999): "A", line: 1, col: 70
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        Letter(9999)
+                          LowercaseLetter(9999)
+                            TOKEN_76(9999): "l", line: 1, col: 71
+                    TOKEN_3(9999): """, line: 1, col: 72
+                    Spaces(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 73
         AND(9999)
           TOKEN_33(9999): "A", line: 1, col: 74
           TOKEN_46(9999): "N", line: 1, col: 75
@@ -222,30 +224,31 @@ Filter(9999)
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 99
-                  String(9999)
-                    TOKEN_3(9999): """, line: 1, col: 100
-                    EscapedChar(9999)
-                      UnescapedChar(9999)
-                        Letter(9999)
-                          UppercaseLetter(9999)
-                            TOKEN_33(9999): "A", line: 1, col: 101
-                    EscapedChar(9999)
-                      UnescapedChar(9999)
-                        Letter(9999)
-                          LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 102
-                    TOKEN_3(9999): """, line: 1, col: 103
-                    Spaces(9999)
-                      Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 104
-                      Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 105
-                      Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 106
-                      Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 107
-                      Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 108
-                      Space(9999)
-                        nl(9999)
-                          SPECIAL_1(9999): "(...)", line: 1, col: 109
+                  StringProperty(9999)
+                    String(9999)
+                      TOKEN_3(9999): """, line: 1, col: 100
+                      EscapedChar(9999)
+                        UnescapedChar(9999)
+                          Letter(9999)
+                            UppercaseLetter(9999)
+                              TOKEN_33(9999): "A", line: 1, col: 101
+                      EscapedChar(9999)
+                        UnescapedChar(9999)
+                          Letter(9999)
+                            LowercaseLetter(9999)
+                              TOKEN_76(9999): "l", line: 1, col: 102
+                      TOKEN_3(9999): """, line: 1, col: 103
+                      Spaces(9999)
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 104
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 105
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 106
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 107
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 108
+                        Space(9999)
+                          nl(9999)
+                            SPECIAL_1(9999): "(...)", line: 1, col: 109

--- a/tests/outputs/Filter_065.out
+++ b/tests/outputs/Filter_065.out
@@ -49,19 +49,20 @@ Filter(9999)
                 TOKEN_41(9999): "I", line: 1, col: 22
                 TOKEN_46(9999): "N", line: 1, col: 23
                 TOKEN_51(9999): "S", line: 1, col: 24
-              String(9999)
-                TOKEN_3(9999): """, line: 1, col: 25
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_33(9999): "A", line: 1, col: 26
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 27
-                TOKEN_3(9999): """, line: 1, col: 28
+              StringProperty(9999)
+                String(9999)
+                  TOKEN_3(9999): """, line: 1, col: 25
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_33(9999): "A", line: 1, col: 26
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_76(9999): "l", line: 1, col: 27
+                  TOKEN_3(9999): """, line: 1, col: 28
       AND(9999)
         TOKEN_33(9999): "A", line: 1, col: 29
         TOKEN_46(9999): "N", line: 1, col: 30
@@ -112,19 +113,20 @@ Filter(9999)
                   TOKEN_50(9999): "R", line: 1, col: 51
                   TOKEN_52(9999): "T", line: 1, col: 52
                   TOKEN_51(9999): "S", line: 1, col: 53
-                String(9999)
-                  TOKEN_3(9999): """, line: 1, col: 54
-                  EscapedChar(9999)
-                    UnescapedChar(9999)
-                      Letter(9999)
-                        UppercaseLetter(9999)
-                          TOKEN_33(9999): "A", line: 1, col: 55
-                  EscapedChar(9999)
-                    UnescapedChar(9999)
-                      Letter(9999)
-                        LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 56
-                  TOKEN_3(9999): """, line: 1, col: 57
+                StringProperty(9999)
+                  String(9999)
+                    TOKEN_3(9999): """, line: 1, col: 54
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        Letter(9999)
+                          UppercaseLetter(9999)
+                            TOKEN_33(9999): "A", line: 1, col: 55
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        Letter(9999)
+                          LowercaseLetter(9999)
+                            TOKEN_76(9999): "l", line: 1, col: 56
+                    TOKEN_3(9999): """, line: 1, col: 57
         AND(9999)
           TOKEN_33(9999): "A", line: 1, col: 58
           TOKEN_46(9999): "N", line: 1, col: 59
@@ -173,20 +175,21 @@ Filter(9999)
                     TOKEN_46(9999): "N", line: 1, col: 78
                     TOKEN_36(9999): "D", line: 1, col: 79
                     TOKEN_51(9999): "S", line: 1, col: 80
-                  String(9999)
-                    TOKEN_3(9999): """, line: 1, col: 81
-                    EscapedChar(9999)
-                      UnescapedChar(9999)
-                        Letter(9999)
-                          UppercaseLetter(9999)
-                            TOKEN_33(9999): "A", line: 1, col: 82
-                    EscapedChar(9999)
-                      UnescapedChar(9999)
-                        Letter(9999)
-                          LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 83
-                    TOKEN_3(9999): """, line: 1, col: 84
-                    Spaces(9999)
-                      Space(9999)
-                        nl(9999)
-                          SPECIAL_1(9999): "(...)", line: 1, col: 85
+                  StringProperty(9999)
+                    String(9999)
+                      TOKEN_3(9999): """, line: 1, col: 81
+                      EscapedChar(9999)
+                        UnescapedChar(9999)
+                          Letter(9999)
+                            UppercaseLetter(9999)
+                              TOKEN_33(9999): "A", line: 1, col: 82
+                      EscapedChar(9999)
+                        UnescapedChar(9999)
+                          Letter(9999)
+                            LowercaseLetter(9999)
+                              TOKEN_76(9999): "l", line: 1, col: 83
+                      TOKEN_3(9999): """, line: 1, col: 84
+                      Spaces(9999)
+                        Space(9999)
+                          nl(9999)
+                            SPECIAL_1(9999): "(...)", line: 1, col: 85

--- a/tests/outputs/Filter_070.out
+++ b/tests/outputs/Filter_070.out
@@ -100,50 +100,51 @@ Filter(9999)
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 47
-              String(9999)
-                TOKEN_3(9999): """, line: 1, col: 48
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_36(9999): "D", line: 1, col: 49
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_73(9999): "i", line: 1, col: 50
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_74(9999): "j", line: 1, col: 51
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_75(9999): "k", line: 1, col: 52
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 53
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 54
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_82(9999): "r", line: 1, col: 55
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_65(9999): "a", line: 1, col: 56
-                TOKEN_3(9999): """, line: 1, col: 57
-                Spaces(9999)
-                  Space(9999)
-                    nl(9999)
-                      SPECIAL_1(9999): "(...)", line: 1, col: 58
+              StringProperty(9999)
+                String(9999)
+                  TOKEN_3(9999): """, line: 1, col: 48
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_36(9999): "D", line: 1, col: 49
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_73(9999): "i", line: 1, col: 50
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_74(9999): "j", line: 1, col: 51
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_75(9999): "k", line: 1, col: 52
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_83(9999): "s", line: 1, col: 53
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_84(9999): "t", line: 1, col: 54
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_82(9999): "r", line: 1, col: 55
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_65(9999): "a", line: 1, col: 56
+                  TOKEN_3(9999): """, line: 1, col: 57
+                  Spaces(9999)
+                    Space(9999)
+                      nl(9999)
+                        SPECIAL_1(9999): "(...)", line: 1, col: 58

--- a/tests/outputs/Filter_072.out
+++ b/tests/outputs/Filter_072.out
@@ -51,32 +51,33 @@ Filter(9999)
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 22
-              String(9999)
-                TOKEN_3(9999): """, line: 1, col: 23
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 24
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_18(9999): "2", line: 1, col: 25
-                EscapedChar(9999)
-                  UnescapedChar(9999)
+              StringProperty(9999)
+                String(9999)
+                  TOKEN_3(9999): """, line: 1, col: 23
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_40(9999): "H", line: 1, col: 24
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_18(9999): "2", line: 1, col: 25
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 26
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_47(9999): "O", line: 1, col: 27
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_18(9999): "2", line: 1, col: 28
+                  TOKEN_3(9999): """, line: 1, col: 29
+                  Spaces(9999)
                     Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 26
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 27
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_18(9999): "2", line: 1, col: 28
-                TOKEN_3(9999): """, line: 1, col: 29
-                Spaces(9999)
-                  Space(9999)
-                    nl(9999)
-                      SPECIAL_1(9999): "(...)", line: 1, col: 30
+                      nl(9999)
+                        SPECIAL_1(9999): "(...)", line: 1, col: 30

--- a/tests/outputs/Filter_072.out
+++ b/tests/outputs/Filter_072.out
@@ -1,0 +1,82 @@
+Parse tree from tests/cases/Filter_072.inp:
+Filter(9999)
+  Expression(9999)
+    ExpressionClause(9999)
+      ExpressionPhrase(9999)
+        Comparison(9999)
+          PropertyFirstComparison(9999)
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_67(9999): "c", line: 1, col: 1
+                LowercaseLetter(9999)
+                  TOKEN_72(9999): "h", line: 1, col: 2
+                LowercaseLetter(9999)
+                  TOKEN_69(9999): "e", line: 1, col: 3
+                LowercaseLetter(9999)
+                  TOKEN_77(9999): "m", line: 1, col: 4
+                LowercaseLetter(9999)
+                  TOKEN_73(9999): "i", line: 1, col: 5
+                LowercaseLetter(9999)
+                  TOKEN_67(9999): "c", line: 1, col: 6
+                LowercaseLetter(9999)
+                  TOKEN_65(9999): "a", line: 1, col: 7
+                LowercaseLetter(9999)
+                  TOKEN_76(9999): "l", line: 1, col: 8
+                LowercaseLetter(9999)
+                  TOKEN_63(9999): "_", line: 1, col: 9
+                LowercaseLetter(9999)
+                  TOKEN_70(9999): "f", line: 1, col: 10
+                LowercaseLetter(9999)
+                  TOKEN_79(9999): "o", line: 1, col: 11
+                LowercaseLetter(9999)
+                  TOKEN_82(9999): "r", line: 1, col: 12
+                LowercaseLetter(9999)
+                  TOKEN_77(9999): "m", line: 1, col: 13
+                LowercaseLetter(9999)
+                  TOKEN_85(9999): "u", line: 1, col: 14
+                LowercaseLetter(9999)
+                  TOKEN_76(9999): "l", line: 1, col: 15
+                LowercaseLetter(9999)
+                  TOKEN_65(9999): "a", line: 1, col: 16
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 17
+            FuzzyStringOpRhs(9999)
+              LIKE(9999)
+                TOKEN_44(9999): "L", line: 1, col: 18
+                TOKEN_41(9999): "I", line: 1, col: 19
+                TOKEN_43(9999): "K", line: 1, col: 20
+                TOKEN_37(9999): "E", line: 1, col: 21
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 22
+              String(9999)
+                TOKEN_3(9999): """, line: 1, col: 23
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Letter(9999)
+                      UppercaseLetter(9999)
+                        TOKEN_40(9999): "H", line: 1, col: 24
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_18(9999): "2", line: 1, col: 25
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 26
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Letter(9999)
+                      UppercaseLetter(9999)
+                        TOKEN_47(9999): "O", line: 1, col: 27
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_18(9999): "2", line: 1, col: 28
+                TOKEN_3(9999): """, line: 1, col: 29
+                Spaces(9999)
+                  Space(9999)
+                    nl(9999)
+                      SPECIAL_1(9999): "(...)", line: 1, col: 30

--- a/tests/outputs/Filter_073.out
+++ b/tests/outputs/Filter_073.out
@@ -58,49 +58,50 @@ Filter(9999)
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 26
-              String(9999)
-                TOKEN_3(9999): """, line: 1, col: 27
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_35(9999): "C", line: 1, col: 28
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_22(9999): "6", line: 1, col: 29
-                EscapedChar(9999)
-                  UnescapedChar(9999)
+              StringProperty(9999)
+                String(9999)
+                  TOKEN_3(9999): """, line: 1, col: 27
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_35(9999): "C", line: 1, col: 28
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_22(9999): "6", line: 1, col: 29
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 30
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_40(9999): "H", line: 1, col: 31
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_17(9999): "1", line: 1, col: 32
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_18(9999): "2", line: 1, col: 33
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 34
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_47(9999): "O", line: 1, col: 35
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_22(9999): "6", line: 1, col: 36
+                  TOKEN_3(9999): """, line: 1, col: 37
+                  Spaces(9999)
                     Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 30
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 31
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_17(9999): "1", line: 1, col: 32
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_18(9999): "2", line: 1, col: 33
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 34
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 35
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_22(9999): "6", line: 1, col: 36
-                TOKEN_3(9999): """, line: 1, col: 37
-                Spaces(9999)
-                  Space(9999)
-                    nl(9999)
-                      SPECIAL_1(9999): "(...)", line: 1, col: 38
+                      nl(9999)
+                        SPECIAL_1(9999): "(...)", line: 1, col: 38

--- a/tests/outputs/Filter_073.out
+++ b/tests/outputs/Filter_073.out
@@ -1,0 +1,106 @@
+Parse tree from tests/cases/Filter_073.inp:
+Filter(9999)
+  Expression(9999)
+    ExpressionClause(9999)
+      ExpressionPhrase(9999)
+        Comparison(9999)
+          PropertyFirstComparison(9999)
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_67(9999): "c", line: 1, col: 1
+                LowercaseLetter(9999)
+                  TOKEN_72(9999): "h", line: 1, col: 2
+                LowercaseLetter(9999)
+                  TOKEN_69(9999): "e", line: 1, col: 3
+                LowercaseLetter(9999)
+                  TOKEN_77(9999): "m", line: 1, col: 4
+                LowercaseLetter(9999)
+                  TOKEN_73(9999): "i", line: 1, col: 5
+                LowercaseLetter(9999)
+                  TOKEN_67(9999): "c", line: 1, col: 6
+                LowercaseLetter(9999)
+                  TOKEN_65(9999): "a", line: 1, col: 7
+                LowercaseLetter(9999)
+                  TOKEN_76(9999): "l", line: 1, col: 8
+                LowercaseLetter(9999)
+                  TOKEN_63(9999): "_", line: 1, col: 9
+                LowercaseLetter(9999)
+                  TOKEN_70(9999): "f", line: 1, col: 10
+                LowercaseLetter(9999)
+                  TOKEN_79(9999): "o", line: 1, col: 11
+                LowercaseLetter(9999)
+                  TOKEN_82(9999): "r", line: 1, col: 12
+                LowercaseLetter(9999)
+                  TOKEN_77(9999): "m", line: 1, col: 13
+                LowercaseLetter(9999)
+                  TOKEN_85(9999): "u", line: 1, col: 14
+                LowercaseLetter(9999)
+                  TOKEN_76(9999): "l", line: 1, col: 15
+                LowercaseLetter(9999)
+                  TOKEN_65(9999): "a", line: 1, col: 16
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 17
+            FuzzyStringOpRhs(9999)
+              NOT(9999)
+                TOKEN_46(9999): "N", line: 1, col: 18
+                TOKEN_47(9999): "O", line: 1, col: 19
+                TOKEN_52(9999): "T", line: 1, col: 20
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 21
+              LIKE(9999)
+                TOKEN_44(9999): "L", line: 1, col: 22
+                TOKEN_41(9999): "I", line: 1, col: 23
+                TOKEN_43(9999): "K", line: 1, col: 24
+                TOKEN_37(9999): "E", line: 1, col: 25
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 26
+              String(9999)
+                TOKEN_3(9999): """, line: 1, col: 27
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Letter(9999)
+                      UppercaseLetter(9999)
+                        TOKEN_35(9999): "C", line: 1, col: 28
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_22(9999): "6", line: 1, col: 29
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 30
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Letter(9999)
+                      UppercaseLetter(9999)
+                        TOKEN_40(9999): "H", line: 1, col: 31
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_17(9999): "1", line: 1, col: 32
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_18(9999): "2", line: 1, col: 33
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 34
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Letter(9999)
+                      UppercaseLetter(9999)
+                        TOKEN_47(9999): "O", line: 1, col: 35
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_22(9999): "6", line: 1, col: 36
+                TOKEN_3(9999): """, line: 1, col: 37
+                Spaces(9999)
+                  Space(9999)
+                    nl(9999)
+                      SPECIAL_1(9999): "(...)", line: 1, col: 38

--- a/tests/outputs/Filter_074.out
+++ b/tests/outputs/Filter_074.out
@@ -53,49 +53,50 @@ Filter(9999)
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 24
-              String(9999)
-                TOKEN_3(9999): """, line: 1, col: 25
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_35(9999): "C", line: 1, col: 26
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_22(9999): "6", line: 1, col: 27
-                EscapedChar(9999)
-                  UnescapedChar(9999)
+              StringProperty(9999)
+                String(9999)
+                  TOKEN_3(9999): """, line: 1, col: 25
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_35(9999): "C", line: 1, col: 26
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_22(9999): "6", line: 1, col: 27
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 28
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_40(9999): "H", line: 1, col: 29
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_17(9999): "1", line: 1, col: 30
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_18(9999): "2", line: 1, col: 31
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 32
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Letter(9999)
+                        UppercaseLetter(9999)
+                          TOKEN_47(9999): "O", line: 1, col: 33
+                  EscapedChar(9999)
+                    UnescapedChar(9999)
+                      Digit(9999)
+                        TOKEN_22(9999): "6", line: 1, col: 34
+                  TOKEN_3(9999): """, line: 1, col: 35
+                  Spaces(9999)
                     Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 28
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 29
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_17(9999): "1", line: 1, col: 30
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_18(9999): "2", line: 1, col: 31
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 32
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Letter(9999)
-                      UppercaseLetter(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 33
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_22(9999): "6", line: 1, col: 34
-                TOKEN_3(9999): """, line: 1, col: 35
-                Spaces(9999)
-                  Space(9999)
-                    nl(9999)
-                      SPECIAL_1(9999): "(...)", line: 1, col: 36
+                      nl(9999)
+                        SPECIAL_1(9999): "(...)", line: 1, col: 36

--- a/tests/outputs/Filter_074.out
+++ b/tests/outputs/Filter_074.out
@@ -1,0 +1,101 @@
+Parse tree from tests/cases/Filter_074.inp:
+Filter(9999)
+  Expression(9999)
+    ExpressionClause(9999)
+      ExpressionPhrase(9999)
+        Comparison(9999)
+          PropertyFirstComparison(9999)
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_67(9999): "c", line: 1, col: 1
+                LowercaseLetter(9999)
+                  TOKEN_72(9999): "h", line: 1, col: 2
+                LowercaseLetter(9999)
+                  TOKEN_69(9999): "e", line: 1, col: 3
+                LowercaseLetter(9999)
+                  TOKEN_77(9999): "m", line: 1, col: 4
+                LowercaseLetter(9999)
+                  TOKEN_73(9999): "i", line: 1, col: 5
+                LowercaseLetter(9999)
+                  TOKEN_67(9999): "c", line: 1, col: 6
+                LowercaseLetter(9999)
+                  TOKEN_65(9999): "a", line: 1, col: 7
+                LowercaseLetter(9999)
+                  TOKEN_76(9999): "l", line: 1, col: 8
+                LowercaseLetter(9999)
+                  TOKEN_63(9999): "_", line: 1, col: 9
+                LowercaseLetter(9999)
+                  TOKEN_70(9999): "f", line: 1, col: 10
+                LowercaseLetter(9999)
+                  TOKEN_79(9999): "o", line: 1, col: 11
+                LowercaseLetter(9999)
+                  TOKEN_82(9999): "r", line: 1, col: 12
+                LowercaseLetter(9999)
+                  TOKEN_77(9999): "m", line: 1, col: 13
+                LowercaseLetter(9999)
+                  TOKEN_85(9999): "u", line: 1, col: 14
+                LowercaseLetter(9999)
+                  TOKEN_76(9999): "l", line: 1, col: 15
+                LowercaseLetter(9999)
+                  TOKEN_65(9999): "a", line: 1, col: 16
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 17
+            FuzzyStringOpRhs(9999)
+              UNLIKE(9999)
+                TOKEN_53(9999): "U", line: 1, col: 18
+                TOKEN_46(9999): "N", line: 1, col: 19
+                TOKEN_44(9999): "L", line: 1, col: 20
+                TOKEN_41(9999): "I", line: 1, col: 21
+                TOKEN_43(9999): "K", line: 1, col: 22
+                TOKEN_37(9999): "E", line: 1, col: 23
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 24
+              String(9999)
+                TOKEN_3(9999): """, line: 1, col: 25
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Letter(9999)
+                      UppercaseLetter(9999)
+                        TOKEN_35(9999): "C", line: 1, col: 26
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_22(9999): "6", line: 1, col: 27
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 28
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Letter(9999)
+                      UppercaseLetter(9999)
+                        TOKEN_40(9999): "H", line: 1, col: 29
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_17(9999): "1", line: 1, col: 30
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_18(9999): "2", line: 1, col: 31
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 32
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Letter(9999)
+                      UppercaseLetter(9999)
+                        TOKEN_47(9999): "O", line: 1, col: 33
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_22(9999): "6", line: 1, col: 34
+                TOKEN_3(9999): """, line: 1, col: 35
+                Spaces(9999)
+                  Space(9999)
+                    nl(9999)
+                      SPECIAL_1(9999): "(...)", line: 1, col: 36

--- a/tests/outputs/Filter_075.out
+++ b/tests/outputs/Filter_075.out
@@ -1,0 +1,95 @@
+Parse tree from tests/cases/Filter_075.inp:
+Filter(9999)
+  Expression(9999)
+    ExpressionClause(9999)
+      ExpressionPhrase(9999)
+        Comparison(9999)
+          PropertyFirstComparison(9999)
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_67(9999): "c", line: 1, col: 1
+                LowercaseLetter(9999)
+                  TOKEN_72(9999): "h", line: 1, col: 2
+                LowercaseLetter(9999)
+                  TOKEN_69(9999): "e", line: 1, col: 3
+                LowercaseLetter(9999)
+                  TOKEN_77(9999): "m", line: 1, col: 4
+                LowercaseLetter(9999)
+                  TOKEN_73(9999): "i", line: 1, col: 5
+                LowercaseLetter(9999)
+                  TOKEN_67(9999): "c", line: 1, col: 6
+                LowercaseLetter(9999)
+                  TOKEN_65(9999): "a", line: 1, col: 7
+                LowercaseLetter(9999)
+                  TOKEN_76(9999): "l", line: 1, col: 8
+                LowercaseLetter(9999)
+                  TOKEN_63(9999): "_", line: 1, col: 9
+                LowercaseLetter(9999)
+                  TOKEN_70(9999): "f", line: 1, col: 10
+                LowercaseLetter(9999)
+                  TOKEN_79(9999): "o", line: 1, col: 11
+                LowercaseLetter(9999)
+                  TOKEN_82(9999): "r", line: 1, col: 12
+                LowercaseLetter(9999)
+                  TOKEN_77(9999): "m", line: 1, col: 13
+                LowercaseLetter(9999)
+                  TOKEN_85(9999): "u", line: 1, col: 14
+                LowercaseLetter(9999)
+                  TOKEN_76(9999): "l", line: 1, col: 15
+                LowercaseLetter(9999)
+                  TOKEN_65(9999): "a", line: 1, col: 16
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 17
+            FuzzyStringOpRhs(9999)
+              UNLIKE(9999)
+                TOKEN_53(9999): "U", line: 1, col: 18
+                TOKEN_46(9999): "N", line: 1, col: 19
+                TOKEN_44(9999): "L", line: 1, col: 20
+                TOKEN_41(9999): "I", line: 1, col: 21
+                TOKEN_43(9999): "K", line: 1, col: 22
+                TOKEN_37(9999): "E", line: 1, col: 23
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 24
+              StringProperty(9999)
+                Property(9999)
+                  Identifier(9999)
+                    LowercaseLetter(9999)
+                      TOKEN_65(9999): "a", line: 1, col: 25
+                    LowercaseLetter(9999)
+                      TOKEN_78(9999): "n", line: 1, col: 26
+                    LowercaseLetter(9999)
+                      TOKEN_79(9999): "o", line: 1, col: 27
+                    LowercaseLetter(9999)
+                      TOKEN_84(9999): "t", line: 1, col: 28
+                    LowercaseLetter(9999)
+                      TOKEN_72(9999): "h", line: 1, col: 29
+                    LowercaseLetter(9999)
+                      TOKEN_69(9999): "e", line: 1, col: 30
+                    LowercaseLetter(9999)
+                      TOKEN_82(9999): "r", line: 1, col: 31
+                    LowercaseLetter(9999)
+                      TOKEN_63(9999): "_", line: 1, col: 32
+                    LowercaseLetter(9999)
+                      TOKEN_70(9999): "f", line: 1, col: 33
+                    LowercaseLetter(9999)
+                      TOKEN_79(9999): "o", line: 1, col: 34
+                    LowercaseLetter(9999)
+                      TOKEN_82(9999): "r", line: 1, col: 35
+                    LowercaseLetter(9999)
+                      TOKEN_77(9999): "m", line: 1, col: 36
+                    LowercaseLetter(9999)
+                      TOKEN_85(9999): "u", line: 1, col: 37
+                    LowercaseLetter(9999)
+                      TOKEN_76(9999): "l", line: 1, col: 38
+                    LowercaseLetter(9999)
+                      TOKEN_65(9999): "a", line: 1, col: 39
+                    Spaces(9999)
+                      Space(9999)
+                        nl(9999)
+                          SPECIAL_1(9999): "(...)", line: 1, col: 40
+                      Space(9999)
+                        nl(9999)
+                          SPECIAL_1(9999): "(...)", line: 2, col: 1

--- a/tests/outputs/Filter_076.out
+++ b/tests/outputs/Filter_076.out
@@ -1,0 +1,41 @@
+Parse tree from tests/cases/Filter_076.inp:
+Filter(9999)
+  Expression(9999)
+    ExpressionClause(9999)
+      ExpressionPhrase(9999)
+        Comparison(9999)
+          ConstantFirstComparison(9999)
+            Constant(9999)
+              String(9999)
+                TOKEN_3(9999): """, line: 1, col: 1
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Letter(9999)
+                      UppercaseLetter(9999)
+                        TOKEN_35(9999): "C", line: 1, col: 2
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_18(9999): "2", line: 1, col: 3
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 4
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Letter(9999)
+                      UppercaseLetter(9999)
+                        TOKEN_40(9999): "H", line: 1, col: 5
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_18(9999): "2", line: 1, col: 6
+                TOKEN_3(9999): """, line: 1, col: 7
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 8
+Error: in tests/cases/Filter_076.inp: line 1:
+    unexpected token "L", expected one of "<", ">", "=", or "!"
+
+"C2 H2" LIKE formula
+        ^


### PR DESCRIPTION
Adding grammar rules to the Filter EBNF grammar to permit 'property CONTAINS another_property' constructs, which are described in the specification as optional features.