### PR TITLE
Dropping restrictions on the IDs

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -81,11 +81,9 @@ interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 * Property: anything that can be in the filtering of results.
 * Field: an entity that can be requested as partial output from the API.
 * ID: a unique identifier that specifies a specific resource in a database,
-  that does not necessarily need to be immutable. It MUST NOT be a reserved
-  word.
+  that does not necessarily need to be immutable.
 * Immutable ID: a unique identifier that specifies a specific resource in a
   database that MUST be immutable.
-* Reserved words: the list of reserved words in this standard is: info.
 * Property Types :
     * **string**, **integer**, **float**, **boolean**, **null value**: base data
       types as defined in more detail in [section '5.1. Lexical

--- a/optimade.md
+++ b/optimade.md
@@ -396,7 +396,6 @@ needs the following fields
 * **id**: a string which together with the type uniquely identifies the object, this can be the local database ID
 * **attributes**: a dictionary, containing key-value pairs representing the
   entries properties, and the following fields:
-    * **local\_id**: the entry's local database ID
     * **last\_modified**: an [ISO 8601](https://www.iso.org/standard/40874.html)
       representing the entry's last modification time
     * **immutable\_id**: an OPTIONAL field containing the entry's immutable ID
@@ -421,7 +420,6 @@ Example:
       "id": "example.db:structs:0001",
       "attributes": {
         "formula": "Es2 O3",
-        "local_id": "example.db:structs:0001",
         "url": "http://example.db/structs/0001",
         "immutable_id": "http://example.db/structs/0001@123",
         "last_modified": "2007-04-05T14:30Z"
@@ -432,7 +430,6 @@ Example:
       "type": "structure",
       "attributes": {
         "formula": "Es2"
-        "local_id": "example.db:structs:1234",
         "url": "http://example.db/structs/1234",
         "immutable_id": "http://example.db/structs/1234@123",
         "last_modified": "2007-04-07T12:02Z"

--- a/optimade.md
+++ b/optimade.md
@@ -450,9 +450,6 @@ that ID.
 
 If using the JSON API format, the ID component MUST be the content of the id field.
 
-Note that entries cannot have an ID of 'info', as this would collide with the
-'Info' endpoint (described in [section '4.4. Info endpoints'](#h.4.4)) for a given entry type.
-
 Examples:
 
 * http://example.com/optimade/v0.9/structures/exmpl:struct/3232823

--- a/optimade.md
+++ b/optimade.md
@@ -832,7 +832,6 @@ This section defines standard entry types and their properties.
 
 * Description: An entry's ID.
 * Requirements/Conventions:
-    * IDs MUST be URL-safe; in particular, they MUST NOT contain commas.
     * Reasonably short IDs are encouraged and SHOULD NOT be longer than 255 characters.
 * Examples:
     * db/1234567

--- a/optimade.md
+++ b/optimade.md
@@ -444,7 +444,7 @@ Example:
 
 ## <a name="h.4.2">4.2. Single entry endpoints</a>
 
-A client can request a specific entry by appending an URI-encoded ID component to the URL
+A client can request a specific entry by appending an URL-encoded ID component to the URL
 of an entry listing endpoint. This will return properties for the entry with
 that ID.
 

--- a/optimade.md
+++ b/optimade.md
@@ -444,7 +444,7 @@ Example:
 
 ## <a name="h.4.2">4.2. Single entry endpoints</a>
 
-A client can request a specific entry by appending an ID component to the URL
+A client can request a specific entry by appending an URI-encoded ID component to the URL
 of an entry listing endpoint. This will return properties for the entry with
 that ID.
 
@@ -452,8 +452,8 @@ If using the JSON API format, the ID component MUST be the content of the id fie
 
 Examples:
 
-* http://example.com/optimade/v0.9/structures/exmpl:struct/3232823
-* http://example.com/optimade/v0.9/calculations/exmpl:calc/232132
+* http://example.com/optimade/v0.9/structures/exmpl%3Astruct%2F3232823%0A
+* http://example.com/optimade/v0.9/calculations/exmpl%3Acalc%2F232132%0A
 
 ### <a name="h.4.2.1">4.2.1. URL Query Parameters</a>
 


### PR DESCRIPTION
This PR is a follow-up on #158. Changes done (from TODO list by @rartino):

* Removed the requirement on ID to be URL-safe so that any character string is a valid ID.
* Pointed out that in URLs of the kind, e.g., `<entry type>/<ID>` the `<ID>` should be URL-encoded.
* Remove the `local_id` property (the main ID now can be the local ID of your database).