### PR TITLE
'property ID' -> 'property name'.

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -914,7 +914,7 @@ The response for these endpoints MUST include the following information in the `
 
 * **description**: Description of the entry.
 * **properties**: A dictionary describing queryable properties for this entry type,
-where each key is a property ID. Each value is a dictionary, with the REQUIRED key `description`
+where each key is a property name. Each value is a dictionary, with the REQUIRED key `description`
 and OPTIONAL key `unit`.
 * **formats**: List of output formats available for this type of entry.
 * **output\_fields\_by\_format**: Dictionary of available output fields for this entry type,


### PR DESCRIPTION
While reading the specification I've stumbled upon wording "property ID" where "property name" was had in mind, IMO. This "property ID" wording sounds confusing, thus I propose changing to something we have described in the Term Definitions.