### PR TITLE
Fixing description that looks like a grammar (or logic) mistake.

### DIFF
--- a/optimade.md
+++ b/optimade.md
@@ -921,7 +921,7 @@ Example:
 ```jsonc
 {
   "data": {
-    "description": "a structure",
+    "description": "a structures entry",
     "properties": {
       "nelements": {
         "description": "Number of elements",

--- a/optimade.md
+++ b/optimade.md
@@ -921,7 +921,7 @@ Example:
 ```jsonc
 {
   "data": {
-    "description": "a structures",
+    "description": "a structure",
     "properties": {
       "nelements": {
         "description": "Number of elements",


### PR DESCRIPTION
Stumbled upon this while reading the specification. This must be a leftover of singular -> plural transition (`structure` -> `structures`), and I argue that this `a structures` in not appropriate here.