### PR TITLE
Add link to raw develop-branch providers.json

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -2067,7 +2067,7 @@ Appendices
 Database-Provider-Specific Namespace Prefixes
 ---------------------------------------------
 
-This standard refers to database-provider-specific prefixes. These are assigned and included in this standard in the file `providers.json <https://raw.githbusercontent.com/Materials-Consortia/OPTiMaDe/develop/providers.json>`__
+This standard refers to database-provider-specific prefixes. These are assigned and included in this standard in the file `providers.json <https://github.com/Materials-Consortia/OPTiMaDe/develop/providers.json>`__
 
 API implementations SHOULD NOT make up and use new prefixes not included in this standard, but SHOULD rather work to get such prefixes included in a future revision of this API specification.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2067,7 +2067,7 @@ Appendices
 Database-Provider-Specific Namespace Prefixes
 ---------------------------------------------
 
-This standard refers to database-provider-specific prefixes. These are assigned and included in this standard in the file ``providers.json``.
+This standard refers to database-provider-specific prefixes. These are assigned and included in this standard in the file `providers.json <https://raw.githbusercontent.com/Materials-Consortia/OPTiMaDe/develop/providers.json>`__
 
 API implementations SHOULD NOT make up and use new prefixes not included in this standard, but SHOULD rather work to get such prefixes included in a future revision of this API specification.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2067,7 +2067,7 @@ Appendices
 Database-Provider-Specific Namespace Prefixes
 ---------------------------------------------
 
-This standard refers to database-provider-specific prefixes. These are assigned and included in this standard in the file `providers.json <https://github.com/Materials-Consortia/OPTiMaDe/develop/providers.json>`__
+This standard refers to database-provider-specific prefixes. These are assigned and included in this standard in the file `providers.json <https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/providers.json>`__
 
 API implementations SHOULD NOT make up and use new prefixes not included in this standard, but SHOULD rather work to get such prefixes included in a future revision of this API specification.
 


### PR DESCRIPTION
Note: this link should refer to the `v0.10.0` branch raw version rather than the `develop` version of the package.json file for that release, the `master` version in the `master` branch, etc.
