### PR TITLE
Remove uniqueness constraint for species_at_sites

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -1715,7 +1715,6 @@ species\_at\_sites
   - **Response**: REQUIRED in the response unless explicitly excluded.
   - **Query**: Support for queries on this property is OPTIONAL. If supported, filters MAY support only a subset of comparison operators.
   - MUST have length equal to the number of sites in the structure (first dimension of the list property `cartesian_site_positions`_).
-  - Each species MUST have a unique name.
   - Each species name mentioned in the :property:`species_at_sites` list MUST be described in the list property `species`_ (i.e. for each value in the :property:`species_at_sites` list there MUST exist exactly one dictionary in the :property:`species` list with the :property:`name` attribute equal to the corresponding :property:`species_at_sites` value).
   - Each site MUST be associated only to a single species.
     **Note**: However, species can represent mixtures of atoms, and multiple species MAY be defined for the same chemical element.
@@ -1724,6 +1723,7 @@ species\_at\_sites
 - **Examples**:
   
   - :val:`["Ti","O2"]` indicates that the first site is hosting a species labeled :val:`"Ti"` and the second a species labeled :val:`"O2"`.
+  - :val:`["Ac", "Ac", "Ag", "Ir"]` indicating the first two sites contains the :val:`"Ac"` species, while the third and fourth sites contain the :val:`"Ag"` and :val:`"Ir"` species, respectively.
 
 species
 ~~~~~~~


### PR DESCRIPTION
Fixes #188 

Choosing solution number 1 from issue #188.

By removing the requirement on `species_at_sites` that:

- Each species MUST have a unique name.

The bloating of `species` can be stopped.
I've also added an extra example to `species_at_sites`.