### PR TITLE
Small fixes and typos in related to filter's grammar

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -2104,7 +2104,7 @@ The Filter Language EBNF Grammar
     ValueList = [ Operator ], Value, { Comma, [ Operator ], Value } ;
     (* Support for Operator in ValueList is OPTIONAL *)
 
-    ValueZip = [ Operator ], Value, Colon, [ Operator ], Value, {Colon, [ Operator ], Value} ;
+    ValueZip = [ Operator ], Value, Colon, [ Operator ], Value, {Colon, [ Operator ], Value } ;
     (* Support for Operator in ValueZip is OPTIONAL *)
 
     ValueZipList = ValueZip, { Comma, ValueZip } ;
@@ -2115,7 +2115,7 @@ The Filter Language EBNF Grammar
 
     ExpressionClause = ExpressionPhrase, [ AND, ExpressionClause ] ;
 
-    ExpressionPhrase = [ NOT ], ( Comparison | LengthComparison | OpeningBrace, Expression, ClosingBrace ) ;
+    ExpressionPhrase = [ NOT ], ( Comparison | PredicateComparison | OpeningBrace, Expression, ClosingBrace ) ;
 
     Comparison = ConstantFirstComparison
                | PropertyFirstComparison ;
@@ -2147,9 +2147,9 @@ The Filter Language EBNF Grammar
 
     SetZipOpRhs = PropertyZipAddon, HAS, ( ValueZip | ONLY, ValueZipList | ALL, ValueZipList | ANY, ValueZipList ) ;
 
-    LengthComparison = LENGTH, Property, Operator, Value ;
+    PredicateComparison = LENGTH, Property, Operator, Value ;
 
-    PropertyZipAddon = Colon, Property, {Colon, Property} ;
+    PropertyZipAddon = Colon, Property, { Colon, Property } ;
 
     (* Property *)
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2121,12 +2121,11 @@ The Filter Language EBNF Grammar
                | PropertyFirstComparison ;
     (* Note: support for ConstantFirstComparison is OPTIONAL *)
 
-    PropertyFirstComparison = Property, 
-                    ( ValueOpRhs
-                    | KnownOpRhs
-                    | FuzzyStringOpRhs
-                    | SetOpRhs
-                    | SetZipOpRhs );
+    PropertyFirstComparison = Property, ( ValueOpRhs
+                                        | KnownOpRhs
+                                        | FuzzyStringOpRhs
+                                        | SetOpRhs
+                                        | SetZipOpRhs ) ;
     (* Note: support for SetZipOpRhs in Comparison is OPTIONAL *)
 
     ConstantFirstComparison = Constant, ValueOpRhs ;

--- a/optimade.rst
+++ b/optimade.rst
@@ -2130,6 +2130,8 @@ The Filter Language EBNF Grammar
 
     ConstantFirstComparison = Constant, ValueOpRhs ;
 
+    PredicateComparison = LengthComparison ;
+
     ValueOpRhs = Operator, Value ;
 
     KnownOpRhs = IS, ( KNOWN | UNKNOWN ) ; 
@@ -2147,7 +2149,7 @@ The Filter Language EBNF Grammar
 
     SetZipOpRhs = PropertyZipAddon, HAS, ( ValueZip | ONLY, ValueZipList | ALL, ValueZipList | ANY, ValueZipList ) ;
 
-    PredicateComparison = LENGTH, Property, Operator, Value ;
+    LengthComparison = LENGTH, Property, Operator, Value ;
 
     PropertyZipAddon = Colon, Property, { Colon, Property } ;
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2171,24 +2171,24 @@ The Filter Language EBNF Grammar
 
     (* Boolean relations: *)
 
-    AND = 'A', 'N', 'D', [Spaces] ;
-    NOT = 'N', 'O', 'T', [Spaces] ;
-    OR = 'O', 'R', [Spaces] ;
+    AND = 'AND', [Spaces] ;
+    NOT = 'NOT', [Spaces] ;
+    OR = 'OR', [Spaces] ;
 
-    IS = 'I', 'S', [Spaces] ;
-    KNOWN = 'K', 'N', 'O', 'W', 'N', [Spaces] ;
-    UNKNOWN = 'U', 'N', 'K', 'N', 'O', 'W', 'N', [Spaces] ;
+    IS = 'IS', [Spaces] ;
+    KNOWN = 'KNOWN', [Spaces] ;
+    UNKNOWN = 'UNKNOWN', [Spaces] ;
 
-    CONTAINS = 'C', 'O', 'N', 'T', 'A', 'I', 'N', 'S', [Spaces] ;
-    STARTS = 'S', 'T', 'A', 'R', 'T', 'S', [Spaces] ;
-    ENDS = 'E', 'N', 'D', 'S', [Spaces] ;
-    WITH = 'W', 'I', 'T', 'H', [Spaces] ;
+    CONTAINS = 'CONTAINS', [Spaces] ;
+    STARTS = 'STARTS', [Spaces] ;
+    ENDS = 'ENDS', [Spaces] ;
+    WITH = 'WITH', [Spaces] ;
 
-    LENGTH = 'L', 'E', 'N', 'G', 'T', 'H', [Spaces] ;
-    HAS = 'H', 'A', 'S', [Spaces] ;
-    ALL = 'A', 'L', 'L', [Spaces] ;
-    ONLY = 'O', 'N', 'L', 'Y', [Spaces] ;
-    ANY = 'A', 'N', 'Y', [Spaces] ;
+    LENGTH = 'LENGTH', [Spaces] ;
+    HAS = 'HAS', [Spaces] ;
+    ALL = 'ALL', [Spaces] ;
+    ONLY = 'ONLY', [Spaces] ;
+    ANY = 'ANY', [Spaces] ;
 
     (* OperatorComparison operator tokens: *)
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1094,27 +1094,27 @@ The following tokens are used in the filter query component:
   This definition is similar to one used in most widespread programming languages, except that OPTiMaDe limits allowed letter set to lowercase letters only.
   This allows to tell OPTiMaDe identifiers and operator keywords apart unambiguously without consulting a reserved word table and to encode this distinction concisely in the EBNF Filter Language grammar.
 
-Examples of valid property names:
+  Examples of valid property names:
+  
+  - :property:`band_gap`
+  - :property:`cell_length_a`
+  - :property:`cell_volume`
+  
+  Examples of incorrect property names:
+  
+  - :property-fail:`0_kvak` (starts with a number);
+  - :property-fail:`"foo bar"` (contains space; contains quotes)
+  - :property-fail:`BadLuck` (contains upper-case letters)
+  
+  Identifiers that start with an underscore are specific to a database provider, and MUST be on the format of a database-provider-specific prefix as defined in appendix `Database-Provider-Specific Namespace Prefixes`_.
 
-- :property:`band_gap`
-- :property:`cell_length_a`
-- :property:`cell_volume`
+  Examples:
 
-Examples of incorrect property names:
-
-- :property-fail:`0_kvak` (starts with a number);
-- :property-fail:`"foo bar"` (contains space; contains quotes)
-- :property-fail:`BadLuck` (contains upper-case letters)
-
-Identifiers that start with an underscore are specific to a database provider, and MUST be on the format of a database-provider-specific prefix as defined in appendix `Database-Provider-Specific Namespace Prefixes`_.
-
-Examples::
-
-    * :property:`_exmpl_formula_sum` (a property specific to that database)
-    * :property:`_exmpl_band_gap`
-    * :property:`_exmpl_supercell`
-    * :property:`_exmpl_trajectory`
-    * :property:`_exmpl_workflow_id`  
+  - :property:`_exmpl_formula_sum` (a property specific to that database)
+  - :property:`_exmpl_band_gap`
+  - :property:`_exmpl_supercell`
+  - :property:`_exmpl_trajectory`
+  - :property:`_exmpl_workflow_id`  
 
 - **Nested property names** A nested property name is composed of at least two identifiers separated by periods (``.``).
 
@@ -1235,7 +1235,7 @@ The following constructs MUST be supported:
 - :filter:`list HAS value`: matches if at least one element in :filter-fragment:`list` is equal to filter-fragment:`value`. (If :filter-fragment:`list` has no duplicate elements, this implements the set operator IN.)
 - :filter:`list HAS ALL values`: matches if, for each :filter-fragment:`value`, there is at least one element in :filter-fragment:`list` equal to that value. (If both :filter-fragment:`list` and :filter-fragment:`values` do not contain duplicate values, this implements the set operator >=.)
 - :filter:`list HAS ANY values`: matches if at least one element in :filter-fragment:`list` is equal to at least one :filter-fragment:`value`. (This is equivalent to a number of HAS statements separated by OR.)
-- :filter:`LENGTH list <operator> value``: applies the numeric comparison :filter-fragment:`<operator>` for the number of items in the list property.
+- :filter:`LENGTH list <operator> value`: applies the numeric comparison :filter-fragment:`<operator>` for the number of items in the list property.
 
 The following construct MAY be supported:
 
@@ -1308,7 +1308,7 @@ This means that the structures entry has a relationship with the calculations en
     For example, to find all structures with bibliographic references where one of the authors has the last name "Schmit" is performed by the following two steps:
 
     - Query the :endpoint:`references` endpoint with a filter :filter:`authors.lastname HAS "Schmit"` and store the :filter-fragment:`id` values of the returned entries.
-    -  Query the :endpoint:`structures` endpoint with a filter :filter-fragment:`references.id HAS ANY <list-of-IDs>`, where :filter-fragment:`<list-of-IDs>` are the IDs retrieved from the first query separated by commas.
+    - Query the :endpoint:`structures` endpoint with a filter :filter-fragment:`references.id HAS ANY <list-of-IDs>`, where :filter-fragment:`<list-of-IDs>` are the IDs retrieved from the first query separated by commas.
 
     (Note: the type of query discussed here corresponds to a "join"-type operation in a relational data model.)
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2115,7 +2115,7 @@ The Filter Language EBNF Grammar
 
     ExpressionClause = ExpressionPhrase, [ AND, ExpressionClause ] ;
 
-    ExpressionPhrase = [ NOT ], ( Comparison | PredicateComparison | OpeningBrace, Expression, ClosingBrace );
+    ExpressionPhrase = [ NOT ], ( Comparison | LengthComparison | OpeningBrace, Expression, ClosingBrace );
 
     Comparison = ConstantFirstComparison |
                  PropertyFirstComparison ;
@@ -2130,8 +2130,6 @@ The Filter Language EBNF Grammar
     (* Note: support for SetZipOpRhs in Comparison is OPTIONAL *)
 
     ConstantFirstComparison = Constant, ValueOpRhs ;
-                    
-    PredicateComparison = LengthComparison ;
 
     ValueOpRhs = Operator, Value ;
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2115,18 +2115,18 @@ The Filter Language EBNF Grammar
 
     ExpressionClause = ExpressionPhrase, [ AND, ExpressionClause ] ;
 
-    ExpressionPhrase = [ NOT ], ( Comparison | LengthComparison | OpeningBrace, Expression, ClosingBrace );
+    ExpressionPhrase = [ NOT ], ( Comparison | LengthComparison | OpeningBrace, Expression, ClosingBrace ) ;
 
-    Comparison = ConstantFirstComparison |
-                 PropertyFirstComparison ;
+    Comparison = ConstantFirstComparison
+               | PropertyFirstComparison ;
     (* Note: support for ConstantFirstComparison is OPTIONAL *)
 
-    PropertyFirstComparison = Property, ( 
-                    ValueOpRhs |
-                    KnownOpRhs |
-                    FuzzyStringOpRhs |
-                    SetOpRhs | 
-                    SetZipOpRhs );
+    PropertyFirstComparison = Property, 
+                    ( ValueOpRhs
+                    | KnownOpRhs
+                    | FuzzyStringOpRhs
+                    | SetOpRhs
+                    | SetZipOpRhs );
     (* Note: support for SetZipOpRhs in Comparison is OPTIONAL *)
 
     ConstantFirstComparison = Constant, ValueOpRhs ;
@@ -2138,9 +2138,9 @@ The Filter Language EBNF Grammar
     StringProperty = String | Property ;
     (* Support for Property tokens in StringProperty is optional *)
 
-    FuzzyStringOpRhs = CONTAINS, StringProperty |
-                   STARTS, [ WITH ], StringProperty |
-                   ENDS, [ WITH ], StringProperty ;
+    FuzzyStringOpRhs = CONTAINS, StringProperty
+                     | STARTS, [ WITH ], StringProperty
+                     | ENDS, [ WITH ], StringProperty ;
 
     SetOpRhs = HAS, ( [ Operator ], Value | ALL, ValueList | ANY, ValueList | ONLY, ValueList ) ;
     (* Note: support for ONLY in SetOpRhs is OPTIONAL *)
@@ -2188,9 +2188,9 @@ The Filter Language EBNF Grammar
     ONLY = 'ONLY', [Spaces] ;
     ANY = 'ANY', [Spaces] ;
 
-    (* OperatorComparison operator tokens: *)
+    (* Comparison operator tokens: *)
 
-    Operator = ( '<', [ '=' ] | '>', [ '=' ] | '=' | '!', '=' ), [Spaces] ;
+    Operator = ( '<', [ '=' ] | '>', [ '=' ] | [ '!' ], '=' ), [Spaces] ;
 
     (* Property syntax *)
 
@@ -2198,17 +2198,13 @@ The Filter Language EBNF Grammar
 
     Letter = UppercaseLetter | LowercaseLetter ;
 
-    UppercaseLetter =
-        'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' |
-        'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' |
-        'Y' | 'Z'
-    ;
+    UppercaseLetter = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' 
+                    | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' 
+                    | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z' ;
 
-    LowercaseLetter =
-        'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 
-        'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' |
-        'y' | 'z' | '_'
-    ;
+    LowercaseLetter = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' 
+                    | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' 
+                    | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z' | '_' ;
 
     (* Strings: *)
 
@@ -2218,11 +2214,9 @@ The Filter Language EBNF Grammar
 
     UnescapedChar = Letter | Digit | Space | Punctuator | UnicodeHighChar ;
 
-    Punctuator =
-        '!' | '#' | '$' | '%' | '&' | "'" | '(' | ')' | '*' | '+' | ',' |
-        '-' | '.' | '/' | ':' | ';' | '<' | '=' | '>' | '?' | '@' | '[' |
-        ']' | '^' | '`' | '{' | '|' | '}' | '~'
-    ;
+    Punctuator = '!' | '#' | '$' | '%' | '&' | "'" | '(' | ')' | '*' | '+' 
+               | ',' | '-' | '.' | '/' | ':' | ';' | '<' | '=' | '>' | '?' 
+               | '@' | '[' | ']' | '^' | '`' | '{' | '|' | '}' | '~' ;
 
     (* BEGIN EBNF GRAMMAR Number *)
     (* Number token syntax: *)

--- a/tests/outputs/Filter_001.out
+++ b/tests/outputs/Filter_001.out
@@ -8,7 +8,7 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 1
+                  TOKEN_80(9999): "a", line: 1, col: 1
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 2
@@ -22,14 +22,12 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_66(9999): "b", line: 1, col: 5
+                      TOKEN_81(9999): "b", line: 1, col: 5
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 6
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 7
-        TOKEN_46(9999): "N", line: 1, col: 8
-        TOKEN_36(9999): "D", line: 1, col: 9
+        TOKEN_35(9999): "AND", line: 1, col: 7
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 10
@@ -45,7 +43,7 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_65(9999): "a", line: 1, col: 12
+                          TOKEN_80(9999): "a", line: 1, col: 12
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 13
@@ -64,8 +62,7 @@ Filter(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 17
             OR(9999)
-              TOKEN_47(9999): "O", line: 1, col: 18
-              TOKEN_50(9999): "R", line: 1, col: 19
+              TOKEN_59(9999): "OR", line: 1, col: 18
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 20
@@ -77,7 +74,7 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_66(9999): "b", line: 1, col: 21
+                            TOKEN_81(9999): "b", line: 1, col: 21
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 22

--- a/tests/outputs/Filter_002.out
+++ b/tests/outputs/Filter_002.out
@@ -9,9 +9,7 @@ Filter(9999)
           ExpressionClause(9999)
             ExpressionPhrase(9999)
               NOT(9999)
-                TOKEN_46(9999): "N", line: 1, col: 2
-                TOKEN_47(9999): "O", line: 1, col: 3
-                TOKEN_52(9999): "T", line: 1, col: 4
+                TOKEN_56(9999): "NOT", line: 1, col: 2
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 5
@@ -20,7 +18,7 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_65(9999): "a", line: 1, col: 6
+                        TOKEN_80(9999): "a", line: 1, col: 6
                   ValueOpRhs(9999)
                     Operator(9999)
                       TOKEN_30(9999): ">", line: 1, col: 7
@@ -28,14 +26,12 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_66(9999): "b", line: 1, col: 8
+                            TOKEN_81(9999): "b", line: 1, col: 8
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 9
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 10
-              TOKEN_46(9999): "N", line: 1, col: 11
-              TOKEN_36(9999): "D", line: 1, col: 12
+              TOKEN_35(9999): "AND", line: 1, col: 10
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 13
@@ -46,7 +42,7 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 14
+                          TOKEN_103(9999): "x", line: 1, col: 14
                     ValueOpRhs(9999)
                       Operator(9999)
                         TOKEN_30(9999): ">", line: 1, col: 15

--- a/tests/outputs/Filter_003.out
+++ b/tests/outputs/Filter_003.out
@@ -4,9 +4,7 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         NOT(9999)
-          TOKEN_46(9999): "N", line: 1, col: 1
-          TOKEN_47(9999): "O", line: 1, col: 2
-          TOKEN_52(9999): "T", line: 1, col: 3
+          TOKEN_56(9999): "NOT", line: 1, col: 1
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 4
@@ -20,7 +18,7 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_65(9999): "a", line: 1, col: 6
+                        TOKEN_80(9999): "a", line: 1, col: 6
                   ValueOpRhs(9999)
                     Operator(9999)
                       TOKEN_30(9999): ">", line: 1, col: 7
@@ -28,16 +26,14 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_66(9999): "b", line: 1, col: 8
+                            TOKEN_81(9999): "b", line: 1, col: 8
         ClosingBrace(9999)
           TOKEN_9(9999): ")", line: 1, col: 9
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 10
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 11
-        TOKEN_46(9999): "N", line: 1, col: 12
-        TOKEN_36(9999): "D", line: 1, col: 13
+        TOKEN_35(9999): "AND", line: 1, col: 11
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 14
@@ -48,7 +44,7 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_88(9999): "x", line: 1, col: 15
+                    TOKEN_103(9999): "x", line: 1, col: 15
               ValueOpRhs(9999)
                 Operator(9999)
                   TOKEN_30(9999): ">", line: 1, col: 16

--- a/tests/outputs/Filter_004.out
+++ b/tests/outputs/Filter_004.out
@@ -8,11 +8,11 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 1
+                  TOKEN_80(9999): "a", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 2
+                  TOKEN_80(9999): "a", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 3
+                  TOKEN_103(9999): "x", line: 1, col: 3
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 4
@@ -32,7 +32,7 @@ Filter(9999)
                     Digit(9999)
                       TOKEN_17(9999): "1", line: 1, col: 10
                   Exponent(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 11
+                    TOKEN_84(9999): "e", line: 1, col: 11
                     Digits(9999)
                       Digit(9999)
                         TOKEN_24(9999): "8", line: 1, col: 12
@@ -40,8 +40,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 13
     OR(9999)
-      TOKEN_47(9999): "O", line: 1, col: 14
-      TOKEN_50(9999): "R", line: 1, col: 15
+      TOKEN_59(9999): "OR", line: 1, col: 14
       Spaces(9999)
         Space(9999)
           TOKEN_1(9999): " ", line: 1, col: 16
@@ -53,7 +52,7 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 17
+                    TOKEN_82(9999): "c", line: 1, col: 17
                   Digit(9999)
                     TOKEN_18(9999): "2", line: 1, col: 18
                   Digit(9999)
@@ -79,18 +78,14 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 26
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 27
-          TOKEN_46(9999): "N", line: 1, col: 28
-          TOKEN_36(9999): "D", line: 1, col: 29
+          TOKEN_35(9999): "AND", line: 1, col: 27
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 30
         ExpressionClause(9999)
           ExpressionPhrase(9999)
             NOT(9999)
-              TOKEN_46(9999): "N", line: 1, col: 31
-              TOKEN_47(9999): "O", line: 1, col: 32
-              TOKEN_52(9999): "T", line: 1, col: 33
+              TOKEN_56(9999): "NOT", line: 1, col: 31
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 34
@@ -107,7 +102,7 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_88(9999): "x", line: 1, col: 37
+                            TOKEN_103(9999): "x", line: 1, col: 37
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 38
@@ -125,22 +120,22 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_51(9999): "S", line: 1, col: 43
+                                    TOKEN_63(9999): "S", line: 1, col: 43
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_79(9999): "o", line: 1, col: 44
+                                    TOKEN_94(9999): "o", line: 1, col: 44
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_77(9999): "m", line: 1, col: 45
+                                    TOKEN_92(9999): "m", line: 1, col: 45
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 46
+                                    TOKEN_84(9999): "e", line: 1, col: 46
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Space(9999)
@@ -149,39 +144,38 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_83(9999): "s", line: 1, col: 48
+                                    TOKEN_98(9999): "s", line: 1, col: 48
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_84(9999): "t", line: 1, col: 49
+                                    TOKEN_99(9999): "t", line: 1, col: 49
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_82(9999): "r", line: 1, col: 50
+                                    TOKEN_97(9999): "r", line: 1, col: 50
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_73(9999): "i", line: 1, col: 51
+                                    TOKEN_88(9999): "i", line: 1, col: 51
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_78(9999): "n", line: 1, col: 52
+                                    TOKEN_93(9999): "n", line: 1, col: 52
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_71(9999): "g", line: 1, col: 53
+                                    TOKEN_86(9999): "g", line: 1, col: 53
                             TOKEN_3(9999): """, line: 1, col: 54
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 55
               OR(9999)
-                TOKEN_47(9999): "O", line: 1, col: 56
-                TOKEN_50(9999): "R", line: 1, col: 57
+                TOKEN_59(9999): "OR", line: 1, col: 56
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 58
@@ -189,9 +183,7 @@ Filter(9999)
                 ExpressionClause(9999)
                   ExpressionPhrase(9999)
                     NOT(9999)
-                      TOKEN_46(9999): "N", line: 1, col: 59
-                      TOKEN_47(9999): "O", line: 1, col: 60
-                      TOKEN_52(9999): "T", line: 1, col: 61
+                      TOKEN_56(9999): "NOT", line: 1, col: 59
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 62
@@ -200,7 +192,7 @@ Filter(9999)
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_65(9999): "a", line: 1, col: 63
+                              TOKEN_80(9999): "a", line: 1, col: 63
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 64
@@ -214,7 +206,7 @@ Filter(9999)
                             Property(9999)
                               Identifier(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_66(9999): "b", line: 1, col: 67
+                                  TOKEN_81(9999): "b", line: 1, col: 67
             ClosingBrace(9999)
               TOKEN_9(9999): ")", line: 1, col: 68
               Spaces(9999)

--- a/tests/outputs/Filter_005.out
+++ b/tests/outputs/Filter_005.out
@@ -8,7 +8,7 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 1
+                  TOKEN_80(9999): "a", line: 1, col: 1
             ValueOpRhs(9999)
               Operator(9999)
                 TOKEN_29(9999): "=", line: 1, col: 2

--- a/tests/outputs/Filter_006.out
+++ b/tests/outputs/Filter_006.out
@@ -8,7 +8,7 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_66(9999): "b", line: 1, col: 1
+                  TOKEN_81(9999): "b", line: 1, col: 1
             ValueOpRhs(9999)
               Operator(9999)
                 TOKEN_29(9999): "=", line: 1, col: 2
@@ -19,25 +19,23 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_75(9999): "k", line: 1, col: 4
+                          TOKEN_90(9999): "k", line: 1, col: 4
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_86(9999): "v", line: 1, col: 5
+                          TOKEN_101(9999): "v", line: 1, col: 5
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_65(9999): "a", line: 1, col: 6
+                          TOKEN_80(9999): "a", line: 1, col: 6
                   TOKEN_3(9999): """, line: 1, col: 7
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 8
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 9
-        TOKEN_46(9999): "N", line: 1, col: 10
-        TOKEN_36(9999): "D", line: 1, col: 11
+        TOKEN_35(9999): "AND", line: 1, col: 9
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 12
@@ -62,13 +60,12 @@ Filter(9999)
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_83(9999): "s", line: 1, col: 16
+                              TOKEN_98(9999): "s", line: 1, col: 16
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 17
             OR(9999)
-              TOKEN_47(9999): "O", line: 1, col: 18
-              TOKEN_50(9999): "R", line: 1, col: 19
+              TOKEN_59(9999): "OR", line: 1, col: 18
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 20
@@ -76,9 +73,7 @@ Filter(9999)
               ExpressionClause(9999)
                 ExpressionPhrase(9999)
                   NOT(9999)
-                    TOKEN_46(9999): "N", line: 1, col: 21
-                    TOKEN_47(9999): "O", line: 1, col: 22
-                    TOKEN_52(9999): "T", line: 1, col: 23
+                    TOKEN_56(9999): "NOT", line: 1, col: 21
                   OpeningBrace(9999)
                     TOKEN_8(9999): "(", line: 1, col: 24
                     Spaces(9999)
@@ -92,7 +87,7 @@ Filter(9999)
                             Property(9999)
                               Identifier(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_88(9999): "x", line: 1, col: 26
+                                  TOKEN_103(9999): "x", line: 1, col: 26
                             ValueOpRhs(9999)
                               Operator(9999)
                                 TOKEN_2(9999): "!", line: 1, col: 27
@@ -101,14 +96,12 @@ Filter(9999)
                                 Property(9999)
                                   Identifier(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_89(9999): "y", line: 1, col: 29
+                                      TOKEN_104(9999): "y", line: 1, col: 29
                                     Spaces(9999)
                                       Space(9999)
                                         TOKEN_1(9999): " ", line: 1, col: 30
                       AND(9999)
-                        TOKEN_33(9999): "A", line: 1, col: 31
-                        TOKEN_46(9999): "N", line: 1, col: 32
-                        TOKEN_36(9999): "D", line: 1, col: 33
+                        TOKEN_35(9999): "AND", line: 1, col: 31
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 34
@@ -119,7 +112,7 @@ Filter(9999)
                               Property(9999)
                                 Identifier(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_90(9999): "z", line: 1, col: 35
+                                    TOKEN_105(9999): "z", line: 1, col: 35
                               ValueOpRhs(9999)
                                 Operator(9999)
                                   TOKEN_30(9999): ">", line: 1, col: 36

--- a/tests/outputs/Filter_007.out
+++ b/tests/outputs/Filter_007.out
@@ -78,19 +78,21 @@ Filter(9999)
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "?", line: 1, col: 26
+                          SPECIAL_5(9999): "ą", line: 1, col: 26
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "?", line: 1, col: 27
+                          SPECIAL_5(9999): "ž", line: 1, col: 27
                     EscapedChar(9999)
                       UnescapedChar(9999)
-                        UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "?", line: 1, col: 28
+                        Letter(9999)
+                          LowercaseLetter(9999)
+                            TOKEN_88(9999): "i", line: 1, col: 28
                     EscapedChar(9999)
                       UnescapedChar(9999)
-                        UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "?", line: 1, col: 29
+                        Letter(9999)
+                          LowercaseLetter(9999)
+                            TOKEN_93(9999): "n", line: 1, col: 29
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
@@ -105,78 +107,60 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_88(9999): "i", line: 1, col: 32
+                            TOKEN_86(9999): "g", line: 1, col: 32
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_93(9999): "n", line: 1, col: 33
-                    EscapedChar(9999)
-                      UnescapedChar(9999)
-                        Letter(9999)
-                          LowercaseLetter(9999)
-                            TOKEN_86(9999): "g", line: 1, col: 34
-                    EscapedChar(9999)
-                      UnescapedChar(9999)
-                        Letter(9999)
-                          LowercaseLetter(9999)
-                            TOKEN_80(9999): "a", line: 1, col: 35
+                            TOKEN_80(9999): "a", line: 1, col: 33
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 36
+                          TOKEN_1(9999): " ", line: 1, col: 34
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "?", line: 1, col: 37
+                          SPECIAL_5(9999): "ž", line: 1, col: 35
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "?", line: 1, col: 38
-                    EscapedChar(9999)
-                      UnescapedChar(9999)
-                        UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "?", line: 1, col: 39
-                    EscapedChar(9999)
-                      UnescapedChar(9999)
-                        UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "?", line: 1, col: 40
+                          SPECIAL_5(9999): "ą", line: 1, col: 36
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_98(9999): "s", line: 1, col: 41
+                            TOKEN_98(9999): "s", line: 1, col: 37
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_88(9999): "i", line: 1, col: 42
+                            TOKEN_88(9999): "i", line: 1, col: 38
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_98(9999): "s", line: 1, col: 43
-                    TOKEN_3(9999): """, line: 1, col: 44
+                            TOKEN_98(9999): "s", line: 1, col: 39
+                    TOKEN_3(9999): """, line: 1, col: 40
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 45
+                        TOKEN_1(9999): " ", line: 1, col: 41
         AND(9999)
-          TOKEN_35(9999): "AND", line: 1, col: 46
+          TOKEN_35(9999): "AND", line: 1, col: 42
           Spaces(9999)
             Space(9999)
-              TOKEN_1(9999): " ", line: 1, col: 49
+              TOKEN_1(9999): " ", line: 1, col: 45
         ExpressionClause(9999)
           ExpressionPhrase(9999)
             NOT(9999)
-              TOKEN_56(9999): "NOT", line: 1, col: 50
+              TOKEN_56(9999): "NOT", line: 1, col: 46
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 53
+                  TOKEN_1(9999): " ", line: 1, col: 49
             OpeningBrace(9999)
-              TOKEN_8(9999): "(", line: 1, col: 54
+              TOKEN_8(9999): "(", line: 1, col: 50
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 55
+                  TOKEN_1(9999): " ", line: 1, col: 51
             Expression(9999)
               ExpressionClause(9999)
                 ExpressionPhrase(9999)
@@ -185,94 +169,94 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_103(9999): "x", line: 1, col: 56
+                            TOKEN_103(9999): "x", line: 1, col: 52
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 57
+                              TOKEN_1(9999): " ", line: 1, col: 53
                       ValueOpRhs(9999)
                         Operator(9999)
-                          TOKEN_2(9999): "!", line: 1, col: 58
-                          TOKEN_29(9999): "=", line: 1, col: 59
+                          TOKEN_2(9999): "!", line: 1, col: 54
+                          TOKEN_29(9999): "=", line: 1, col: 55
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 60
+                              TOKEN_1(9999): " ", line: 1, col: 56
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 61
+                            TOKEN_3(9999): """, line: 1, col: 57
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_63(9999): "S", line: 1, col: 62
+                                    TOKEN_63(9999): "S", line: 1, col: 58
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_94(9999): "o", line: 1, col: 63
+                                    TOKEN_94(9999): "o", line: 1, col: 59
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_92(9999): "m", line: 1, col: 64
+                                    TOKEN_92(9999): "m", line: 1, col: 60
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_84(9999): "e", line: 1, col: 65
+                                    TOKEN_84(9999): "e", line: 1, col: 61
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Space(9999)
-                                  TOKEN_1(9999): " ", line: 1, col: 66
+                                  TOKEN_1(9999): " ", line: 1, col: 62
                             EscapedChar(9999)
-                              TOKEN_75(9999): "\", line: 1, col: 67
-                              TOKEN_75(9999): "\", line: 1, col: 68
+                              TOKEN_75(9999): "\", line: 1, col: 63
+                              TOKEN_75(9999): "\", line: 1, col: 64
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Space(9999)
-                                  TOKEN_1(9999): " ", line: 1, col: 69
+                                  TOKEN_1(9999): " ", line: 1, col: 65
                             EscapedChar(9999)
-                              TOKEN_75(9999): "\", line: 1, col: 70
-                              TOKEN_3(9999): """, line: 1, col: 71
-                            EscapedChar(9999)
-                              UnescapedChar(9999)
-                                Letter(9999)
-                                  LowercaseLetter(9999)
-                                    TOKEN_98(9999): "s", line: 1, col: 72
+                              TOKEN_75(9999): "\", line: 1, col: 66
+                              TOKEN_3(9999): """, line: 1, col: 67
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_99(9999): "t", line: 1, col: 73
+                                    TOKEN_98(9999): "s", line: 1, col: 68
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_97(9999): "r", line: 1, col: 74
+                                    TOKEN_99(9999): "t", line: 1, col: 69
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_88(9999): "i", line: 1, col: 75
+                                    TOKEN_97(9999): "r", line: 1, col: 70
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_93(9999): "n", line: 1, col: 76
+                                    TOKEN_88(9999): "i", line: 1, col: 71
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_86(9999): "g", line: 1, col: 77
+                                    TOKEN_93(9999): "n", line: 1, col: 72
                             EscapedChar(9999)
-                              TOKEN_75(9999): "\", line: 1, col: 78
-                              TOKEN_3(9999): """, line: 1, col: 79
-                            TOKEN_3(9999): """, line: 1, col: 80
+                              UnescapedChar(9999)
+                                Letter(9999)
+                                  LowercaseLetter(9999)
+                                    TOKEN_86(9999): "g", line: 1, col: 73
+                            EscapedChar(9999)
+                              TOKEN_75(9999): "\", line: 1, col: 74
+                              TOKEN_3(9999): """, line: 1, col: 75
+                            TOKEN_3(9999): """, line: 1, col: 76
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 81
+                                TOKEN_1(9999): " ", line: 1, col: 77
             ClosingBrace(9999)
-              TOKEN_9(9999): ")", line: 1, col: 82
+              TOKEN_9(9999): ")", line: 1, col: 78
               Spaces(9999)
                 Space(9999)
                   nl(9999)
-                    SPECIAL_1(9999): "(...)", line: 1, col: 83
+                    SPECIAL_1(9999): "(...)", line: 1, col: 79

--- a/tests/outputs/Filter_007.out
+++ b/tests/outputs/Filter_007.out
@@ -8,11 +8,11 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 1
+                  TOKEN_80(9999): "a", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 2
+                  TOKEN_80(9999): "a", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 3
+                  TOKEN_103(9999): "x", line: 1, col: 3
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 4
@@ -32,7 +32,7 @@ Filter(9999)
                     Digit(9999)
                       TOKEN_17(9999): "1", line: 1, col: 10
                   Exponent(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 11
+                    TOKEN_84(9999): "e", line: 1, col: 11
                     Digits(9999)
                       Digit(9999)
                         TOKEN_24(9999): "8", line: 1, col: 12
@@ -40,8 +40,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 13
     OR(9999)
-      TOKEN_47(9999): "O", line: 1, col: 14
-      TOKEN_50(9999): "R", line: 1, col: 15
+      TOKEN_59(9999): "OR", line: 1, col: 14
       Spaces(9999)
         Space(9999)
           TOKEN_1(9999): " ", line: 1, col: 16
@@ -53,7 +52,7 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 17
+                    TOKEN_82(9999): "c", line: 1, col: 17
                   Digit(9999)
                     TOKEN_18(9999): "2", line: 1, col: 18
                   Digit(9999)
@@ -75,97 +74,109 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           UppercaseLetter(9999)
-                            TOKEN_51(9999): "S", line: 1, col: 25
+                            TOKEN_63(9999): "S", line: 1, col: 25
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "ą", line: 1, col: 26
+                          SPECIAL_5(9999): "?", line: 1, col: 26
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "ž", line: 1, col: 27
+                          SPECIAL_5(9999): "?", line: 1, col: 27
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        UnicodeHighChar(9999)
+                          SPECIAL_5(9999): "?", line: 1, col: 28
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        UnicodeHighChar(9999)
+                          SPECIAL_5(9999): "?", line: 1, col: 29
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_73(9999): "i", line: 1, col: 28
+                            TOKEN_88(9999): "i", line: 1, col: 30
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 29
+                            TOKEN_93(9999): "n", line: 1, col: 31
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_73(9999): "i", line: 1, col: 30
+                            TOKEN_88(9999): "i", line: 1, col: 32
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 31
+                            TOKEN_93(9999): "n", line: 1, col: 33
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_71(9999): "g", line: 1, col: 32
+                            TOKEN_86(9999): "g", line: 1, col: 34
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_65(9999): "a", line: 1, col: 33
+                            TOKEN_80(9999): "a", line: 1, col: 35
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 34
+                          TOKEN_1(9999): " ", line: 1, col: 36
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "ž", line: 1, col: 35
+                          SPECIAL_5(9999): "?", line: 1, col: 37
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         UnicodeHighChar(9999)
-                          SPECIAL_5(9999): "ą", line: 1, col: 36
+                          SPECIAL_5(9999): "?", line: 1, col: 38
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        UnicodeHighChar(9999)
+                          SPECIAL_5(9999): "?", line: 1, col: 39
+                    EscapedChar(9999)
+                      UnescapedChar(9999)
+                        UnicodeHighChar(9999)
+                          SPECIAL_5(9999): "?", line: 1, col: 40
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 37
+                            TOKEN_98(9999): "s", line: 1, col: 41
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_73(9999): "i", line: 1, col: 38
+                            TOKEN_88(9999): "i", line: 1, col: 42
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 39
-                    TOKEN_3(9999): """, line: 1, col: 40
+                            TOKEN_98(9999): "s", line: 1, col: 43
+                    TOKEN_3(9999): """, line: 1, col: 44
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 41
+                        TOKEN_1(9999): " ", line: 1, col: 45
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 42
-          TOKEN_46(9999): "N", line: 1, col: 43
-          TOKEN_36(9999): "D", line: 1, col: 44
+          TOKEN_35(9999): "AND", line: 1, col: 46
           Spaces(9999)
             Space(9999)
-              TOKEN_1(9999): " ", line: 1, col: 45
+              TOKEN_1(9999): " ", line: 1, col: 49
         ExpressionClause(9999)
           ExpressionPhrase(9999)
             NOT(9999)
-              TOKEN_46(9999): "N", line: 1, col: 46
-              TOKEN_47(9999): "O", line: 1, col: 47
-              TOKEN_52(9999): "T", line: 1, col: 48
+              TOKEN_56(9999): "NOT", line: 1, col: 50
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 49
+                  TOKEN_1(9999): " ", line: 1, col: 53
             OpeningBrace(9999)
-              TOKEN_8(9999): "(", line: 1, col: 50
+              TOKEN_8(9999): "(", line: 1, col: 54
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 51
+                  TOKEN_1(9999): " ", line: 1, col: 55
             Expression(9999)
               ExpressionClause(9999)
                 ExpressionPhrase(9999)
@@ -174,94 +185,94 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_88(9999): "x", line: 1, col: 52
+                            TOKEN_103(9999): "x", line: 1, col: 56
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 53
+                              TOKEN_1(9999): " ", line: 1, col: 57
                       ValueOpRhs(9999)
                         Operator(9999)
-                          TOKEN_2(9999): "!", line: 1, col: 54
-                          TOKEN_29(9999): "=", line: 1, col: 55
+                          TOKEN_2(9999): "!", line: 1, col: 58
+                          TOKEN_29(9999): "=", line: 1, col: 59
                           Spaces(9999)
                             Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 56
+                              TOKEN_1(9999): " ", line: 1, col: 60
                         Value(9999)
                           String(9999)
-                            TOKEN_3(9999): """, line: 1, col: 57
+                            TOKEN_3(9999): """, line: 1, col: 61
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_51(9999): "S", line: 1, col: 58
+                                    TOKEN_63(9999): "S", line: 1, col: 62
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_79(9999): "o", line: 1, col: 59
+                                    TOKEN_94(9999): "o", line: 1, col: 63
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_77(9999): "m", line: 1, col: 60
+                                    TOKEN_92(9999): "m", line: 1, col: 64
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 61
+                                    TOKEN_84(9999): "e", line: 1, col: 65
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Space(9999)
-                                  TOKEN_1(9999): " ", line: 1, col: 62
+                                  TOKEN_1(9999): " ", line: 1, col: 66
                             EscapedChar(9999)
-                              TOKEN_60(9999): "\", line: 1, col: 63
-                              TOKEN_60(9999): "\", line: 1, col: 64
+                              TOKEN_75(9999): "\", line: 1, col: 67
+                              TOKEN_75(9999): "\", line: 1, col: 68
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Space(9999)
-                                  TOKEN_1(9999): " ", line: 1, col: 65
+                                  TOKEN_1(9999): " ", line: 1, col: 69
                             EscapedChar(9999)
-                              TOKEN_60(9999): "\", line: 1, col: 66
-                              TOKEN_3(9999): """, line: 1, col: 67
-                            EscapedChar(9999)
-                              UnescapedChar(9999)
-                                Letter(9999)
-                                  LowercaseLetter(9999)
-                                    TOKEN_83(9999): "s", line: 1, col: 68
+                              TOKEN_75(9999): "\", line: 1, col: 70
+                              TOKEN_3(9999): """, line: 1, col: 71
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_84(9999): "t", line: 1, col: 69
+                                    TOKEN_98(9999): "s", line: 1, col: 72
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_82(9999): "r", line: 1, col: 70
+                                    TOKEN_99(9999): "t", line: 1, col: 73
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_73(9999): "i", line: 1, col: 71
+                                    TOKEN_97(9999): "r", line: 1, col: 74
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_78(9999): "n", line: 1, col: 72
+                                    TOKEN_88(9999): "i", line: 1, col: 75
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_71(9999): "g", line: 1, col: 73
+                                    TOKEN_93(9999): "n", line: 1, col: 76
                             EscapedChar(9999)
-                              TOKEN_60(9999): "\", line: 1, col: 74
-                              TOKEN_3(9999): """, line: 1, col: 75
-                            TOKEN_3(9999): """, line: 1, col: 76
+                              UnescapedChar(9999)
+                                Letter(9999)
+                                  LowercaseLetter(9999)
+                                    TOKEN_86(9999): "g", line: 1, col: 77
+                            EscapedChar(9999)
+                              TOKEN_75(9999): "\", line: 1, col: 78
+                              TOKEN_3(9999): """, line: 1, col: 79
+                            TOKEN_3(9999): """, line: 1, col: 80
                             Spaces(9999)
                               Space(9999)
-                                TOKEN_1(9999): " ", line: 1, col: 77
+                                TOKEN_1(9999): " ", line: 1, col: 81
             ClosingBrace(9999)
-              TOKEN_9(9999): ")", line: 1, col: 78
+              TOKEN_9(9999): ")", line: 1, col: 82
               Spaces(9999)
                 Space(9999)
                   nl(9999)
-                    SPECIAL_1(9999): "(...)", line: 1, col: 79
+                    SPECIAL_1(9999): "(...)", line: 1, col: 83

--- a/tests/outputs/Filter_008.out
+++ b/tests/outputs/Filter_008.out
@@ -14,9 +14,7 @@ Filter(9999)
                 ExpressionClause(9999)
                   ExpressionPhrase(9999)
                     NOT(9999)
-                      TOKEN_46(9999): "N", line: 1, col: 3
-                      TOKEN_47(9999): "O", line: 1, col: 4
-                      TOKEN_52(9999): "T", line: 1, col: 5
+                      TOKEN_56(9999): "NOT", line: 1, col: 3
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 6
@@ -30,7 +28,7 @@ Filter(9999)
                               Property(9999)
                                 Identifier(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 8
+                                    TOKEN_80(9999): "a", line: 1, col: 8
                               ValueOpRhs(9999)
                                 Operator(9999)
                                   TOKEN_30(9999): ">", line: 1, col: 9
@@ -38,7 +36,7 @@ Filter(9999)
                                   Property(9999)
                                     Identifier(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_66(9999): "b", line: 1, col: 10
+                                        TOKEN_81(9999): "b", line: 1, col: 10
                     ClosingBrace(9999)
                       TOKEN_9(9999): ")", line: 1, col: 11
               ClosingBrace(9999)
@@ -47,9 +45,7 @@ Filter(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 13
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 14
-              TOKEN_46(9999): "N", line: 1, col: 15
-              TOKEN_36(9999): "D", line: 1, col: 16
+              TOKEN_35(9999): "AND", line: 1, col: 14
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 17
@@ -60,7 +56,7 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 18
+                          TOKEN_103(9999): "x", line: 1, col: 18
                     ValueOpRhs(9999)
                       Operator(9999)
                         TOKEN_30(9999): ">", line: 1, col: 19

--- a/tests/outputs/Filter_009.out
+++ b/tests/outputs/Filter_009.out
@@ -8,11 +8,11 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 1
+                  TOKEN_80(9999): "a", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 2
+                  TOKEN_80(9999): "a", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 3
+                  TOKEN_103(9999): "x", line: 1, col: 3
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 4
@@ -32,7 +32,7 @@ Filter(9999)
                     Digit(9999)
                       TOKEN_17(9999): "1", line: 1, col: 10
                   Exponent(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 11
+                    TOKEN_84(9999): "e", line: 1, col: 11
                     Digits(9999)
                       Digit(9999)
                         TOKEN_24(9999): "8", line: 1, col: 12
@@ -40,8 +40,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 13
     OR(9999)
-      TOKEN_47(9999): "O", line: 1, col: 14
-      TOKEN_50(9999): "R", line: 1, col: 15
+      TOKEN_59(9999): "OR", line: 1, col: 14
       Spaces(9999)
         Space(9999)
           TOKEN_1(9999): " ", line: 1, col: 16
@@ -53,7 +52,7 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 17
+                    TOKEN_82(9999): "c", line: 1, col: 17
                   Digit(9999)
                     TOKEN_18(9999): "2", line: 1, col: 18
                   Digit(9999)
@@ -79,18 +78,14 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 26
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 27
-          TOKEN_46(9999): "N", line: 1, col: 28
-          TOKEN_36(9999): "D", line: 1, col: 29
+          TOKEN_35(9999): "AND", line: 1, col: 27
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 30
         ExpressionClause(9999)
           ExpressionPhrase(9999)
             NOT(9999)
-              TOKEN_46(9999): "N", line: 1, col: 31
-              TOKEN_47(9999): "O", line: 1, col: 32
-              TOKEN_52(9999): "T", line: 1, col: 33
+              TOKEN_56(9999): "NOT", line: 1, col: 31
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 34
@@ -107,7 +102,7 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_88(9999): "x", line: 1, col: 37
+                            TOKEN_103(9999): "x", line: 1, col: 37
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 38
@@ -125,22 +120,22 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_51(9999): "S", line: 1, col: 43
+                                    TOKEN_63(9999): "S", line: 1, col: 43
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_79(9999): "o", line: 1, col: 44
+                                    TOKEN_94(9999): "o", line: 1, col: 44
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_77(9999): "m", line: 1, col: 45
+                                    TOKEN_92(9999): "m", line: 1, col: 45
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 46
+                                    TOKEN_84(9999): "e", line: 1, col: 46
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Space(9999)
@@ -149,32 +144,32 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_83(9999): "s", line: 1, col: 48
+                                    TOKEN_98(9999): "s", line: 1, col: 48
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_84(9999): "t", line: 1, col: 49
+                                    TOKEN_99(9999): "t", line: 1, col: 49
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_82(9999): "r", line: 1, col: 50
+                                    TOKEN_97(9999): "r", line: 1, col: 50
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_73(9999): "i", line: 1, col: 51
+                                    TOKEN_88(9999): "i", line: 1, col: 51
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_78(9999): "n", line: 1, col: 52
+                                    TOKEN_93(9999): "n", line: 1, col: 52
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_71(9999): "g", line: 1, col: 53
+                                    TOKEN_86(9999): "g", line: 1, col: 53
                             TOKEN_3(9999): """, line: 1, col: 54
                             Spaces(9999)
                               Space(9999)

--- a/tests/outputs/Filter_010.out
+++ b/tests/outputs/Filter_010.out
@@ -8,11 +8,11 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 1
+                  TOKEN_80(9999): "a", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 2
+                  TOKEN_80(9999): "a", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 3
+                  TOKEN_103(9999): "x", line: 1, col: 3
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 4
@@ -32,7 +32,7 @@ Filter(9999)
                     Digit(9999)
                       TOKEN_17(9999): "1", line: 1, col: 10
                   Exponent(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 11
+                    TOKEN_84(9999): "e", line: 1, col: 11
                     Digits(9999)
                       Digit(9999)
                         TOKEN_24(9999): "8", line: 1, col: 12
@@ -40,8 +40,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 13
     OR(9999)
-      TOKEN_47(9999): "O", line: 1, col: 14
-      TOKEN_50(9999): "R", line: 1, col: 15
+      TOKEN_59(9999): "OR", line: 1, col: 14
       Spaces(9999)
         Space(9999)
           TOKEN_1(9999): " ", line: 1, col: 16
@@ -53,7 +52,7 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 17
+                    TOKEN_82(9999): "c", line: 1, col: 17
                   Digit(9999)
                     TOKEN_18(9999): "2", line: 1, col: 18
                   Digit(9999)
@@ -79,18 +78,14 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 26
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 27
-          TOKEN_46(9999): "N", line: 1, col: 28
-          TOKEN_36(9999): "D", line: 1, col: 29
+          TOKEN_35(9999): "AND", line: 1, col: 27
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 30
         ExpressionClause(9999)
           ExpressionPhrase(9999)
             NOT(9999)
-              TOKEN_46(9999): "N", line: 1, col: 31
-              TOKEN_47(9999): "O", line: 1, col: 32
-              TOKEN_52(9999): "T", line: 1, col: 33
+              TOKEN_56(9999): "NOT", line: 1, col: 31
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 34
@@ -99,7 +94,7 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_70(9999): "f", line: 1, col: 35
+                      TOKEN_85(9999): "f", line: 1, col: 35
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 36
@@ -113,13 +108,12 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_89(9999): "y", line: 1, col: 39
+                          TOKEN_104(9999): "y", line: 1, col: 39
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 40
       OR(9999)
-        TOKEN_47(9999): "O", line: 1, col: 41
-        TOKEN_50(9999): "R", line: 1, col: 42
+        TOKEN_59(9999): "OR", line: 1, col: 41
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 43
@@ -127,9 +121,7 @@ Filter(9999)
         ExpressionClause(9999)
           ExpressionPhrase(9999)
             NOT(9999)
-              TOKEN_46(9999): "N", line: 1, col: 44
-              TOKEN_47(9999): "O", line: 1, col: 45
-              TOKEN_52(9999): "T", line: 1, col: 46
+              TOKEN_56(9999): "NOT", line: 1, col: 44
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 47
@@ -138,7 +130,7 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 48
+                      TOKEN_80(9999): "a", line: 1, col: 48
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 49
@@ -153,13 +145,12 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_66(9999): "b", line: 1, col: 53
+                          TOKEN_81(9999): "b", line: 1, col: 53
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 54
         OR(9999)
-          TOKEN_47(9999): "O", line: 1, col: 55
-          TOKEN_50(9999): "R", line: 1, col: 56
+          TOKEN_59(9999): "OR", line: 1, col: 55
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 57
@@ -171,7 +162,7 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_88(9999): "x", line: 1, col: 58
+                        TOKEN_103(9999): "x", line: 1, col: 58
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 59
@@ -185,13 +176,12 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 62
+                            TOKEN_99(9999): "t", line: 1, col: 62
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 63
           OR(9999)
-            TOKEN_47(9999): "O", line: 1, col: 64
-            TOKEN_50(9999): "R", line: 1, col: 65
+            TOKEN_59(9999): "OR", line: 1, col: 64
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 66
@@ -207,9 +197,7 @@ Filter(9999)
                   ExpressionClause(9999)
                     ExpressionPhrase(9999)
                       NOT(9999)
-                        TOKEN_46(9999): "N", line: 1, col: 69
-                        TOKEN_47(9999): "O", line: 1, col: 70
-                        TOKEN_52(9999): "T", line: 1, col: 71
+                        TOKEN_56(9999): "NOT", line: 1, col: 69
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 72
@@ -218,7 +206,7 @@ Filter(9999)
                           Property(9999)
                             Identifier(9999)
                               LowercaseLetter(9999)
-                                TOKEN_88(9999): "x", line: 1, col: 73
+                                TOKEN_103(9999): "x", line: 1, col: 73
                               Spaces(9999)
                                 Space(9999)
                                   TOKEN_1(9999): " ", line: 1, col: 74
@@ -236,22 +224,22 @@ Filter(9999)
                                   UnescapedChar(9999)
                                     Letter(9999)
                                       UppercaseLetter(9999)
-                                        TOKEN_51(9999): "S", line: 1, col: 79
+                                        TOKEN_63(9999): "S", line: 1, col: 79
                                 EscapedChar(9999)
                                   UnescapedChar(9999)
                                     Letter(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_79(9999): "o", line: 1, col: 80
+                                        TOKEN_94(9999): "o", line: 1, col: 80
                                 EscapedChar(9999)
                                   UnescapedChar(9999)
                                     Letter(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_77(9999): "m", line: 1, col: 81
+                                        TOKEN_92(9999): "m", line: 1, col: 81
                                 EscapedChar(9999)
                                   UnescapedChar(9999)
                                     Letter(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_69(9999): "e", line: 1, col: 82
+                                        TOKEN_84(9999): "e", line: 1, col: 82
                                 EscapedChar(9999)
                                   UnescapedChar(9999)
                                     Space(9999)
@@ -260,39 +248,38 @@ Filter(9999)
                                   UnescapedChar(9999)
                                     Letter(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_83(9999): "s", line: 1, col: 84
+                                        TOKEN_98(9999): "s", line: 1, col: 84
                                 EscapedChar(9999)
                                   UnescapedChar(9999)
                                     Letter(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_84(9999): "t", line: 1, col: 85
+                                        TOKEN_99(9999): "t", line: 1, col: 85
                                 EscapedChar(9999)
                                   UnescapedChar(9999)
                                     Letter(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_82(9999): "r", line: 1, col: 86
+                                        TOKEN_97(9999): "r", line: 1, col: 86
                                 EscapedChar(9999)
                                   UnescapedChar(9999)
                                     Letter(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_73(9999): "i", line: 1, col: 87
+                                        TOKEN_88(9999): "i", line: 1, col: 87
                                 EscapedChar(9999)
                                   UnescapedChar(9999)
                                     Letter(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_78(9999): "n", line: 1, col: 88
+                                        TOKEN_93(9999): "n", line: 1, col: 88
                                 EscapedChar(9999)
                                   UnescapedChar(9999)
                                     Letter(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_71(9999): "g", line: 1, col: 89
+                                        TOKEN_86(9999): "g", line: 1, col: 89
                                 TOKEN_3(9999): """, line: 1, col: 90
                                 Spaces(9999)
                                   Space(9999)
                                     TOKEN_1(9999): " ", line: 1, col: 91
                   OR(9999)
-                    TOKEN_47(9999): "O", line: 1, col: 92
-                    TOKEN_50(9999): "R", line: 1, col: 93
+                    TOKEN_59(9999): "OR", line: 1, col: 92
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 94
@@ -304,7 +291,7 @@ Filter(9999)
                             Property(9999)
                               Identifier(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 95
+                                  TOKEN_80(9999): "a", line: 1, col: 95
                                 Spaces(9999)
                                   Space(9999)
                                     TOKEN_1(9999): " ", line: 1, col: 96
@@ -318,14 +305,12 @@ Filter(9999)
                                 Property(9999)
                                   Identifier(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_66(9999): "b", line: 1, col: 99
+                                      TOKEN_81(9999): "b", line: 1, col: 99
                                     Spaces(9999)
                                       Space(9999)
                                         TOKEN_1(9999): " ", line: 1, col: 100
                       AND(9999)
-                        TOKEN_33(9999): "A", line: 1, col: 101
-                        TOKEN_46(9999): "N", line: 1, col: 102
-                        TOKEN_36(9999): "D", line: 1, col: 103
+                        TOKEN_35(9999): "AND", line: 1, col: 101
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 104
@@ -336,7 +321,7 @@ Filter(9999)
                               Property(9999)
                                 Identifier(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_88(9999): "x", line: 1, col: 105
+                                    TOKEN_103(9999): "x", line: 1, col: 105
                                   Spaces(9999)
                                     Space(9999)
                                       TOKEN_1(9999): " ", line: 1, col: 106
@@ -350,23 +335,19 @@ Filter(9999)
                                   Property(9999)
                                     Identifier(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_86(9999): "v", line: 1, col: 109
+                                        TOKEN_101(9999): "v", line: 1, col: 109
                                       Spaces(9999)
                                         Space(9999)
                                           TOKEN_1(9999): " ", line: 1, col: 110
                         AND(9999)
-                          TOKEN_33(9999): "A", line: 1, col: 111
-                          TOKEN_46(9999): "N", line: 1, col: 112
-                          TOKEN_36(9999): "D", line: 1, col: 113
+                          TOKEN_35(9999): "AND", line: 1, col: 111
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 114
                         ExpressionClause(9999)
                           ExpressionPhrase(9999)
                             NOT(9999)
-                              TOKEN_46(9999): "N", line: 1, col: 115
-                              TOKEN_47(9999): "O", line: 1, col: 116
-                              TOKEN_52(9999): "T", line: 1, col: 117
+                              TOKEN_56(9999): "NOT", line: 1, col: 115
                               Spaces(9999)
                                 Space(9999)
                                   TOKEN_1(9999): " ", line: 1, col: 118
@@ -375,7 +356,7 @@ Filter(9999)
                                 Property(9999)
                                   Identifier(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_86(9999): "v", line: 1, col: 119
+                                      TOKEN_101(9999): "v", line: 1, col: 119
                                     Spaces(9999)
                                       Space(9999)
                                         TOKEN_1(9999): " ", line: 1, col: 120
@@ -389,7 +370,7 @@ Filter(9999)
                                     Property(9999)
                                       Identifier(9999)
                                         LowercaseLetter(9999)
-                                          TOKEN_87(9999): "w", line: 1, col: 123
+                                          TOKEN_102(9999): "w", line: 1, col: 123
                 ClosingBrace(9999)
                   TOKEN_9(9999): ")", line: 1, col: 124
                   Spaces(9999)

--- a/tests/outputs/Filter_011.out
+++ b/tests/outputs/Filter_011.out
@@ -14,9 +14,7 @@ Filter(9999)
                 ExpressionClause(9999)
                   ExpressionPhrase(9999)
                     NOT(9999)
-                      TOKEN_46(9999): "N", line: 1, col: 3
-                      TOKEN_47(9999): "O", line: 1, col: 4
-                      TOKEN_52(9999): "T", line: 1, col: 5
+                      TOKEN_56(9999): "NOT", line: 1, col: 3
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 6
@@ -30,7 +28,7 @@ Filter(9999)
                               Property(9999)
                                 Identifier(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 8
+                                    TOKEN_80(9999): "a", line: 1, col: 8
                               ValueOpRhs(9999)
                                 Operator(9999)
                                   TOKEN_30(9999): ">", line: 1, col: 9
@@ -38,7 +36,7 @@ Filter(9999)
                                   Property(9999)
                                     Identifier(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_66(9999): "b", line: 1, col: 10
+                                        TOKEN_81(9999): "b", line: 1, col: 10
                     ClosingBrace(9999)
                       TOKEN_9(9999): ")", line: 1, col: 11
               ClosingBrace(9999)
@@ -47,18 +45,14 @@ Filter(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 13
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 14
-              TOKEN_46(9999): "N", line: 1, col: 15
-              TOKEN_36(9999): "D", line: 1, col: 16
+              TOKEN_35(9999): "AND", line: 1, col: 14
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 17
             ExpressionClause(9999)
               ExpressionPhrase(9999)
                 NOT(9999)
-                  TOKEN_46(9999): "N", line: 1, col: 18
-                  TOKEN_47(9999): "O", line: 1, col: 19
-                  TOKEN_52(9999): "T", line: 1, col: 20
+                  TOKEN_56(9999): "NOT", line: 1, col: 18
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 21
@@ -77,7 +71,7 @@ Filter(9999)
                                 Property(9999)
                                   Identifier(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_88(9999): "x", line: 1, col: 24
+                                      TOKEN_103(9999): "x", line: 1, col: 24
                                 ValueOpRhs(9999)
                                   Operator(9999)
                                     TOKEN_30(9999): ">", line: 1, col: 25

--- a/tests/outputs/Filter_012.out
+++ b/tests/outputs/Filter_012.out
@@ -8,7 +8,7 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 1
+                  TOKEN_80(9999): "a", line: 1, col: 1
             ValueOpRhs(9999)
               Operator(9999)
                 TOKEN_30(9999): ">", line: 1, col: 2
@@ -21,9 +21,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 4
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 5
-        TOKEN_46(9999): "N", line: 1, col: 6
-        TOKEN_36(9999): "D", line: 1, col: 7
+        TOKEN_35(9999): "AND", line: 1, col: 5
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 8
@@ -39,7 +37,7 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_66(9999): "b", line: 1, col: 10
+                          TOKEN_81(9999): "b", line: 1, col: 10
                     ValueOpRhs(9999)
                       Operator(9999)
                         TOKEN_28(9999): "<", line: 1, col: 11
@@ -54,8 +52,7 @@ Filter(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 14
             OR(9999)
-              TOKEN_47(9999): "O", line: 1, col: 15
-              TOKEN_50(9999): "R", line: 1, col: 16
+              TOKEN_59(9999): "OR", line: 1, col: 15
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 17
@@ -67,7 +64,7 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 18
+                            TOKEN_82(9999): "c", line: 1, col: 18
                       ValueOpRhs(9999)
                         Operator(9999)
                           TOKEN_2(9999): "!", line: 1, col: 19
@@ -76,13 +73,12 @@ Filter(9999)
                           Property(9999)
                             Identifier(9999)
                               LowercaseLetter(9999)
-                                TOKEN_66(9999): "b", line: 1, col: 21
+                                TOKEN_81(9999): "b", line: 1, col: 21
                               Spaces(9999)
                                 Space(9999)
                                   TOKEN_1(9999): " ", line: 1, col: 22
               OR(9999)
-                TOKEN_47(9999): "O", line: 1, col: 23
-                TOKEN_50(9999): "R", line: 1, col: 24
+                TOKEN_59(9999): "OR", line: 1, col: 23
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 25
@@ -94,7 +90,7 @@ Filter(9999)
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_88(9999): "x", line: 1, col: 26
+                              TOKEN_103(9999): "x", line: 1, col: 26
                         ValueOpRhs(9999)
                           Operator(9999)
                             TOKEN_30(9999): ">", line: 1, col: 27

--- a/tests/outputs/Filter_013.out
+++ b/tests/outputs/Filter_013.out
@@ -4,9 +4,7 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         NOT(9999)
-          TOKEN_46(9999): "N", line: 1, col: 1
-          TOKEN_47(9999): "O", line: 1, col: 2
-          TOKEN_52(9999): "T", line: 1, col: 3
+          TOKEN_56(9999): "NOT", line: 1, col: 1
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 4
@@ -15,7 +13,7 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 5
+                  TOKEN_80(9999): "a", line: 1, col: 5
             ValueOpRhs(9999)
               Operator(9999)
                 TOKEN_30(9999): ">", line: 1, col: 6
@@ -23,14 +21,12 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_66(9999): "b", line: 1, col: 7
+                      TOKEN_81(9999): "b", line: 1, col: 7
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 8
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 9
-        TOKEN_46(9999): "N", line: 1, col: 10
-        TOKEN_36(9999): "D", line: 1, col: 11
+        TOKEN_35(9999): "AND", line: 1, col: 9
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 12
@@ -41,7 +37,7 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_88(9999): "x", line: 1, col: 13
+                    TOKEN_103(9999): "x", line: 1, col: 13
               ValueOpRhs(9999)
                 Operator(9999)
                   TOKEN_30(9999): ">", line: 1, col: 14

--- a/tests/outputs/Filter_014.out
+++ b/tests/outputs/Filter_014.out
@@ -14,9 +14,7 @@ Filter(9999)
                 ExpressionClause(9999)
                   ExpressionPhrase(9999)
                     NOT(9999)
-                      TOKEN_46(9999): "N", line: 1, col: 3
-                      TOKEN_47(9999): "O", line: 1, col: 4
-                      TOKEN_52(9999): "T", line: 1, col: 5
+                      TOKEN_56(9999): "NOT", line: 1, col: 3
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 6
@@ -30,7 +28,7 @@ Filter(9999)
                               Property(9999)
                                 Identifier(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 8
+                                    TOKEN_80(9999): "a", line: 1, col: 8
                               ValueOpRhs(9999)
                                 Operator(9999)
                                   TOKEN_30(9999): ">", line: 1, col: 9
@@ -38,7 +36,7 @@ Filter(9999)
                                   Property(9999)
                                     Identifier(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_66(9999): "b", line: 1, col: 10
+                                        TOKEN_81(9999): "b", line: 1, col: 10
                     ClosingBrace(9999)
                       TOKEN_9(9999): ")", line: 1, col: 11
               ClosingBrace(9999)
@@ -47,9 +45,7 @@ Filter(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 13
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 14
-              TOKEN_46(9999): "N", line: 1, col: 15
-              TOKEN_36(9999): "D", line: 1, col: 16
+              TOKEN_35(9999): "AND", line: 1, col: 14
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 17
@@ -70,7 +66,7 @@ Filter(9999)
                                 Property(9999)
                                   Identifier(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_88(9999): "x", line: 1, col: 20
+                                      TOKEN_103(9999): "x", line: 1, col: 20
                                 ValueOpRhs(9999)
                                   Operator(9999)
                                     TOKEN_30(9999): ">", line: 1, col: 21

--- a/tests/outputs/Filter_015.out
+++ b/tests/outputs/Filter_015.out
@@ -8,37 +8,37 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17
@@ -60,23 +60,22 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 22
+                          TOKEN_91(9999): "l", line: 1, col: 22
                   TOKEN_3(9999): """, line: 1, col: 23
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 24
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 25
-        TOKEN_46(9999): "N", line: 1, col: 26
-        TOKEN_36(9999): "D", line: 1, col: 27
+        TOKEN_35(9999): "AND", line: 1, col: 25
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 28
 Error: in tests/cases/Filter_015.inp: line 1:
-    unexpected token "O", expected one of "N", """, "+", "-", "0",
+    unexpected token "OR", expected one of "NOT", """, "+", "-", "0",
     "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "a", "b", "c",
     "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p",
-    "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "_", "L", or "("
+    "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "_", "LENGTH",
+    or "("
 
 chemical_formula = "Al" AND OR prototype_formula = "A"
                             ^

--- a/tests/outputs/Filter_016.out
+++ b/tests/outputs/Filter_016.out
@@ -24,37 +24,37 @@ Filter(9999)
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_67(9999): "c", line: 1, col: 5
+                              TOKEN_82(9999): "c", line: 1, col: 5
                             LowercaseLetter(9999)
-                              TOKEN_72(9999): "h", line: 1, col: 6
+                              TOKEN_87(9999): "h", line: 1, col: 6
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 7
+                              TOKEN_84(9999): "e", line: 1, col: 7
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 8
+                              TOKEN_92(9999): "m", line: 1, col: 8
                             LowercaseLetter(9999)
-                              TOKEN_73(9999): "i", line: 1, col: 9
+                              TOKEN_88(9999): "i", line: 1, col: 9
                             LowercaseLetter(9999)
-                              TOKEN_67(9999): "c", line: 1, col: 10
+                              TOKEN_82(9999): "c", line: 1, col: 10
                             LowercaseLetter(9999)
-                              TOKEN_65(9999): "a", line: 1, col: 11
+                              TOKEN_80(9999): "a", line: 1, col: 11
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 12
+                              TOKEN_91(9999): "l", line: 1, col: 12
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 13
+                              TOKEN_78(9999): "_", line: 1, col: 13
                             LowercaseLetter(9999)
-                              TOKEN_70(9999): "f", line: 1, col: 14
+                              TOKEN_85(9999): "f", line: 1, col: 14
                             LowercaseLetter(9999)
-                              TOKEN_79(9999): "o", line: 1, col: 15
+                              TOKEN_94(9999): "o", line: 1, col: 15
                             LowercaseLetter(9999)
-                              TOKEN_82(9999): "r", line: 1, col: 16
+                              TOKEN_97(9999): "r", line: 1, col: 16
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 17
+                              TOKEN_92(9999): "m", line: 1, col: 17
                             LowercaseLetter(9999)
-                              TOKEN_85(9999): "u", line: 1, col: 18
+                              TOKEN_100(9999): "u", line: 1, col: 18
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 19
+                              TOKEN_91(9999): "l", line: 1, col: 19
                             LowercaseLetter(9999)
-                              TOKEN_65(9999): "a", line: 1, col: 20
+                              TOKEN_80(9999): "a", line: 1, col: 20
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 21
@@ -76,7 +76,7 @@ Filter(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_76(9999): "l", line: 1, col: 26
+                                      TOKEN_91(9999): "l", line: 1, col: 26
                               TOKEN_3(9999): """, line: 1, col: 27
                               Spaces(9999)
                                 Space(9999)

--- a/tests/outputs/Filter_017.out
+++ b/tests/outputs/Filter_017.out
@@ -8,37 +8,37 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17
@@ -60,7 +60,7 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 22
+                          TOKEN_91(9999): "l", line: 1, col: 22
                   TOKEN_3(9999): """, line: 1, col: 23
                   Spaces(9999)
                     Space(9999)

--- a/tests/outputs/Filter_018.out
+++ b/tests/outputs/Filter_018.out
@@ -4,9 +4,7 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         NOT(9999)
-          TOKEN_46(9999): "N", line: 1, col: 1
-          TOKEN_47(9999): "O", line: 1, col: 2
-          TOKEN_52(9999): "T", line: 1, col: 3
+          TOKEN_56(9999): "NOT", line: 1, col: 1
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 4
@@ -23,37 +21,37 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_67(9999): "c", line: 1, col: 7
+                        TOKEN_82(9999): "c", line: 1, col: 7
                       LowercaseLetter(9999)
-                        TOKEN_72(9999): "h", line: 1, col: 8
+                        TOKEN_87(9999): "h", line: 1, col: 8
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 9
+                        TOKEN_84(9999): "e", line: 1, col: 9
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 10
+                        TOKEN_92(9999): "m", line: 1, col: 10
                       LowercaseLetter(9999)
-                        TOKEN_73(9999): "i", line: 1, col: 11
+                        TOKEN_88(9999): "i", line: 1, col: 11
                       LowercaseLetter(9999)
-                        TOKEN_67(9999): "c", line: 1, col: 12
+                        TOKEN_82(9999): "c", line: 1, col: 12
                       LowercaseLetter(9999)
-                        TOKEN_65(9999): "a", line: 1, col: 13
+                        TOKEN_80(9999): "a", line: 1, col: 13
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 14
+                        TOKEN_91(9999): "l", line: 1, col: 14
                       LowercaseLetter(9999)
-                        TOKEN_63(9999): "_", line: 1, col: 15
+                        TOKEN_78(9999): "_", line: 1, col: 15
                       LowercaseLetter(9999)
-                        TOKEN_70(9999): "f", line: 1, col: 16
+                        TOKEN_85(9999): "f", line: 1, col: 16
                       LowercaseLetter(9999)
-                        TOKEN_79(9999): "o", line: 1, col: 17
+                        TOKEN_94(9999): "o", line: 1, col: 17
                       LowercaseLetter(9999)
-                        TOKEN_82(9999): "r", line: 1, col: 18
+                        TOKEN_97(9999): "r", line: 1, col: 18
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 19
+                        TOKEN_92(9999): "m", line: 1, col: 19
                       LowercaseLetter(9999)
-                        TOKEN_85(9999): "u", line: 1, col: 20
+                        TOKEN_100(9999): "u", line: 1, col: 20
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 21
+                        TOKEN_91(9999): "l", line: 1, col: 21
                       LowercaseLetter(9999)
-                        TOKEN_65(9999): "a", line: 1, col: 22
+                        TOKEN_80(9999): "a", line: 1, col: 22
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 23
@@ -75,15 +73,13 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_76(9999): "l", line: 1, col: 28
+                                TOKEN_91(9999): "l", line: 1, col: 28
                         TOKEN_3(9999): """, line: 1, col: 29
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 30
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 31
-              TOKEN_46(9999): "N", line: 1, col: 32
-              TOKEN_36(9999): "D", line: 1, col: 33
+              TOKEN_35(9999): "AND", line: 1, col: 31
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 34
@@ -94,39 +90,39 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 35
+                          TOKEN_95(9999): "p", line: 1, col: 35
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 36
+                          TOKEN_97(9999): "r", line: 1, col: 36
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 37
+                          TOKEN_94(9999): "o", line: 1, col: 37
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 38
+                          TOKEN_99(9999): "t", line: 1, col: 38
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 39
+                          TOKEN_94(9999): "o", line: 1, col: 39
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 40
+                          TOKEN_99(9999): "t", line: 1, col: 40
                         LowercaseLetter(9999)
-                          TOKEN_89(9999): "y", line: 1, col: 41
+                          TOKEN_104(9999): "y", line: 1, col: 41
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 42
+                          TOKEN_95(9999): "p", line: 1, col: 42
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 43
+                          TOKEN_84(9999): "e", line: 1, col: 43
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 44
+                          TOKEN_78(9999): "_", line: 1, col: 44
                         LowercaseLetter(9999)
-                          TOKEN_70(9999): "f", line: 1, col: 45
+                          TOKEN_85(9999): "f", line: 1, col: 45
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 46
+                          TOKEN_94(9999): "o", line: 1, col: 46
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 47
+                          TOKEN_97(9999): "r", line: 1, col: 47
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 48
+                          TOKEN_92(9999): "m", line: 1, col: 48
                         LowercaseLetter(9999)
-                          TOKEN_85(9999): "u", line: 1, col: 49
+                          TOKEN_100(9999): "u", line: 1, col: 49
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 50
+                          TOKEN_91(9999): "l", line: 1, col: 50
                         LowercaseLetter(9999)
-                          TOKEN_65(9999): "a", line: 1, col: 51
+                          TOKEN_80(9999): "a", line: 1, col: 51
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 52
@@ -149,8 +145,7 @@ Filter(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 58
           OR(9999)
-            TOKEN_47(9999): "O", line: 1, col: 59
-            TOKEN_50(9999): "R", line: 1, col: 60
+            TOKEN_59(9999): "OR", line: 1, col: 59
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 61
@@ -162,39 +157,39 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 62
+                          TOKEN_95(9999): "p", line: 1, col: 62
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 63
+                          TOKEN_97(9999): "r", line: 1, col: 63
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 64
+                          TOKEN_94(9999): "o", line: 1, col: 64
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 65
+                          TOKEN_99(9999): "t", line: 1, col: 65
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 66
+                          TOKEN_94(9999): "o", line: 1, col: 66
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 67
+                          TOKEN_99(9999): "t", line: 1, col: 67
                         LowercaseLetter(9999)
-                          TOKEN_89(9999): "y", line: 1, col: 68
+                          TOKEN_104(9999): "y", line: 1, col: 68
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 69
+                          TOKEN_95(9999): "p", line: 1, col: 69
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 70
+                          TOKEN_84(9999): "e", line: 1, col: 70
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 71
+                          TOKEN_78(9999): "_", line: 1, col: 71
                         LowercaseLetter(9999)
-                          TOKEN_70(9999): "f", line: 1, col: 72
+                          TOKEN_85(9999): "f", line: 1, col: 72
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 73
+                          TOKEN_94(9999): "o", line: 1, col: 73
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 74
+                          TOKEN_97(9999): "r", line: 1, col: 74
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 75
+                          TOKEN_92(9999): "m", line: 1, col: 75
                         LowercaseLetter(9999)
-                          TOKEN_85(9999): "u", line: 1, col: 76
+                          TOKEN_100(9999): "u", line: 1, col: 76
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 77
+                          TOKEN_91(9999): "l", line: 1, col: 77
                         LowercaseLetter(9999)
-                          TOKEN_65(9999): "a", line: 1, col: 78
+                          TOKEN_80(9999): "a", line: 1, col: 78
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 79
@@ -216,24 +211,20 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_76(9999): "l", line: 1, col: 84
+                                  TOKEN_91(9999): "l", line: 1, col: 84
                           TOKEN_3(9999): """, line: 1, col: 85
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 86
               AND(9999)
-                TOKEN_33(9999): "A", line: 1, col: 87
-                TOKEN_46(9999): "N", line: 1, col: 88
-                TOKEN_36(9999): "D", line: 1, col: 89
+                TOKEN_35(9999): "AND", line: 1, col: 87
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 90
               ExpressionClause(9999)
                 ExpressionPhrase(9999)
                   NOT(9999)
-                    TOKEN_46(9999): "N", line: 1, col: 91
-                    TOKEN_47(9999): "O", line: 1, col: 92
-                    TOKEN_52(9999): "T", line: 1, col: 93
+                    TOKEN_56(9999): "NOT", line: 1, col: 91
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 94
@@ -242,37 +233,37 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 95
+                            TOKEN_82(9999): "c", line: 1, col: 95
                           LowercaseLetter(9999)
-                            TOKEN_72(9999): "h", line: 1, col: 96
+                            TOKEN_87(9999): "h", line: 1, col: 96
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 97
+                            TOKEN_84(9999): "e", line: 1, col: 97
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 98
+                            TOKEN_92(9999): "m", line: 1, col: 98
                           LowercaseLetter(9999)
-                            TOKEN_73(9999): "i", line: 1, col: 99
+                            TOKEN_88(9999): "i", line: 1, col: 99
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 100
+                            TOKEN_82(9999): "c", line: 1, col: 100
                           LowercaseLetter(9999)
-                            TOKEN_65(9999): "a", line: 1, col: 101
+                            TOKEN_80(9999): "a", line: 1, col: 101
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 102
+                            TOKEN_91(9999): "l", line: 1, col: 102
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 103
+                            TOKEN_78(9999): "_", line: 1, col: 103
                           LowercaseLetter(9999)
-                            TOKEN_70(9999): "f", line: 1, col: 104
+                            TOKEN_85(9999): "f", line: 1, col: 104
                           LowercaseLetter(9999)
-                            TOKEN_79(9999): "o", line: 1, col: 105
+                            TOKEN_94(9999): "o", line: 1, col: 105
                           LowercaseLetter(9999)
-                            TOKEN_82(9999): "r", line: 1, col: 106
+                            TOKEN_97(9999): "r", line: 1, col: 106
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 107
+                            TOKEN_92(9999): "m", line: 1, col: 107
                           LowercaseLetter(9999)
-                            TOKEN_85(9999): "u", line: 1, col: 108
+                            TOKEN_100(9999): "u", line: 1, col: 108
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 109
+                            TOKEN_91(9999): "l", line: 1, col: 109
                           LowercaseLetter(9999)
-                            TOKEN_65(9999): "a", line: 1, col: 110
+                            TOKEN_80(9999): "a", line: 1, col: 110
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 111
@@ -289,12 +280,12 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_52(9999): "T", line: 1, col: 115
+                                    TOKEN_65(9999): "T", line: 1, col: 115
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_73(9999): "i", line: 1, col: 116
+                                    TOKEN_88(9999): "i", line: 1, col: 116
                             TOKEN_3(9999): """, line: 1, col: 117
                             Spaces(9999)
                               Space(9999)
@@ -305,9 +296,7 @@ Filter(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 120
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 121
-        TOKEN_46(9999): "N", line: 1, col: 122
-        TOKEN_36(9999): "D", line: 1, col: 123
+        TOKEN_35(9999): "AND", line: 1, col: 121
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 124
@@ -326,39 +315,39 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 127
+                          TOKEN_95(9999): "p", line: 1, col: 127
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 128
+                          TOKEN_97(9999): "r", line: 1, col: 128
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 129
+                          TOKEN_94(9999): "o", line: 1, col: 129
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 130
+                          TOKEN_99(9999): "t", line: 1, col: 130
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 131
+                          TOKEN_94(9999): "o", line: 1, col: 131
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 132
+                          TOKEN_99(9999): "t", line: 1, col: 132
                         LowercaseLetter(9999)
-                          TOKEN_89(9999): "y", line: 1, col: 133
+                          TOKEN_104(9999): "y", line: 1, col: 133
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 134
+                          TOKEN_95(9999): "p", line: 1, col: 134
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 135
+                          TOKEN_84(9999): "e", line: 1, col: 135
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 136
+                          TOKEN_78(9999): "_", line: 1, col: 136
                         LowercaseLetter(9999)
-                          TOKEN_70(9999): "f", line: 1, col: 137
+                          TOKEN_85(9999): "f", line: 1, col: 137
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 138
+                          TOKEN_94(9999): "o", line: 1, col: 138
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 139
+                          TOKEN_97(9999): "r", line: 1, col: 139
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 140
+                          TOKEN_92(9999): "m", line: 1, col: 140
                         LowercaseLetter(9999)
-                          TOKEN_85(9999): "u", line: 1, col: 141
+                          TOKEN_100(9999): "u", line: 1, col: 141
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 142
+                          TOKEN_91(9999): "l", line: 1, col: 142
                         LowercaseLetter(9999)
-                          TOKEN_65(9999): "a", line: 1, col: 143
+                          TOKEN_80(9999): "a", line: 1, col: 143
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 144
@@ -375,20 +364,18 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_39(9999): "G", line: 1, col: 148
+                                  TOKEN_44(9999): "G", line: 1, col: 148
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 149
+                                  TOKEN_80(9999): "a", line: 1, col: 149
                           TOKEN_3(9999): """, line: 1, col: 150
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 151
               AND(9999)
-                TOKEN_33(9999): "A", line: 1, col: 152
-                TOKEN_46(9999): "N", line: 1, col: 153
-                TOKEN_36(9999): "D", line: 1, col: 154
+                TOKEN_35(9999): "AND", line: 1, col: 152
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 155
@@ -399,37 +386,37 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 156
+                            TOKEN_82(9999): "c", line: 1, col: 156
                           LowercaseLetter(9999)
-                            TOKEN_72(9999): "h", line: 1, col: 157
+                            TOKEN_87(9999): "h", line: 1, col: 157
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 158
+                            TOKEN_84(9999): "e", line: 1, col: 158
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 159
+                            TOKEN_92(9999): "m", line: 1, col: 159
                           LowercaseLetter(9999)
-                            TOKEN_73(9999): "i", line: 1, col: 160
+                            TOKEN_88(9999): "i", line: 1, col: 160
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 161
+                            TOKEN_82(9999): "c", line: 1, col: 161
                           LowercaseLetter(9999)
-                            TOKEN_65(9999): "a", line: 1, col: 162
+                            TOKEN_80(9999): "a", line: 1, col: 162
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 163
+                            TOKEN_91(9999): "l", line: 1, col: 163
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 164
+                            TOKEN_78(9999): "_", line: 1, col: 164
                           LowercaseLetter(9999)
-                            TOKEN_70(9999): "f", line: 1, col: 165
+                            TOKEN_85(9999): "f", line: 1, col: 165
                           LowercaseLetter(9999)
-                            TOKEN_79(9999): "o", line: 1, col: 166
+                            TOKEN_94(9999): "o", line: 1, col: 166
                           LowercaseLetter(9999)
-                            TOKEN_82(9999): "r", line: 1, col: 167
+                            TOKEN_97(9999): "r", line: 1, col: 167
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 168
+                            TOKEN_92(9999): "m", line: 1, col: 168
                           LowercaseLetter(9999)
-                            TOKEN_85(9999): "u", line: 1, col: 169
+                            TOKEN_100(9999): "u", line: 1, col: 169
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 170
+                            TOKEN_91(9999): "l", line: 1, col: 170
                           LowercaseLetter(9999)
-                            TOKEN_65(9999): "a", line: 1, col: 171
+                            TOKEN_80(9999): "a", line: 1, col: 171
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 172
@@ -446,19 +433,18 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_52(9999): "T", line: 1, col: 176
+                                    TOKEN_65(9999): "T", line: 1, col: 176
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_73(9999): "i", line: 1, col: 177
+                                    TOKEN_88(9999): "i", line: 1, col: 177
                             TOKEN_3(9999): """, line: 1, col: 178
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 179
             OR(9999)
-              TOKEN_47(9999): "O", line: 1, col: 180
-              TOKEN_50(9999): "R", line: 1, col: 181
+              TOKEN_59(9999): "OR", line: 1, col: 180
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 182
@@ -478,37 +464,37 @@ Filter(9999)
                             Property(9999)
                               Identifier(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_67(9999): "c", line: 1, col: 185
+                                  TOKEN_82(9999): "c", line: 1, col: 185
                                 LowercaseLetter(9999)
-                                  TOKEN_72(9999): "h", line: 1, col: 186
+                                  TOKEN_87(9999): "h", line: 1, col: 186
                                 LowercaseLetter(9999)
-                                  TOKEN_69(9999): "e", line: 1, col: 187
+                                  TOKEN_84(9999): "e", line: 1, col: 187
                                 LowercaseLetter(9999)
-                                  TOKEN_77(9999): "m", line: 1, col: 188
+                                  TOKEN_92(9999): "m", line: 1, col: 188
                                 LowercaseLetter(9999)
-                                  TOKEN_73(9999): "i", line: 1, col: 189
+                                  TOKEN_88(9999): "i", line: 1, col: 189
                                 LowercaseLetter(9999)
-                                  TOKEN_67(9999): "c", line: 1, col: 190
+                                  TOKEN_82(9999): "c", line: 1, col: 190
                                 LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 191
+                                  TOKEN_80(9999): "a", line: 1, col: 191
                                 LowercaseLetter(9999)
-                                  TOKEN_76(9999): "l", line: 1, col: 192
+                                  TOKEN_91(9999): "l", line: 1, col: 192
                                 LowercaseLetter(9999)
-                                  TOKEN_63(9999): "_", line: 1, col: 193
+                                  TOKEN_78(9999): "_", line: 1, col: 193
                                 LowercaseLetter(9999)
-                                  TOKEN_70(9999): "f", line: 1, col: 194
+                                  TOKEN_85(9999): "f", line: 1, col: 194
                                 LowercaseLetter(9999)
-                                  TOKEN_79(9999): "o", line: 1, col: 195
+                                  TOKEN_94(9999): "o", line: 1, col: 195
                                 LowercaseLetter(9999)
-                                  TOKEN_82(9999): "r", line: 1, col: 196
+                                  TOKEN_97(9999): "r", line: 1, col: 196
                                 LowercaseLetter(9999)
-                                  TOKEN_77(9999): "m", line: 1, col: 197
+                                  TOKEN_92(9999): "m", line: 1, col: 197
                                 LowercaseLetter(9999)
-                                  TOKEN_85(9999): "u", line: 1, col: 198
+                                  TOKEN_100(9999): "u", line: 1, col: 198
                                 LowercaseLetter(9999)
-                                  TOKEN_76(9999): "l", line: 1, col: 199
+                                  TOKEN_91(9999): "l", line: 1, col: 199
                                 LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 200
+                                  TOKEN_80(9999): "a", line: 1, col: 200
                                 Spaces(9999)
                                   Space(9999)
                                     TOKEN_1(9999): " ", line: 1, col: 201
@@ -525,20 +511,18 @@ Filter(9999)
                                     UnescapedChar(9999)
                                       Letter(9999)
                                         UppercaseLetter(9999)
-                                          TOKEN_46(9999): "N", line: 1, col: 205
+                                          TOKEN_55(9999): "N", line: 1, col: 205
                                   EscapedChar(9999)
                                     UnescapedChar(9999)
                                       Letter(9999)
                                         LowercaseLetter(9999)
-                                          TOKEN_65(9999): "a", line: 1, col: 206
+                                          TOKEN_80(9999): "a", line: 1, col: 206
                                   TOKEN_3(9999): """, line: 1, col: 207
                                   Spaces(9999)
                                     Space(9999)
                                       TOKEN_1(9999): " ", line: 1, col: 208
                       AND(9999)
-                        TOKEN_33(9999): "A", line: 1, col: 209
-                        TOKEN_46(9999): "N", line: 1, col: 210
-                        TOKEN_36(9999): "D", line: 1, col: 211
+                        TOKEN_35(9999): "AND", line: 1, col: 209
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 212
@@ -549,37 +533,37 @@ Filter(9999)
                               Property(9999)
                                 Identifier(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_67(9999): "c", line: 1, col: 213
+                                    TOKEN_82(9999): "c", line: 1, col: 213
                                   LowercaseLetter(9999)
-                                    TOKEN_72(9999): "h", line: 1, col: 214
+                                    TOKEN_87(9999): "h", line: 1, col: 214
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 215
+                                    TOKEN_84(9999): "e", line: 1, col: 215
                                   LowercaseLetter(9999)
-                                    TOKEN_77(9999): "m", line: 1, col: 216
+                                    TOKEN_92(9999): "m", line: 1, col: 216
                                   LowercaseLetter(9999)
-                                    TOKEN_73(9999): "i", line: 1, col: 217
+                                    TOKEN_88(9999): "i", line: 1, col: 217
                                   LowercaseLetter(9999)
-                                    TOKEN_67(9999): "c", line: 1, col: 218
+                                    TOKEN_82(9999): "c", line: 1, col: 218
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 219
+                                    TOKEN_80(9999): "a", line: 1, col: 219
                                   LowercaseLetter(9999)
-                                    TOKEN_76(9999): "l", line: 1, col: 220
+                                    TOKEN_91(9999): "l", line: 1, col: 220
                                   LowercaseLetter(9999)
-                                    TOKEN_63(9999): "_", line: 1, col: 221
+                                    TOKEN_78(9999): "_", line: 1, col: 221
                                   LowercaseLetter(9999)
-                                    TOKEN_70(9999): "f", line: 1, col: 222
+                                    TOKEN_85(9999): "f", line: 1, col: 222
                                   LowercaseLetter(9999)
-                                    TOKEN_79(9999): "o", line: 1, col: 223
+                                    TOKEN_94(9999): "o", line: 1, col: 223
                                   LowercaseLetter(9999)
-                                    TOKEN_82(9999): "r", line: 1, col: 224
+                                    TOKEN_97(9999): "r", line: 1, col: 224
                                   LowercaseLetter(9999)
-                                    TOKEN_77(9999): "m", line: 1, col: 225
+                                    TOKEN_92(9999): "m", line: 1, col: 225
                                   LowercaseLetter(9999)
-                                    TOKEN_85(9999): "u", line: 1, col: 226
+                                    TOKEN_100(9999): "u", line: 1, col: 226
                                   LowercaseLetter(9999)
-                                    TOKEN_76(9999): "l", line: 1, col: 227
+                                    TOKEN_91(9999): "l", line: 1, col: 227
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 228
+                                    TOKEN_80(9999): "a", line: 1, col: 228
                                   Spaces(9999)
                                     Space(9999)
                                       TOKEN_1(9999): " ", line: 1, col: 229
@@ -596,12 +580,12 @@ Filter(9999)
                                       UnescapedChar(9999)
                                         Letter(9999)
                                           UppercaseLetter(9999)
-                                            TOKEN_52(9999): "T", line: 1, col: 233
+                                            TOKEN_65(9999): "T", line: 1, col: 233
                                     EscapedChar(9999)
                                       UnescapedChar(9999)
                                         Letter(9999)
                                           LowercaseLetter(9999)
-                                            TOKEN_73(9999): "i", line: 1, col: 234
+                                            TOKEN_88(9999): "i", line: 1, col: 234
                                     TOKEN_3(9999): """, line: 1, col: 235
                   ClosingBrace(9999)
                     TOKEN_9(9999): ")", line: 1, col: 236

--- a/tests/outputs/Filter_019.out
+++ b/tests/outputs/Filter_019.out
@@ -8,50 +8,43 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17
             FuzzyStringOpRhs(9999)
               CONTAINS(9999)
-                TOKEN_35(9999): "C", line: 1, col: 18
-                TOKEN_47(9999): "O", line: 1, col: 19
-                TOKEN_46(9999): "N", line: 1, col: 20
-                TOKEN_52(9999): "T", line: 1, col: 21
-                TOKEN_33(9999): "A", line: 1, col: 22
-                TOKEN_41(9999): "I", line: 1, col: 23
-                TOKEN_46(9999): "N", line: 1, col: 24
-                TOKEN_51(9999): "S", line: 1, col: 25
+                TOKEN_39(9999): "CONTAINS", line: 1, col: 18
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 26

--- a/tests/outputs/Filter_020.out
+++ b/tests/outputs/Filter_020.out
@@ -8,57 +8,50 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17
             FuzzyStringOpRhs(9999)
               CONTAINS(9999)
-                TOKEN_35(9999): "C", line: 1, col: 18
-                TOKEN_47(9999): "O", line: 1, col: 19
-                TOKEN_46(9999): "N", line: 1, col: 20
-                TOKEN_52(9999): "T", line: 1, col: 21
-                TOKEN_33(9999): "A", line: 1, col: 22
-                TOKEN_41(9999): "I", line: 1, col: 23
-                TOKEN_46(9999): "N", line: 1, col: 24
-                TOKEN_51(9999): "S", line: 1, col: 25
+                TOKEN_39(9999): "CONTAINS", line: 1, col: 18
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 26
 Error: in tests/cases/Filter_020.inp: line 1:
-    unexpected token "S", expected one of """, "a", "b", "c", "d",
-    "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q",
-    "r", "s", "t", "u", "v", "w", "x", "y", "z", or "_"
+    unexpected token "STARTS", expected one of """, "a", "b", "c",
+    "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p",
+    "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", or "_"
 
 chemical_formula CONTAINS STARTS "Al"
                           ^

--- a/tests/outputs/Filter_021.out
+++ b/tests/outputs/Filter_021.out
@@ -8,50 +8,43 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17
             FuzzyStringOpRhs(9999)
               CONTAINS(9999)
-                TOKEN_35(9999): "C", line: 1, col: 18
-                TOKEN_47(9999): "O", line: 1, col: 19
-                TOKEN_46(9999): "N", line: 1, col: 20
-                TOKEN_52(9999): "T", line: 1, col: 21
-                TOKEN_33(9999): "A", line: 1, col: 22
-                TOKEN_41(9999): "I", line: 1, col: 23
-                TOKEN_46(9999): "N", line: 1, col: 24
-                TOKEN_51(9999): "S", line: 1, col: 25
+                TOKEN_39(9999): "CONTAINS", line: 1, col: 18
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 26
@@ -67,15 +60,13 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 29
+                          TOKEN_91(9999): "l", line: 1, col: 29
                   TOKEN_3(9999): """, line: 1, col: 30
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 31
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 32
-        TOKEN_46(9999): "N", line: 1, col: 33
-        TOKEN_36(9999): "D", line: 1, col: 34
+        TOKEN_35(9999): "AND", line: 1, col: 32
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 35
@@ -86,48 +77,43 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 36
+                    TOKEN_82(9999): "c", line: 1, col: 36
                   LowercaseLetter(9999)
-                    TOKEN_72(9999): "h", line: 1, col: 37
+                    TOKEN_87(9999): "h", line: 1, col: 37
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 38
+                    TOKEN_84(9999): "e", line: 1, col: 38
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 39
+                    TOKEN_92(9999): "m", line: 1, col: 39
                   LowercaseLetter(9999)
-                    TOKEN_73(9999): "i", line: 1, col: 40
+                    TOKEN_88(9999): "i", line: 1, col: 40
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 41
+                    TOKEN_82(9999): "c", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 42
+                    TOKEN_80(9999): "a", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 43
+                    TOKEN_91(9999): "l", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 44
+                    TOKEN_78(9999): "_", line: 1, col: 44
                   LowercaseLetter(9999)
-                    TOKEN_70(9999): "f", line: 1, col: 45
+                    TOKEN_85(9999): "f", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 46
+                    TOKEN_94(9999): "o", line: 1, col: 46
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 47
+                    TOKEN_97(9999): "r", line: 1, col: 47
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 48
+                    TOKEN_92(9999): "m", line: 1, col: 48
                   LowercaseLetter(9999)
-                    TOKEN_85(9999): "u", line: 1, col: 49
+                    TOKEN_100(9999): "u", line: 1, col: 49
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 50
+                    TOKEN_91(9999): "l", line: 1, col: 50
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 51
+                    TOKEN_80(9999): "a", line: 1, col: 51
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 52
               FuzzyStringOpRhs(9999)
                 STARTS(9999)
-                  TOKEN_51(9999): "S", line: 1, col: 53
-                  TOKEN_52(9999): "T", line: 1, col: 54
-                  TOKEN_33(9999): "A", line: 1, col: 55
-                  TOKEN_50(9999): "R", line: 1, col: 56
-                  TOKEN_52(9999): "T", line: 1, col: 57
-                  TOKEN_51(9999): "S", line: 1, col: 58
+                  TOKEN_64(9999): "STARTS", line: 1, col: 53
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 59
@@ -143,15 +129,13 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 62
+                            TOKEN_91(9999): "l", line: 1, col: 62
                     TOKEN_3(9999): """, line: 1, col: 63
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 64
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 65
-          TOKEN_46(9999): "N", line: 1, col: 66
-          TOKEN_36(9999): "D", line: 1, col: 67
+          TOKEN_35(9999): "AND", line: 1, col: 65
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 68
@@ -162,46 +146,43 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 69
+                      TOKEN_82(9999): "c", line: 1, col: 69
                     LowercaseLetter(9999)
-                      TOKEN_72(9999): "h", line: 1, col: 70
+                      TOKEN_87(9999): "h", line: 1, col: 70
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 71
+                      TOKEN_84(9999): "e", line: 1, col: 71
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 72
+                      TOKEN_92(9999): "m", line: 1, col: 72
                     LowercaseLetter(9999)
-                      TOKEN_73(9999): "i", line: 1, col: 73
+                      TOKEN_88(9999): "i", line: 1, col: 73
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 74
+                      TOKEN_82(9999): "c", line: 1, col: 74
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 75
+                      TOKEN_80(9999): "a", line: 1, col: 75
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 76
+                      TOKEN_91(9999): "l", line: 1, col: 76
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 77
+                      TOKEN_78(9999): "_", line: 1, col: 77
                     LowercaseLetter(9999)
-                      TOKEN_70(9999): "f", line: 1, col: 78
+                      TOKEN_85(9999): "f", line: 1, col: 78
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 79
+                      TOKEN_94(9999): "o", line: 1, col: 79
                     LowercaseLetter(9999)
-                      TOKEN_82(9999): "r", line: 1, col: 80
+                      TOKEN_97(9999): "r", line: 1, col: 80
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 81
+                      TOKEN_92(9999): "m", line: 1, col: 81
                     LowercaseLetter(9999)
-                      TOKEN_85(9999): "u", line: 1, col: 82
+                      TOKEN_100(9999): "u", line: 1, col: 82
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 83
+                      TOKEN_91(9999): "l", line: 1, col: 83
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 84
+                      TOKEN_80(9999): "a", line: 1, col: 84
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 85
                 FuzzyStringOpRhs(9999)
                   ENDS(9999)
-                    TOKEN_37(9999): "E", line: 1, col: 86
-                    TOKEN_46(9999): "N", line: 1, col: 87
-                    TOKEN_36(9999): "D", line: 1, col: 88
-                    TOKEN_51(9999): "S", line: 1, col: 89
+                    TOKEN_42(9999): "ENDS", line: 1, col: 86
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 90
@@ -217,7 +198,7 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 93
+                              TOKEN_91(9999): "l", line: 1, col: 93
                       TOKEN_3(9999): """, line: 1, col: 94
                       Spaces(9999)
                         Space(9999)

--- a/tests/outputs/Filter_022.out
+++ b/tests/outputs/Filter_022.out
@@ -8,45 +8,45 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 1
+                  TOKEN_95(9999): "p", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 2
+                  TOKEN_97(9999): "r", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 3
+                  TOKEN_94(9999): "o", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 4
+                  TOKEN_99(9999): "t", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 5
+                  TOKEN_94(9999): "o", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 6
+                  TOKEN_99(9999): "t", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_89(9999): "y", line: 1, col: 7
+                  TOKEN_104(9999): "y", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 8
+                  TOKEN_95(9999): "p", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 9
+                  TOKEN_84(9999): "e", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 10
+                  TOKEN_78(9999): "_", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 11
+                  TOKEN_85(9999): "f", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 12
+                  TOKEN_94(9999): "o", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 13
+                  TOKEN_97(9999): "r", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 14
+                  TOKEN_92(9999): "m", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 15
+                  TOKEN_100(9999): "u", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 16
+                  TOKEN_91(9999): "l", line: 1, col: 16
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 17
+                  TOKEN_80(9999): "a", line: 1, col: 17
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 18
 Error: in tests/cases/Filter_022.inp: line 1:
-    unexpected token "U", expected one of "<", ">", "=", "!", "I",
-    "C", "S", "E", "H", or ":"
+    unexpected token "UNKNOWN", expected one of "<", ">", "!", "=",
+    "IS", "CONTAINS", "STARTS", "ENDS", "HAS", or ":"
 
 prototype_formula UNKNOWN
                   ^

--- a/tests/outputs/Filter_023.out
+++ b/tests/outputs/Filter_023.out
@@ -8,27 +8,27 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
 Error: in tests/cases/Filter_023.inp: line 1:
-    unexpected token "f", expected one of "<", ">", "=", "!", "I",
-    "C", "S", "E", "H", or ":"
+    unexpected token "f", expected one of "<", ">", "!", "=", "IS",
+    "CONTAINS", "STARTS", "ENDS", "HAS", or ":"
 
 chemical formula IS KNOWN 42
          ^

--- a/tests/outputs/Filter_024.out
+++ b/tests/outputs/Filter_024.out
@@ -8,43 +8,43 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17
 Error: in tests/cases/Filter_024.inp: line 1:
-    unexpected token "K", expected one of "<", ">", "=", "!", "I",
-    "C", "S", "E", "H", or ":"
+    unexpected token "KNOWN", expected one of "<", ">", "!", "=",
+    "IS", "CONTAINS", "STARTS", "ENDS", "HAS", or ":"
 
 chemical_formula KNOWN
                  ^

--- a/tests/outputs/Filter_025.out
+++ b/tests/outputs/Filter_025.out
@@ -8,60 +8,53 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17
             KnownOpRhs(9999)
               IS(9999)
-                TOKEN_41(9999): "I", line: 1, col: 18
-                TOKEN_51(9999): "S", line: 1, col: 19
+                TOKEN_48(9999): "IS", line: 1, col: 18
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 20
               KNOWN(9999)
-                TOKEN_43(9999): "K", line: 1, col: 21
-                TOKEN_46(9999): "N", line: 1, col: 22
-                TOKEN_47(9999): "O", line: 1, col: 23
-                TOKEN_55(9999): "W", line: 1, col: 24
-                TOKEN_46(9999): "N", line: 1, col: 25
+                TOKEN_51(9999): "KNOWN", line: 1, col: 21
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 26
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 27
-        TOKEN_46(9999): "N", line: 1, col: 28
-        TOKEN_36(9999): "D", line: 1, col: 29
+        TOKEN_35(9999): "AND", line: 1, col: 27
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 30
@@ -72,57 +65,50 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_80(9999): "p", line: 1, col: 31
+                    TOKEN_95(9999): "p", line: 1, col: 31
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 32
+                    TOKEN_97(9999): "r", line: 1, col: 32
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 33
+                    TOKEN_94(9999): "o", line: 1, col: 33
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 34
+                    TOKEN_99(9999): "t", line: 1, col: 34
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 35
+                    TOKEN_94(9999): "o", line: 1, col: 35
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 36
+                    TOKEN_99(9999): "t", line: 1, col: 36
                   LowercaseLetter(9999)
-                    TOKEN_89(9999): "y", line: 1, col: 37
+                    TOKEN_104(9999): "y", line: 1, col: 37
                   LowercaseLetter(9999)
-                    TOKEN_80(9999): "p", line: 1, col: 38
+                    TOKEN_95(9999): "p", line: 1, col: 38
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 39
+                    TOKEN_84(9999): "e", line: 1, col: 39
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 40
+                    TOKEN_78(9999): "_", line: 1, col: 40
                   LowercaseLetter(9999)
-                    TOKEN_70(9999): "f", line: 1, col: 41
+                    TOKEN_85(9999): "f", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 42
+                    TOKEN_94(9999): "o", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 43
+                    TOKEN_97(9999): "r", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 44
+                    TOKEN_92(9999): "m", line: 1, col: 44
                   LowercaseLetter(9999)
-                    TOKEN_85(9999): "u", line: 1, col: 45
+                    TOKEN_100(9999): "u", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 46
+                    TOKEN_91(9999): "l", line: 1, col: 46
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 47
+                    TOKEN_80(9999): "a", line: 1, col: 47
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 48
               KnownOpRhs(9999)
                 IS(9999)
-                  TOKEN_41(9999): "I", line: 1, col: 49
-                  TOKEN_51(9999): "S", line: 1, col: 50
+                  TOKEN_48(9999): "IS", line: 1, col: 49
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 51
                 UNKNOWN(9999)
-                  TOKEN_53(9999): "U", line: 1, col: 52
-                  TOKEN_46(9999): "N", line: 1, col: 53
-                  TOKEN_43(9999): "K", line: 1, col: 54
-                  TOKEN_46(9999): "N", line: 1, col: 55
-                  TOKEN_47(9999): "O", line: 1, col: 56
-                  TOKEN_55(9999): "W", line: 1, col: 57
-                  TOKEN_46(9999): "N", line: 1, col: 58
+                  TOKEN_67(9999): "UNKNOWN", line: 1, col: 52
                   Spaces(9999)
                     Space(9999)
                       nl(9999)

--- a/tests/outputs/Filter_026.out
+++ b/tests/outputs/Filter_026.out
@@ -3,36 +3,30 @@ Filter(9999)
   Expression(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
-        PredicateComparison(9999)
-          LengthComparison(9999)
-            LENGTH(9999)
-              TOKEN_44(9999): "L", line: 1, col: 1
-              TOKEN_37(9999): "E", line: 1, col: 2
-              TOKEN_46(9999): "N", line: 1, col: 3
-              TOKEN_39(9999): "G", line: 1, col: 4
-              TOKEN_52(9999): "T", line: 1, col: 5
-              TOKEN_40(9999): "H", line: 1, col: 6
-              Spaces(9999)
-                Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 7
-            Property(9999)
-              Identifier(9999)
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 8
-                LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 9
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 10
-                LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 11
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 12
-                LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 13
-                LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 14
-                LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 15
+        LengthComparison(9999)
+          LENGTH(9999)
+            TOKEN_53(9999): "LENGTH", line: 1, col: 1
+            Spaces(9999)
+              Space(9999)
+                TOKEN_1(9999): " ", line: 1, col: 7
+          Property(9999)
+            Identifier(9999)
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 8
+              LowercaseLetter(9999)
+                TOKEN_91(9999): "l", line: 1, col: 9
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 10
+              LowercaseLetter(9999)
+                TOKEN_92(9999): "m", line: 1, col: 11
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 12
+              LowercaseLetter(9999)
+                TOKEN_93(9999): "n", line: 1, col: 13
+              LowercaseLetter(9999)
+                TOKEN_99(9999): "t", line: 1, col: 14
+              LowercaseLetter(9999)
+                TOKEN_98(9999): "s", line: 1, col: 15
 Error: in tests/cases/Filter_026.inp: line 1:
     unexpected end of file
 

--- a/tests/outputs/Filter_026.out
+++ b/tests/outputs/Filter_026.out
@@ -3,7 +3,7 @@ Filter(9999)
   Expression(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
-        LengthComparison(9999)
+        PredicateComparison(9999)
           LENGTH(9999)
             TOKEN_53(9999): "LENGTH", line: 1, col: 1
             Spaces(9999)

--- a/tests/outputs/Filter_026.out
+++ b/tests/outputs/Filter_026.out
@@ -4,29 +4,30 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         PredicateComparison(9999)
-          LENGTH(9999)
-            TOKEN_53(9999): "LENGTH", line: 1, col: 1
-            Spaces(9999)
-              Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 7
-          Property(9999)
-            Identifier(9999)
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 8
-              LowercaseLetter(9999)
-                TOKEN_91(9999): "l", line: 1, col: 9
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 10
-              LowercaseLetter(9999)
-                TOKEN_92(9999): "m", line: 1, col: 11
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 12
-              LowercaseLetter(9999)
-                TOKEN_93(9999): "n", line: 1, col: 13
-              LowercaseLetter(9999)
-                TOKEN_99(9999): "t", line: 1, col: 14
-              LowercaseLetter(9999)
-                TOKEN_98(9999): "s", line: 1, col: 15
+          LengthComparison(9999)
+            LENGTH(9999)
+              TOKEN_53(9999): "LENGTH", line: 1, col: 1
+              Spaces(9999)
+                Space(9999)
+                  TOKEN_1(9999): " ", line: 1, col: 7
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 8
+                LowercaseLetter(9999)
+                  TOKEN_91(9999): "l", line: 1, col: 9
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 10
+                LowercaseLetter(9999)
+                  TOKEN_92(9999): "m", line: 1, col: 11
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 12
+                LowercaseLetter(9999)
+                  TOKEN_93(9999): "n", line: 1, col: 13
+                LowercaseLetter(9999)
+                  TOKEN_99(9999): "t", line: 1, col: 14
+                LowercaseLetter(9999)
+                  TOKEN_98(9999): "s", line: 1, col: 15
 Error: in tests/cases/Filter_026.inp: line 1:
     unexpected end of file
 

--- a/tests/outputs/Filter_027.out
+++ b/tests/outputs/Filter_027.out
@@ -3,53 +3,47 @@ Filter(9999)
   Expression(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
-        PredicateComparison(9999)
-          LengthComparison(9999)
-            LENGTH(9999)
-              TOKEN_44(9999): "L", line: 1, col: 1
-              TOKEN_37(9999): "E", line: 1, col: 2
-              TOKEN_46(9999): "N", line: 1, col: 3
-              TOKEN_39(9999): "G", line: 1, col: 4
-              TOKEN_52(9999): "T", line: 1, col: 5
-              TOKEN_40(9999): "H", line: 1, col: 6
+        LengthComparison(9999)
+          LENGTH(9999)
+            TOKEN_53(9999): "LENGTH", line: 1, col: 1
+            Spaces(9999)
+              Space(9999)
+                TOKEN_1(9999): " ", line: 1, col: 7
+          Property(9999)
+            Identifier(9999)
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 8
+              LowercaseLetter(9999)
+                TOKEN_91(9999): "l", line: 1, col: 9
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 10
+              LowercaseLetter(9999)
+                TOKEN_92(9999): "m", line: 1, col: 11
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 12
+              LowercaseLetter(9999)
+                TOKEN_93(9999): "n", line: 1, col: 13
+              LowercaseLetter(9999)
+                TOKEN_99(9999): "t", line: 1, col: 14
+              LowercaseLetter(9999)
+                TOKEN_98(9999): "s", line: 1, col: 15
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 7
-            Property(9999)
-              Identifier(9999)
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 8
-                LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 9
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 10
-                LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 11
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 12
-                LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 13
-                LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 14
-                LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 15
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 16
-            Operator(9999)
-              TOKEN_29(9999): "=", line: 1, col: 17
-              Spaces(9999)
-                Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 18
-            Value(9999)
-              String(9999)
-                TOKEN_3(9999): """, line: 1, col: 19
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_20(9999): "4", line: 1, col: 20
-                EscapedChar(9999)
-                  UnescapedChar(9999)
-                    Digit(9999)
-                      TOKEN_18(9999): "2", line: 1, col: 21
-                TOKEN_3(9999): """, line: 1, col: 22
+                  TOKEN_1(9999): " ", line: 1, col: 16
+          Operator(9999)
+            TOKEN_29(9999): "=", line: 1, col: 17
+            Spaces(9999)
+              Space(9999)
+                TOKEN_1(9999): " ", line: 1, col: 18
+          Value(9999)
+            String(9999)
+              TOKEN_3(9999): """, line: 1, col: 19
+              EscapedChar(9999)
+                UnescapedChar(9999)
+                  Digit(9999)
+                    TOKEN_20(9999): "4", line: 1, col: 20
+              EscapedChar(9999)
+                UnescapedChar(9999)
+                  Digit(9999)
+                    TOKEN_18(9999): "2", line: 1, col: 21
+              TOKEN_3(9999): """, line: 1, col: 22

--- a/tests/outputs/Filter_027.out
+++ b/tests/outputs/Filter_027.out
@@ -3,7 +3,7 @@ Filter(9999)
   Expression(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
-        LengthComparison(9999)
+        PredicateComparison(9999)
           LENGTH(9999)
             TOKEN_53(9999): "LENGTH", line: 1, col: 1
             Spaces(9999)

--- a/tests/outputs/Filter_027.out
+++ b/tests/outputs/Filter_027.out
@@ -4,46 +4,47 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         PredicateComparison(9999)
-          LENGTH(9999)
-            TOKEN_53(9999): "LENGTH", line: 1, col: 1
-            Spaces(9999)
-              Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 7
-          Property(9999)
-            Identifier(9999)
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 8
-              LowercaseLetter(9999)
-                TOKEN_91(9999): "l", line: 1, col: 9
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 10
-              LowercaseLetter(9999)
-                TOKEN_92(9999): "m", line: 1, col: 11
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 12
-              LowercaseLetter(9999)
-                TOKEN_93(9999): "n", line: 1, col: 13
-              LowercaseLetter(9999)
-                TOKEN_99(9999): "t", line: 1, col: 14
-              LowercaseLetter(9999)
-                TOKEN_98(9999): "s", line: 1, col: 15
+          LengthComparison(9999)
+            LENGTH(9999)
+              TOKEN_53(9999): "LENGTH", line: 1, col: 1
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 16
-          Operator(9999)
-            TOKEN_29(9999): "=", line: 1, col: 17
-            Spaces(9999)
-              Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 18
-          Value(9999)
-            String(9999)
-              TOKEN_3(9999): """, line: 1, col: 19
-              EscapedChar(9999)
-                UnescapedChar(9999)
-                  Digit(9999)
-                    TOKEN_20(9999): "4", line: 1, col: 20
-              EscapedChar(9999)
-                UnescapedChar(9999)
-                  Digit(9999)
-                    TOKEN_18(9999): "2", line: 1, col: 21
-              TOKEN_3(9999): """, line: 1, col: 22
+                  TOKEN_1(9999): " ", line: 1, col: 7
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 8
+                LowercaseLetter(9999)
+                  TOKEN_91(9999): "l", line: 1, col: 9
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 10
+                LowercaseLetter(9999)
+                  TOKEN_92(9999): "m", line: 1, col: 11
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 12
+                LowercaseLetter(9999)
+                  TOKEN_93(9999): "n", line: 1, col: 13
+                LowercaseLetter(9999)
+                  TOKEN_99(9999): "t", line: 1, col: 14
+                LowercaseLetter(9999)
+                  TOKEN_98(9999): "s", line: 1, col: 15
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 16
+            Operator(9999)
+              TOKEN_29(9999): "=", line: 1, col: 17
+              Spaces(9999)
+                Space(9999)
+                  TOKEN_1(9999): " ", line: 1, col: 18
+            Value(9999)
+              String(9999)
+                TOKEN_3(9999): """, line: 1, col: 19
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_20(9999): "4", line: 1, col: 20
+                EscapedChar(9999)
+                  UnescapedChar(9999)
+                    Digit(9999)
+                      TOKEN_18(9999): "2", line: 1, col: 21
+                TOKEN_3(9999): """, line: 1, col: 22

--- a/tests/outputs/Filter_028.out
+++ b/tests/outputs/Filter_028.out
@@ -8,27 +8,27 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
 Error: in tests/cases/Filter_028.inp: line 1:
-    unexpected token "L", expected one of "<", ">", "=", "!", "I",
-    "C", "S", "E", "H", or ":"
+    unexpected token "LENGTH", expected one of "<", ">", "!", "=",
+    "IS", "CONTAINS", "STARTS", "ENDS", "HAS", or ":"
 
 elements LENGTH 42
          ^

--- a/tests/outputs/Filter_029.out
+++ b/tests/outputs/Filter_029.out
@@ -4,32 +4,33 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         PredicateComparison(9999)
-          LENGTH(9999)
-            TOKEN_53(9999): "LENGTH", line: 1, col: 1
-            Spaces(9999)
-              Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 7
-          Property(9999)
-            Identifier(9999)
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 8
-              LowercaseLetter(9999)
-                TOKEN_91(9999): "l", line: 1, col: 9
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 10
-              LowercaseLetter(9999)
-                TOKEN_92(9999): "m", line: 1, col: 11
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 12
-              LowercaseLetter(9999)
-                TOKEN_93(9999): "n", line: 1, col: 13
-              LowercaseLetter(9999)
-                TOKEN_99(9999): "t", line: 1, col: 14
-              LowercaseLetter(9999)
-                TOKEN_98(9999): "s", line: 1, col: 15
+          LengthComparison(9999)
+            LENGTH(9999)
+              TOKEN_53(9999): "LENGTH", line: 1, col: 1
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 16
+                  TOKEN_1(9999): " ", line: 1, col: 7
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 8
+                LowercaseLetter(9999)
+                  TOKEN_91(9999): "l", line: 1, col: 9
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 10
+                LowercaseLetter(9999)
+                  TOKEN_92(9999): "m", line: 1, col: 11
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 12
+                LowercaseLetter(9999)
+                  TOKEN_93(9999): "n", line: 1, col: 13
+                LowercaseLetter(9999)
+                  TOKEN_99(9999): "t", line: 1, col: 14
+                LowercaseLetter(9999)
+                  TOKEN_98(9999): "s", line: 1, col: 15
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 16
 Error: in tests/cases/Filter_029.inp: line 1:
     unexpected token "IS", expected one of "<", ">", "!", or "="
 

--- a/tests/outputs/Filter_029.out
+++ b/tests/outputs/Filter_029.out
@@ -3,41 +3,35 @@ Filter(9999)
   Expression(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
-        PredicateComparison(9999)
-          LengthComparison(9999)
-            LENGTH(9999)
-              TOKEN_44(9999): "L", line: 1, col: 1
-              TOKEN_37(9999): "E", line: 1, col: 2
-              TOKEN_46(9999): "N", line: 1, col: 3
-              TOKEN_39(9999): "G", line: 1, col: 4
-              TOKEN_52(9999): "T", line: 1, col: 5
-              TOKEN_40(9999): "H", line: 1, col: 6
+        LengthComparison(9999)
+          LENGTH(9999)
+            TOKEN_53(9999): "LENGTH", line: 1, col: 1
+            Spaces(9999)
+              Space(9999)
+                TOKEN_1(9999): " ", line: 1, col: 7
+          Property(9999)
+            Identifier(9999)
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 8
+              LowercaseLetter(9999)
+                TOKEN_91(9999): "l", line: 1, col: 9
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 10
+              LowercaseLetter(9999)
+                TOKEN_92(9999): "m", line: 1, col: 11
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 12
+              LowercaseLetter(9999)
+                TOKEN_93(9999): "n", line: 1, col: 13
+              LowercaseLetter(9999)
+                TOKEN_99(9999): "t", line: 1, col: 14
+              LowercaseLetter(9999)
+                TOKEN_98(9999): "s", line: 1, col: 15
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 7
-            Property(9999)
-              Identifier(9999)
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 8
-                LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 9
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 10
-                LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 11
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 12
-                LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 13
-                LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 14
-                LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 15
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 16
+                  TOKEN_1(9999): " ", line: 1, col: 16
 Error: in tests/cases/Filter_029.inp: line 1:
-    unexpected token "I", expected one of "<", ">", "=", or "!"
+    unexpected token "IS", expected one of "<", ">", "!", or "="
 
 LENGTH elements IS 42
                 ^

--- a/tests/outputs/Filter_029.out
+++ b/tests/outputs/Filter_029.out
@@ -3,7 +3,7 @@ Filter(9999)
   Expression(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
-        LengthComparison(9999)
+        PredicateComparison(9999)
           LENGTH(9999)
             TOKEN_53(9999): "LENGTH", line: 1, col: 1
             Spaces(9999)

--- a/tests/outputs/Filter_030.out
+++ b/tests/outputs/Filter_030.out
@@ -3,41 +3,35 @@ Filter(9999)
   Expression(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
-        PredicateComparison(9999)
-          LengthComparison(9999)
-            LENGTH(9999)
-              TOKEN_44(9999): "L", line: 1, col: 1
-              TOKEN_37(9999): "E", line: 1, col: 2
-              TOKEN_46(9999): "N", line: 1, col: 3
-              TOKEN_39(9999): "G", line: 1, col: 4
-              TOKEN_52(9999): "T", line: 1, col: 5
-              TOKEN_40(9999): "H", line: 1, col: 6
+        LengthComparison(9999)
+          LENGTH(9999)
+            TOKEN_53(9999): "LENGTH", line: 1, col: 1
+            Spaces(9999)
+              Space(9999)
+                TOKEN_1(9999): " ", line: 1, col: 7
+          Property(9999)
+            Identifier(9999)
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 8
+              LowercaseLetter(9999)
+                TOKEN_91(9999): "l", line: 1, col: 9
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 10
+              LowercaseLetter(9999)
+                TOKEN_92(9999): "m", line: 1, col: 11
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 12
+              LowercaseLetter(9999)
+                TOKEN_93(9999): "n", line: 1, col: 13
+              LowercaseLetter(9999)
+                TOKEN_99(9999): "t", line: 1, col: 14
+              LowercaseLetter(9999)
+                TOKEN_98(9999): "s", line: 1, col: 15
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 7
-            Property(9999)
-              Identifier(9999)
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 8
-                LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 9
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 10
-                LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 11
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 12
-                LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 13
-                LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 14
-                LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 15
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 16
+                  TOKEN_1(9999): " ", line: 1, col: 16
 Error: in tests/cases/Filter_030.inp: line 1:
-    unexpected token "4", expected one of "<", ">", "=", or "!"
+    unexpected token "4", expected one of "<", ">", "!", or "="
 
 LENGTH elements 42
                 ^

--- a/tests/outputs/Filter_030.out
+++ b/tests/outputs/Filter_030.out
@@ -4,32 +4,33 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         PredicateComparison(9999)
-          LENGTH(9999)
-            TOKEN_53(9999): "LENGTH", line: 1, col: 1
-            Spaces(9999)
-              Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 7
-          Property(9999)
-            Identifier(9999)
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 8
-              LowercaseLetter(9999)
-                TOKEN_91(9999): "l", line: 1, col: 9
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 10
-              LowercaseLetter(9999)
-                TOKEN_92(9999): "m", line: 1, col: 11
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 12
-              LowercaseLetter(9999)
-                TOKEN_93(9999): "n", line: 1, col: 13
-              LowercaseLetter(9999)
-                TOKEN_99(9999): "t", line: 1, col: 14
-              LowercaseLetter(9999)
-                TOKEN_98(9999): "s", line: 1, col: 15
+          LengthComparison(9999)
+            LENGTH(9999)
+              TOKEN_53(9999): "LENGTH", line: 1, col: 1
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 16
+                  TOKEN_1(9999): " ", line: 1, col: 7
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 8
+                LowercaseLetter(9999)
+                  TOKEN_91(9999): "l", line: 1, col: 9
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 10
+                LowercaseLetter(9999)
+                  TOKEN_92(9999): "m", line: 1, col: 11
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 12
+                LowercaseLetter(9999)
+                  TOKEN_93(9999): "n", line: 1, col: 13
+                LowercaseLetter(9999)
+                  TOKEN_99(9999): "t", line: 1, col: 14
+                LowercaseLetter(9999)
+                  TOKEN_98(9999): "s", line: 1, col: 15
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 16
 Error: in tests/cases/Filter_030.inp: line 1:
     unexpected token "4", expected one of "<", ">", "!", or "="
 

--- a/tests/outputs/Filter_030.out
+++ b/tests/outputs/Filter_030.out
@@ -3,7 +3,7 @@ Filter(9999)
   Expression(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
-        LengthComparison(9999)
+        PredicateComparison(9999)
           LENGTH(9999)
             TOKEN_53(9999): "LENGTH", line: 1, col: 1
             Spaces(9999)

--- a/tests/outputs/Filter_031.out
+++ b/tests/outputs/Filter_031.out
@@ -3,340 +3,294 @@ Filter(9999)
   Expression(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
-        PredicateComparison(9999)
-          LengthComparison(9999)
-            LENGTH(9999)
-              TOKEN_44(9999): "L", line: 1, col: 1
-              TOKEN_37(9999): "E", line: 1, col: 2
-              TOKEN_46(9999): "N", line: 1, col: 3
-              TOKEN_39(9999): "G", line: 1, col: 4
-              TOKEN_52(9999): "T", line: 1, col: 5
-              TOKEN_40(9999): "H", line: 1, col: 6
+        LengthComparison(9999)
+          LENGTH(9999)
+            TOKEN_53(9999): "LENGTH", line: 1, col: 1
+            Spaces(9999)
+              Space(9999)
+                TOKEN_1(9999): " ", line: 1, col: 7
+          Property(9999)
+            Identifier(9999)
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 8
+              LowercaseLetter(9999)
+                TOKEN_91(9999): "l", line: 1, col: 9
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 10
+              LowercaseLetter(9999)
+                TOKEN_92(9999): "m", line: 1, col: 11
+              LowercaseLetter(9999)
+                TOKEN_84(9999): "e", line: 1, col: 12
+              LowercaseLetter(9999)
+                TOKEN_93(9999): "n", line: 1, col: 13
+              LowercaseLetter(9999)
+                TOKEN_99(9999): "t", line: 1, col: 14
+              LowercaseLetter(9999)
+                TOKEN_98(9999): "s", line: 1, col: 15
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 7
-            Property(9999)
-              Identifier(9999)
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 8
-                LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 9
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 10
-                LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 11
-                LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 12
-                LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 13
-                LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 14
-                LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 15
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 16
-            Operator(9999)
-              TOKEN_29(9999): "=", line: 1, col: 17
+                  TOKEN_1(9999): " ", line: 1, col: 16
+          Operator(9999)
+            TOKEN_29(9999): "=", line: 1, col: 17
+            Spaces(9999)
+              Space(9999)
+                TOKEN_1(9999): " ", line: 1, col: 18
+          Value(9999)
+            Number(9999)
+              Digits(9999)
+                Digit(9999)
+                  TOKEN_20(9999): "4", line: 1, col: 19
+                Digit(9999)
+                  TOKEN_18(9999): "2", line: 1, col: 20
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 18
-            Value(9999)
-              Number(9999)
-                Digits(9999)
-                  Digit(9999)
-                    TOKEN_20(9999): "4", line: 1, col: 19
-                  Digit(9999)
-                    TOKEN_18(9999): "2", line: 1, col: 20
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 21
+                  TOKEN_1(9999): " ", line: 1, col: 21
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 22
-        TOKEN_46(9999): "N", line: 1, col: 23
-        TOKEN_36(9999): "D", line: 1, col: 24
+        TOKEN_35(9999): "AND", line: 1, col: 22
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 25
       ExpressionClause(9999)
         ExpressionPhrase(9999)
-          PredicateComparison(9999)
-            LengthComparison(9999)
-              LENGTH(9999)
-                TOKEN_44(9999): "L", line: 1, col: 26
-                TOKEN_37(9999): "E", line: 1, col: 27
-                TOKEN_46(9999): "N", line: 1, col: 28
-                TOKEN_39(9999): "G", line: 1, col: 29
-                TOKEN_52(9999): "T", line: 1, col: 30
-                TOKEN_40(9999): "H", line: 1, col: 31
+          LengthComparison(9999)
+            LENGTH(9999)
+              TOKEN_53(9999): "LENGTH", line: 1, col: 26
+              Spaces(9999)
+                Space(9999)
+                  TOKEN_1(9999): " ", line: 1, col: 32
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 33
+                LowercaseLetter(9999)
+                  TOKEN_91(9999): "l", line: 1, col: 34
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 35
+                LowercaseLetter(9999)
+                  TOKEN_92(9999): "m", line: 1, col: 36
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 37
+                LowercaseLetter(9999)
+                  TOKEN_93(9999): "n", line: 1, col: 38
+                LowercaseLetter(9999)
+                  TOKEN_99(9999): "t", line: 1, col: 39
+                LowercaseLetter(9999)
+                  TOKEN_98(9999): "s", line: 1, col: 40
                 Spaces(9999)
                   Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 32
-              Property(9999)
-                Identifier(9999)
-                  LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 33
-                  LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 34
-                  LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 35
-                  LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 36
-                  LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 37
-                  LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 38
-                  LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 39
-                  LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 40
-                  Spaces(9999)
-                    Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 41
-              Operator(9999)
-                TOKEN_30(9999): ">", line: 1, col: 42
+                    TOKEN_1(9999): " ", line: 1, col: 41
+            Operator(9999)
+              TOKEN_30(9999): ">", line: 1, col: 42
+              Spaces(9999)
+                Space(9999)
+                  TOKEN_1(9999): " ", line: 1, col: 43
+            Value(9999)
+              Number(9999)
+                Digits(9999)
+                  Digit(9999)
+                    TOKEN_20(9999): "4", line: 1, col: 44
+                  Digit(9999)
+                    TOKEN_18(9999): "2", line: 1, col: 45
                 Spaces(9999)
                   Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 43
-              Value(9999)
-                Number(9999)
-                  Digits(9999)
-                    Digit(9999)
-                      TOKEN_20(9999): "4", line: 1, col: 44
-                    Digit(9999)
-                      TOKEN_18(9999): "2", line: 1, col: 45
-                  Spaces(9999)
-                    Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 46
+                    TOKEN_1(9999): " ", line: 1, col: 46
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 47
-          TOKEN_46(9999): "N", line: 1, col: 48
-          TOKEN_36(9999): "D", line: 1, col: 49
+          TOKEN_35(9999): "AND", line: 1, col: 47
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 50
         ExpressionClause(9999)
           ExpressionPhrase(9999)
-            PredicateComparison(9999)
-              LengthComparison(9999)
-                LENGTH(9999)
-                  TOKEN_44(9999): "L", line: 1, col: 51
-                  TOKEN_37(9999): "E", line: 1, col: 52
-                  TOKEN_46(9999): "N", line: 1, col: 53
-                  TOKEN_39(9999): "G", line: 1, col: 54
-                  TOKEN_52(9999): "T", line: 1, col: 55
-                  TOKEN_40(9999): "H", line: 1, col: 56
+            LengthComparison(9999)
+              LENGTH(9999)
+                TOKEN_53(9999): "LENGTH", line: 1, col: 51
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 57
+              Property(9999)
+                Identifier(9999)
+                  LowercaseLetter(9999)
+                    TOKEN_84(9999): "e", line: 1, col: 58
+                  LowercaseLetter(9999)
+                    TOKEN_91(9999): "l", line: 1, col: 59
+                  LowercaseLetter(9999)
+                    TOKEN_84(9999): "e", line: 1, col: 60
+                  LowercaseLetter(9999)
+                    TOKEN_92(9999): "m", line: 1, col: 61
+                  LowercaseLetter(9999)
+                    TOKEN_84(9999): "e", line: 1, col: 62
+                  LowercaseLetter(9999)
+                    TOKEN_93(9999): "n", line: 1, col: 63
+                  LowercaseLetter(9999)
+                    TOKEN_99(9999): "t", line: 1, col: 64
+                  LowercaseLetter(9999)
+                    TOKEN_98(9999): "s", line: 1, col: 65
                   Spaces(9999)
                     Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 57
-                Property(9999)
-                  Identifier(9999)
-                    LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 58
-                    LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 59
-                    LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 60
-                    LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 61
-                    LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 62
-                    LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 63
-                    LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 64
-                    LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 65
-                    Spaces(9999)
-                      Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 66
-                Operator(9999)
-                  TOKEN_28(9999): "<", line: 1, col: 67
+                      TOKEN_1(9999): " ", line: 1, col: 66
+              Operator(9999)
+                TOKEN_28(9999): "<", line: 1, col: 67
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 68
+              Value(9999)
+                Number(9999)
+                  Digits(9999)
+                    Digit(9999)
+                      TOKEN_20(9999): "4", line: 1, col: 69
+                    Digit(9999)
+                      TOKEN_18(9999): "2", line: 1, col: 70
                   Spaces(9999)
                     Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 68
-                Value(9999)
-                  Number(9999)
-                    Digits(9999)
-                      Digit(9999)
-                        TOKEN_20(9999): "4", line: 1, col: 69
-                      Digit(9999)
-                        TOKEN_18(9999): "2", line: 1, col: 70
-                    Spaces(9999)
-                      Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 71
+                      TOKEN_1(9999): " ", line: 1, col: 71
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 72
-            TOKEN_46(9999): "N", line: 1, col: 73
-            TOKEN_36(9999): "D", line: 1, col: 74
+            TOKEN_35(9999): "AND", line: 1, col: 72
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 75
           ExpressionClause(9999)
             ExpressionPhrase(9999)
-              PredicateComparison(9999)
-                LengthComparison(9999)
-                  LENGTH(9999)
-                    TOKEN_44(9999): "L", line: 1, col: 76
-                    TOKEN_37(9999): "E", line: 1, col: 77
-                    TOKEN_46(9999): "N", line: 1, col: 78
-                    TOKEN_39(9999): "G", line: 1, col: 79
-                    TOKEN_52(9999): "T", line: 1, col: 80
-                    TOKEN_40(9999): "H", line: 1, col: 81
+              LengthComparison(9999)
+                LENGTH(9999)
+                  TOKEN_53(9999): "LENGTH", line: 1, col: 76
+                  Spaces(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 82
+                Property(9999)
+                  Identifier(9999)
+                    LowercaseLetter(9999)
+                      TOKEN_84(9999): "e", line: 1, col: 83
+                    LowercaseLetter(9999)
+                      TOKEN_91(9999): "l", line: 1, col: 84
+                    LowercaseLetter(9999)
+                      TOKEN_84(9999): "e", line: 1, col: 85
+                    LowercaseLetter(9999)
+                      TOKEN_92(9999): "m", line: 1, col: 86
+                    LowercaseLetter(9999)
+                      TOKEN_84(9999): "e", line: 1, col: 87
+                    LowercaseLetter(9999)
+                      TOKEN_93(9999): "n", line: 1, col: 88
+                    LowercaseLetter(9999)
+                      TOKEN_99(9999): "t", line: 1, col: 89
+                    LowercaseLetter(9999)
+                      TOKEN_98(9999): "s", line: 1, col: 90
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 82
-                  Property(9999)
-                    Identifier(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 83
-                      LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 84
-                      LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 85
-                      LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 86
-                      LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 87
-                      LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 88
-                      LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 89
-                      LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 90
-                      Spaces(9999)
-                        Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 91
-                  Operator(9999)
-                    TOKEN_2(9999): "!", line: 1, col: 92
-                    TOKEN_29(9999): "=", line: 1, col: 93
+                        TOKEN_1(9999): " ", line: 1, col: 91
+                Operator(9999)
+                  TOKEN_2(9999): "!", line: 1, col: 92
+                  TOKEN_29(9999): "=", line: 1, col: 93
+                  Spaces(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 94
+                Value(9999)
+                  Number(9999)
+                    Digits(9999)
+                      Digit(9999)
+                        TOKEN_20(9999): "4", line: 1, col: 95
+                      Digit(9999)
+                        TOKEN_18(9999): "2", line: 1, col: 96
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 94
-                  Value(9999)
-                    Number(9999)
-                      Digits(9999)
-                        Digit(9999)
-                          TOKEN_20(9999): "4", line: 1, col: 95
-                        Digit(9999)
-                          TOKEN_18(9999): "2", line: 1, col: 96
-                      Spaces(9999)
-                        Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 97
+                        TOKEN_1(9999): " ", line: 1, col: 97
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 98
-              TOKEN_46(9999): "N", line: 1, col: 99
-              TOKEN_36(9999): "D", line: 1, col: 100
+              TOKEN_35(9999): "AND", line: 1, col: 98
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 101
             ExpressionClause(9999)
               ExpressionPhrase(9999)
-                PredicateComparison(9999)
-                  LengthComparison(9999)
-                    LENGTH(9999)
-                      TOKEN_44(9999): "L", line: 1, col: 102
-                      TOKEN_37(9999): "E", line: 1, col: 103
-                      TOKEN_46(9999): "N", line: 1, col: 104
-                      TOKEN_39(9999): "G", line: 1, col: 105
-                      TOKEN_52(9999): "T", line: 1, col: 106
-                      TOKEN_40(9999): "H", line: 1, col: 107
+                LengthComparison(9999)
+                  LENGTH(9999)
+                    TOKEN_53(9999): "LENGTH", line: 1, col: 102
+                    Spaces(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 108
+                  Property(9999)
+                    Identifier(9999)
+                      LowercaseLetter(9999)
+                        TOKEN_84(9999): "e", line: 1, col: 109
+                      LowercaseLetter(9999)
+                        TOKEN_91(9999): "l", line: 1, col: 110
+                      LowercaseLetter(9999)
+                        TOKEN_84(9999): "e", line: 1, col: 111
+                      LowercaseLetter(9999)
+                        TOKEN_92(9999): "m", line: 1, col: 112
+                      LowercaseLetter(9999)
+                        TOKEN_84(9999): "e", line: 1, col: 113
+                      LowercaseLetter(9999)
+                        TOKEN_93(9999): "n", line: 1, col: 114
+                      LowercaseLetter(9999)
+                        TOKEN_99(9999): "t", line: 1, col: 115
+                      LowercaseLetter(9999)
+                        TOKEN_98(9999): "s", line: 1, col: 116
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 108
-                    Property(9999)
-                      Identifier(9999)
-                        LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 109
-                        LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 110
-                        LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 111
-                        LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 112
-                        LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 113
-                        LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 114
-                        LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 115
-                        LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 116
-                        Spaces(9999)
-                          Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 117
-                    Operator(9999)
-                      TOKEN_30(9999): ">", line: 1, col: 118
-                      TOKEN_29(9999): "=", line: 1, col: 119
+                          TOKEN_1(9999): " ", line: 1, col: 117
+                  Operator(9999)
+                    TOKEN_30(9999): ">", line: 1, col: 118
+                    TOKEN_29(9999): "=", line: 1, col: 119
+                    Spaces(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 120
+                  Value(9999)
+                    Number(9999)
+                      Digits(9999)
+                        Digit(9999)
+                          TOKEN_20(9999): "4", line: 1, col: 121
+                        Digit(9999)
+                          TOKEN_18(9999): "2", line: 1, col: 122
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 120
-                    Value(9999)
-                      Number(9999)
-                        Digits(9999)
-                          Digit(9999)
-                            TOKEN_20(9999): "4", line: 1, col: 121
-                          Digit(9999)
-                            TOKEN_18(9999): "2", line: 1, col: 122
-                        Spaces(9999)
-                          Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 123
+                          TOKEN_1(9999): " ", line: 1, col: 123
               AND(9999)
-                TOKEN_33(9999): "A", line: 1, col: 124
-                TOKEN_46(9999): "N", line: 1, col: 125
-                TOKEN_36(9999): "D", line: 1, col: 126
+                TOKEN_35(9999): "AND", line: 1, col: 124
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 127
               ExpressionClause(9999)
                 ExpressionPhrase(9999)
-                  PredicateComparison(9999)
-                    LengthComparison(9999)
-                      LENGTH(9999)
-                        TOKEN_44(9999): "L", line: 1, col: 128
-                        TOKEN_37(9999): "E", line: 1, col: 129
-                        TOKEN_46(9999): "N", line: 1, col: 130
-                        TOKEN_39(9999): "G", line: 1, col: 131
-                        TOKEN_52(9999): "T", line: 1, col: 132
-                        TOKEN_40(9999): "H", line: 1, col: 133
+                  LengthComparison(9999)
+                    LENGTH(9999)
+                      TOKEN_53(9999): "LENGTH", line: 1, col: 128
+                      Spaces(9999)
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 134
+                    Property(9999)
+                      Identifier(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_84(9999): "e", line: 1, col: 135
+                        LowercaseLetter(9999)
+                          TOKEN_91(9999): "l", line: 1, col: 136
+                        LowercaseLetter(9999)
+                          TOKEN_84(9999): "e", line: 1, col: 137
+                        LowercaseLetter(9999)
+                          TOKEN_92(9999): "m", line: 1, col: 138
+                        LowercaseLetter(9999)
+                          TOKEN_84(9999): "e", line: 1, col: 139
+                        LowercaseLetter(9999)
+                          TOKEN_93(9999): "n", line: 1, col: 140
+                        LowercaseLetter(9999)
+                          TOKEN_99(9999): "t", line: 1, col: 141
+                        LowercaseLetter(9999)
+                          TOKEN_98(9999): "s", line: 1, col: 142
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 134
-                      Property(9999)
-                        Identifier(9999)
-                          LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 135
-                          LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 136
-                          LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 137
-                          LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 138
-                          LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 139
-                          LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 140
-                          LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 141
-                          LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 142
-                          Spaces(9999)
-                            Space(9999)
-                              TOKEN_1(9999): " ", line: 1, col: 143
-                      Operator(9999)
-                        TOKEN_28(9999): "<", line: 1, col: 144
-                        TOKEN_29(9999): "=", line: 1, col: 145
+                            TOKEN_1(9999): " ", line: 1, col: 143
+                    Operator(9999)
+                      TOKEN_28(9999): "<", line: 1, col: 144
+                      TOKEN_29(9999): "=", line: 1, col: 145
+                      Spaces(9999)
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 146
+                    Value(9999)
+                      Number(9999)
+                        Digits(9999)
+                          Digit(9999)
+                            TOKEN_20(9999): "4", line: 1, col: 147
+                          Digit(9999)
+                            TOKEN_18(9999): "2", line: 1, col: 148
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 146
-                      Value(9999)
-                        Number(9999)
-                          Digits(9999)
-                            Digit(9999)
-                              TOKEN_20(9999): "4", line: 1, col: 147
-                            Digit(9999)
-                              TOKEN_18(9999): "2", line: 1, col: 148
-                          Spaces(9999)
-                            Space(9999)
-                              nl(9999)
-                                SPECIAL_1(9999): "(...)", line: 1, col: 149
+                            nl(9999)
+                              SPECIAL_1(9999): "(...)", line: 1, col: 149

--- a/tests/outputs/Filter_031.out
+++ b/tests/outputs/Filter_031.out
@@ -4,47 +4,48 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         PredicateComparison(9999)
-          LENGTH(9999)
-            TOKEN_53(9999): "LENGTH", line: 1, col: 1
-            Spaces(9999)
-              Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 7
-          Property(9999)
-            Identifier(9999)
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 8
-              LowercaseLetter(9999)
-                TOKEN_91(9999): "l", line: 1, col: 9
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 10
-              LowercaseLetter(9999)
-                TOKEN_92(9999): "m", line: 1, col: 11
-              LowercaseLetter(9999)
-                TOKEN_84(9999): "e", line: 1, col: 12
-              LowercaseLetter(9999)
-                TOKEN_93(9999): "n", line: 1, col: 13
-              LowercaseLetter(9999)
-                TOKEN_99(9999): "t", line: 1, col: 14
-              LowercaseLetter(9999)
-                TOKEN_98(9999): "s", line: 1, col: 15
+          LengthComparison(9999)
+            LENGTH(9999)
+              TOKEN_53(9999): "LENGTH", line: 1, col: 1
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 16
-          Operator(9999)
-            TOKEN_29(9999): "=", line: 1, col: 17
-            Spaces(9999)
-              Space(9999)
-                TOKEN_1(9999): " ", line: 1, col: 18
-          Value(9999)
-            Number(9999)
-              Digits(9999)
-                Digit(9999)
-                  TOKEN_20(9999): "4", line: 1, col: 19
-                Digit(9999)
-                  TOKEN_18(9999): "2", line: 1, col: 20
+                  TOKEN_1(9999): " ", line: 1, col: 7
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 8
+                LowercaseLetter(9999)
+                  TOKEN_91(9999): "l", line: 1, col: 9
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 10
+                LowercaseLetter(9999)
+                  TOKEN_92(9999): "m", line: 1, col: 11
+                LowercaseLetter(9999)
+                  TOKEN_84(9999): "e", line: 1, col: 12
+                LowercaseLetter(9999)
+                  TOKEN_93(9999): "n", line: 1, col: 13
+                LowercaseLetter(9999)
+                  TOKEN_99(9999): "t", line: 1, col: 14
+                LowercaseLetter(9999)
+                  TOKEN_98(9999): "s", line: 1, col: 15
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 16
+            Operator(9999)
+              TOKEN_29(9999): "=", line: 1, col: 17
               Spaces(9999)
                 Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 21
+                  TOKEN_1(9999): " ", line: 1, col: 18
+            Value(9999)
+              Number(9999)
+                Digits(9999)
+                  Digit(9999)
+                    TOKEN_20(9999): "4", line: 1, col: 19
+                  Digit(9999)
+                    TOKEN_18(9999): "2", line: 1, col: 20
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 21
       AND(9999)
         TOKEN_35(9999): "AND", line: 1, col: 22
         Spaces(9999)
@@ -53,47 +54,48 @@ Filter(9999)
       ExpressionClause(9999)
         ExpressionPhrase(9999)
           PredicateComparison(9999)
-            LENGTH(9999)
-              TOKEN_53(9999): "LENGTH", line: 1, col: 26
-              Spaces(9999)
-                Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 32
-            Property(9999)
-              Identifier(9999)
-                LowercaseLetter(9999)
-                  TOKEN_84(9999): "e", line: 1, col: 33
-                LowercaseLetter(9999)
-                  TOKEN_91(9999): "l", line: 1, col: 34
-                LowercaseLetter(9999)
-                  TOKEN_84(9999): "e", line: 1, col: 35
-                LowercaseLetter(9999)
-                  TOKEN_92(9999): "m", line: 1, col: 36
-                LowercaseLetter(9999)
-                  TOKEN_84(9999): "e", line: 1, col: 37
-                LowercaseLetter(9999)
-                  TOKEN_93(9999): "n", line: 1, col: 38
-                LowercaseLetter(9999)
-                  TOKEN_99(9999): "t", line: 1, col: 39
-                LowercaseLetter(9999)
-                  TOKEN_98(9999): "s", line: 1, col: 40
+            LengthComparison(9999)
+              LENGTH(9999)
+                TOKEN_53(9999): "LENGTH", line: 1, col: 26
                 Spaces(9999)
                   Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 41
-            Operator(9999)
-              TOKEN_30(9999): ">", line: 1, col: 42
-              Spaces(9999)
-                Space(9999)
-                  TOKEN_1(9999): " ", line: 1, col: 43
-            Value(9999)
-              Number(9999)
-                Digits(9999)
-                  Digit(9999)
-                    TOKEN_20(9999): "4", line: 1, col: 44
-                  Digit(9999)
-                    TOKEN_18(9999): "2", line: 1, col: 45
+                    TOKEN_1(9999): " ", line: 1, col: 32
+              Property(9999)
+                Identifier(9999)
+                  LowercaseLetter(9999)
+                    TOKEN_84(9999): "e", line: 1, col: 33
+                  LowercaseLetter(9999)
+                    TOKEN_91(9999): "l", line: 1, col: 34
+                  LowercaseLetter(9999)
+                    TOKEN_84(9999): "e", line: 1, col: 35
+                  LowercaseLetter(9999)
+                    TOKEN_92(9999): "m", line: 1, col: 36
+                  LowercaseLetter(9999)
+                    TOKEN_84(9999): "e", line: 1, col: 37
+                  LowercaseLetter(9999)
+                    TOKEN_93(9999): "n", line: 1, col: 38
+                  LowercaseLetter(9999)
+                    TOKEN_99(9999): "t", line: 1, col: 39
+                  LowercaseLetter(9999)
+                    TOKEN_98(9999): "s", line: 1, col: 40
+                  Spaces(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 41
+              Operator(9999)
+                TOKEN_30(9999): ">", line: 1, col: 42
                 Spaces(9999)
                   Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 46
+                    TOKEN_1(9999): " ", line: 1, col: 43
+              Value(9999)
+                Number(9999)
+                  Digits(9999)
+                    Digit(9999)
+                      TOKEN_20(9999): "4", line: 1, col: 44
+                    Digit(9999)
+                      TOKEN_18(9999): "2", line: 1, col: 45
+                  Spaces(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 46
         AND(9999)
           TOKEN_35(9999): "AND", line: 1, col: 47
           Spaces(9999)
@@ -102,47 +104,48 @@ Filter(9999)
         ExpressionClause(9999)
           ExpressionPhrase(9999)
             PredicateComparison(9999)
-              LENGTH(9999)
-                TOKEN_53(9999): "LENGTH", line: 1, col: 51
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 57
-              Property(9999)
-                Identifier(9999)
-                  LowercaseLetter(9999)
-                    TOKEN_84(9999): "e", line: 1, col: 58
-                  LowercaseLetter(9999)
-                    TOKEN_91(9999): "l", line: 1, col: 59
-                  LowercaseLetter(9999)
-                    TOKEN_84(9999): "e", line: 1, col: 60
-                  LowercaseLetter(9999)
-                    TOKEN_92(9999): "m", line: 1, col: 61
-                  LowercaseLetter(9999)
-                    TOKEN_84(9999): "e", line: 1, col: 62
-                  LowercaseLetter(9999)
-                    TOKEN_93(9999): "n", line: 1, col: 63
-                  LowercaseLetter(9999)
-                    TOKEN_99(9999): "t", line: 1, col: 64
-                  LowercaseLetter(9999)
-                    TOKEN_98(9999): "s", line: 1, col: 65
+              LengthComparison(9999)
+                LENGTH(9999)
+                  TOKEN_53(9999): "LENGTH", line: 1, col: 51
                   Spaces(9999)
                     Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 66
-              Operator(9999)
-                TOKEN_28(9999): "<", line: 1, col: 67
-                Spaces(9999)
-                  Space(9999)
-                    TOKEN_1(9999): " ", line: 1, col: 68
-              Value(9999)
-                Number(9999)
-                  Digits(9999)
-                    Digit(9999)
-                      TOKEN_20(9999): "4", line: 1, col: 69
-                    Digit(9999)
-                      TOKEN_18(9999): "2", line: 1, col: 70
+                      TOKEN_1(9999): " ", line: 1, col: 57
+                Property(9999)
+                  Identifier(9999)
+                    LowercaseLetter(9999)
+                      TOKEN_84(9999): "e", line: 1, col: 58
+                    LowercaseLetter(9999)
+                      TOKEN_91(9999): "l", line: 1, col: 59
+                    LowercaseLetter(9999)
+                      TOKEN_84(9999): "e", line: 1, col: 60
+                    LowercaseLetter(9999)
+                      TOKEN_92(9999): "m", line: 1, col: 61
+                    LowercaseLetter(9999)
+                      TOKEN_84(9999): "e", line: 1, col: 62
+                    LowercaseLetter(9999)
+                      TOKEN_93(9999): "n", line: 1, col: 63
+                    LowercaseLetter(9999)
+                      TOKEN_99(9999): "t", line: 1, col: 64
+                    LowercaseLetter(9999)
+                      TOKEN_98(9999): "s", line: 1, col: 65
+                    Spaces(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 66
+                Operator(9999)
+                  TOKEN_28(9999): "<", line: 1, col: 67
                   Spaces(9999)
                     Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 71
+                      TOKEN_1(9999): " ", line: 1, col: 68
+                Value(9999)
+                  Number(9999)
+                    Digits(9999)
+                      Digit(9999)
+                        TOKEN_20(9999): "4", line: 1, col: 69
+                      Digit(9999)
+                        TOKEN_18(9999): "2", line: 1, col: 70
+                    Spaces(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 71
           AND(9999)
             TOKEN_35(9999): "AND", line: 1, col: 72
             Spaces(9999)
@@ -151,48 +154,49 @@ Filter(9999)
           ExpressionClause(9999)
             ExpressionPhrase(9999)
               PredicateComparison(9999)
-                LENGTH(9999)
-                  TOKEN_53(9999): "LENGTH", line: 1, col: 76
-                  Spaces(9999)
-                    Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 82
-                Property(9999)
-                  Identifier(9999)
-                    LowercaseLetter(9999)
-                      TOKEN_84(9999): "e", line: 1, col: 83
-                    LowercaseLetter(9999)
-                      TOKEN_91(9999): "l", line: 1, col: 84
-                    LowercaseLetter(9999)
-                      TOKEN_84(9999): "e", line: 1, col: 85
-                    LowercaseLetter(9999)
-                      TOKEN_92(9999): "m", line: 1, col: 86
-                    LowercaseLetter(9999)
-                      TOKEN_84(9999): "e", line: 1, col: 87
-                    LowercaseLetter(9999)
-                      TOKEN_93(9999): "n", line: 1, col: 88
-                    LowercaseLetter(9999)
-                      TOKEN_99(9999): "t", line: 1, col: 89
-                    LowercaseLetter(9999)
-                      TOKEN_98(9999): "s", line: 1, col: 90
+                LengthComparison(9999)
+                  LENGTH(9999)
+                    TOKEN_53(9999): "LENGTH", line: 1, col: 76
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 91
-                Operator(9999)
-                  TOKEN_2(9999): "!", line: 1, col: 92
-                  TOKEN_29(9999): "=", line: 1, col: 93
-                  Spaces(9999)
-                    Space(9999)
-                      TOKEN_1(9999): " ", line: 1, col: 94
-                Value(9999)
-                  Number(9999)
-                    Digits(9999)
-                      Digit(9999)
-                        TOKEN_20(9999): "4", line: 1, col: 95
-                      Digit(9999)
-                        TOKEN_18(9999): "2", line: 1, col: 96
+                        TOKEN_1(9999): " ", line: 1, col: 82
+                  Property(9999)
+                    Identifier(9999)
+                      LowercaseLetter(9999)
+                        TOKEN_84(9999): "e", line: 1, col: 83
+                      LowercaseLetter(9999)
+                        TOKEN_91(9999): "l", line: 1, col: 84
+                      LowercaseLetter(9999)
+                        TOKEN_84(9999): "e", line: 1, col: 85
+                      LowercaseLetter(9999)
+                        TOKEN_92(9999): "m", line: 1, col: 86
+                      LowercaseLetter(9999)
+                        TOKEN_84(9999): "e", line: 1, col: 87
+                      LowercaseLetter(9999)
+                        TOKEN_93(9999): "n", line: 1, col: 88
+                      LowercaseLetter(9999)
+                        TOKEN_99(9999): "t", line: 1, col: 89
+                      LowercaseLetter(9999)
+                        TOKEN_98(9999): "s", line: 1, col: 90
+                      Spaces(9999)
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 91
+                  Operator(9999)
+                    TOKEN_2(9999): "!", line: 1, col: 92
+                    TOKEN_29(9999): "=", line: 1, col: 93
                     Spaces(9999)
                       Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 97
+                        TOKEN_1(9999): " ", line: 1, col: 94
+                  Value(9999)
+                    Number(9999)
+                      Digits(9999)
+                        Digit(9999)
+                          TOKEN_20(9999): "4", line: 1, col: 95
+                        Digit(9999)
+                          TOKEN_18(9999): "2", line: 1, col: 96
+                      Spaces(9999)
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 97
             AND(9999)
               TOKEN_35(9999): "AND", line: 1, col: 98
               Spaces(9999)
@@ -201,48 +205,49 @@ Filter(9999)
             ExpressionClause(9999)
               ExpressionPhrase(9999)
                 PredicateComparison(9999)
-                  LENGTH(9999)
-                    TOKEN_53(9999): "LENGTH", line: 1, col: 102
-                    Spaces(9999)
-                      Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 108
-                  Property(9999)
-                    Identifier(9999)
-                      LowercaseLetter(9999)
-                        TOKEN_84(9999): "e", line: 1, col: 109
-                      LowercaseLetter(9999)
-                        TOKEN_91(9999): "l", line: 1, col: 110
-                      LowercaseLetter(9999)
-                        TOKEN_84(9999): "e", line: 1, col: 111
-                      LowercaseLetter(9999)
-                        TOKEN_92(9999): "m", line: 1, col: 112
-                      LowercaseLetter(9999)
-                        TOKEN_84(9999): "e", line: 1, col: 113
-                      LowercaseLetter(9999)
-                        TOKEN_93(9999): "n", line: 1, col: 114
-                      LowercaseLetter(9999)
-                        TOKEN_99(9999): "t", line: 1, col: 115
-                      LowercaseLetter(9999)
-                        TOKEN_98(9999): "s", line: 1, col: 116
+                  LengthComparison(9999)
+                    LENGTH(9999)
+                      TOKEN_53(9999): "LENGTH", line: 1, col: 102
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 117
-                  Operator(9999)
-                    TOKEN_30(9999): ">", line: 1, col: 118
-                    TOKEN_29(9999): "=", line: 1, col: 119
-                    Spaces(9999)
-                      Space(9999)
-                        TOKEN_1(9999): " ", line: 1, col: 120
-                  Value(9999)
-                    Number(9999)
-                      Digits(9999)
-                        Digit(9999)
-                          TOKEN_20(9999): "4", line: 1, col: 121
-                        Digit(9999)
-                          TOKEN_18(9999): "2", line: 1, col: 122
+                          TOKEN_1(9999): " ", line: 1, col: 108
+                    Property(9999)
+                      Identifier(9999)
+                        LowercaseLetter(9999)
+                          TOKEN_84(9999): "e", line: 1, col: 109
+                        LowercaseLetter(9999)
+                          TOKEN_91(9999): "l", line: 1, col: 110
+                        LowercaseLetter(9999)
+                          TOKEN_84(9999): "e", line: 1, col: 111
+                        LowercaseLetter(9999)
+                          TOKEN_92(9999): "m", line: 1, col: 112
+                        LowercaseLetter(9999)
+                          TOKEN_84(9999): "e", line: 1, col: 113
+                        LowercaseLetter(9999)
+                          TOKEN_93(9999): "n", line: 1, col: 114
+                        LowercaseLetter(9999)
+                          TOKEN_99(9999): "t", line: 1, col: 115
+                        LowercaseLetter(9999)
+                          TOKEN_98(9999): "s", line: 1, col: 116
+                        Spaces(9999)
+                          Space(9999)
+                            TOKEN_1(9999): " ", line: 1, col: 117
+                    Operator(9999)
+                      TOKEN_30(9999): ">", line: 1, col: 118
+                      TOKEN_29(9999): "=", line: 1, col: 119
                       Spaces(9999)
                         Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 123
+                          TOKEN_1(9999): " ", line: 1, col: 120
+                    Value(9999)
+                      Number(9999)
+                        Digits(9999)
+                          Digit(9999)
+                            TOKEN_20(9999): "4", line: 1, col: 121
+                          Digit(9999)
+                            TOKEN_18(9999): "2", line: 1, col: 122
+                        Spaces(9999)
+                          Space(9999)
+                            TOKEN_1(9999): " ", line: 1, col: 123
               AND(9999)
                 TOKEN_35(9999): "AND", line: 1, col: 124
                 Spaces(9999)
@@ -251,46 +256,47 @@ Filter(9999)
               ExpressionClause(9999)
                 ExpressionPhrase(9999)
                   PredicateComparison(9999)
-                    LENGTH(9999)
-                      TOKEN_53(9999): "LENGTH", line: 1, col: 128
-                      Spaces(9999)
-                        Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 134
-                    Property(9999)
-                      Identifier(9999)
-                        LowercaseLetter(9999)
-                          TOKEN_84(9999): "e", line: 1, col: 135
-                        LowercaseLetter(9999)
-                          TOKEN_91(9999): "l", line: 1, col: 136
-                        LowercaseLetter(9999)
-                          TOKEN_84(9999): "e", line: 1, col: 137
-                        LowercaseLetter(9999)
-                          TOKEN_92(9999): "m", line: 1, col: 138
-                        LowercaseLetter(9999)
-                          TOKEN_84(9999): "e", line: 1, col: 139
-                        LowercaseLetter(9999)
-                          TOKEN_93(9999): "n", line: 1, col: 140
-                        LowercaseLetter(9999)
-                          TOKEN_99(9999): "t", line: 1, col: 141
-                        LowercaseLetter(9999)
-                          TOKEN_98(9999): "s", line: 1, col: 142
+                    LengthComparison(9999)
+                      LENGTH(9999)
+                        TOKEN_53(9999): "LENGTH", line: 1, col: 128
                         Spaces(9999)
                           Space(9999)
-                            TOKEN_1(9999): " ", line: 1, col: 143
-                    Operator(9999)
-                      TOKEN_28(9999): "<", line: 1, col: 144
-                      TOKEN_29(9999): "=", line: 1, col: 145
-                      Spaces(9999)
-                        Space(9999)
-                          TOKEN_1(9999): " ", line: 1, col: 146
-                    Value(9999)
-                      Number(9999)
-                        Digits(9999)
-                          Digit(9999)
-                            TOKEN_20(9999): "4", line: 1, col: 147
-                          Digit(9999)
-                            TOKEN_18(9999): "2", line: 1, col: 148
+                            TOKEN_1(9999): " ", line: 1, col: 134
+                      Property(9999)
+                        Identifier(9999)
+                          LowercaseLetter(9999)
+                            TOKEN_84(9999): "e", line: 1, col: 135
+                          LowercaseLetter(9999)
+                            TOKEN_91(9999): "l", line: 1, col: 136
+                          LowercaseLetter(9999)
+                            TOKEN_84(9999): "e", line: 1, col: 137
+                          LowercaseLetter(9999)
+                            TOKEN_92(9999): "m", line: 1, col: 138
+                          LowercaseLetter(9999)
+                            TOKEN_84(9999): "e", line: 1, col: 139
+                          LowercaseLetter(9999)
+                            TOKEN_93(9999): "n", line: 1, col: 140
+                          LowercaseLetter(9999)
+                            TOKEN_99(9999): "t", line: 1, col: 141
+                          LowercaseLetter(9999)
+                            TOKEN_98(9999): "s", line: 1, col: 142
+                          Spaces(9999)
+                            Space(9999)
+                              TOKEN_1(9999): " ", line: 1, col: 143
+                      Operator(9999)
+                        TOKEN_28(9999): "<", line: 1, col: 144
+                        TOKEN_29(9999): "=", line: 1, col: 145
                         Spaces(9999)
                           Space(9999)
-                            nl(9999)
-                              SPECIAL_1(9999): "(...)", line: 1, col: 149
+                            TOKEN_1(9999): " ", line: 1, col: 146
+                      Value(9999)
+                        Number(9999)
+                          Digits(9999)
+                            Digit(9999)
+                              TOKEN_20(9999): "4", line: 1, col: 147
+                            Digit(9999)
+                              TOKEN_18(9999): "2", line: 1, col: 148
+                          Spaces(9999)
+                            Space(9999)
+                              nl(9999)
+                                SPECIAL_1(9999): "(...)", line: 1, col: 149

--- a/tests/outputs/Filter_031.out
+++ b/tests/outputs/Filter_031.out
@@ -3,7 +3,7 @@ Filter(9999)
   Expression(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
-        LengthComparison(9999)
+        PredicateComparison(9999)
           LENGTH(9999)
             TOKEN_53(9999): "LENGTH", line: 1, col: 1
             Spaces(9999)
@@ -52,7 +52,7 @@ Filter(9999)
             TOKEN_1(9999): " ", line: 1, col: 25
       ExpressionClause(9999)
         ExpressionPhrase(9999)
-          LengthComparison(9999)
+          PredicateComparison(9999)
             LENGTH(9999)
               TOKEN_53(9999): "LENGTH", line: 1, col: 26
               Spaces(9999)
@@ -101,7 +101,7 @@ Filter(9999)
               TOKEN_1(9999): " ", line: 1, col: 50
         ExpressionClause(9999)
           ExpressionPhrase(9999)
-            LengthComparison(9999)
+            PredicateComparison(9999)
               LENGTH(9999)
                 TOKEN_53(9999): "LENGTH", line: 1, col: 51
                 Spaces(9999)
@@ -150,7 +150,7 @@ Filter(9999)
                 TOKEN_1(9999): " ", line: 1, col: 75
           ExpressionClause(9999)
             ExpressionPhrase(9999)
-              LengthComparison(9999)
+              PredicateComparison(9999)
                 LENGTH(9999)
                   TOKEN_53(9999): "LENGTH", line: 1, col: 76
                   Spaces(9999)
@@ -200,7 +200,7 @@ Filter(9999)
                   TOKEN_1(9999): " ", line: 1, col: 101
             ExpressionClause(9999)
               ExpressionPhrase(9999)
-                LengthComparison(9999)
+                PredicateComparison(9999)
                   LENGTH(9999)
                     TOKEN_53(9999): "LENGTH", line: 1, col: 102
                     Spaces(9999)
@@ -250,7 +250,7 @@ Filter(9999)
                     TOKEN_1(9999): " ", line: 1, col: 127
               ExpressionClause(9999)
                 ExpressionPhrase(9999)
-                  LengthComparison(9999)
+                  PredicateComparison(9999)
                     LENGTH(9999)
                       TOKEN_53(9999): "LENGTH", line: 1, col: 128
                       Spaces(9999)

--- a/tests/outputs/Filter_032.out
+++ b/tests/outputs/Filter_032.out
@@ -8,38 +8,36 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
             SetOpRhs(9999)
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 10
-                TOKEN_33(9999): "A", line: 1, col: 11
-                TOKEN_51(9999): "S", line: 1, col: 12
+                TOKEN_46(9999): "HAS", line: 1, col: 10
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 13
 Error: in tests/cases/Filter_032.inp: line 1:
-    unexpected token "I", expected one of "<", ">", "=", "!", """,
+    unexpected token "IS", expected one of "<", ">", "!", "=", """,
     "+", "-", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".",
     "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
     "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
-    "_", "A", or "O"
+    "_", "ALL", "ANY", or "ONLY"
 
 elements HAS IS "H"
              ^

--- a/tests/outputs/Filter_033.out
+++ b/tests/outputs/Filter_033.out
@@ -8,29 +8,27 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
             SetOpRhs(9999)
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 10
-                TOKEN_33(9999): "A", line: 1, col: 11
-                TOKEN_51(9999): "S", line: 1, col: 12
+                TOKEN_46(9999): "HAS", line: 1, col: 10
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 13
@@ -41,15 +39,13 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_40(9999): "H", line: 1, col: 15
+                          TOKEN_45(9999): "H", line: 1, col: 15
                   TOKEN_3(9999): """, line: 1, col: 16
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 17
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 18
-        TOKEN_46(9999): "N", line: 1, col: 19
-        TOKEN_36(9999): "D", line: 1, col: 20
+        TOKEN_35(9999): "AND", line: 1, col: 18
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 21
@@ -60,36 +56,32 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 22
+                    TOKEN_84(9999): "e", line: 1, col: 22
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 23
+                    TOKEN_91(9999): "l", line: 1, col: 23
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 24
+                    TOKEN_84(9999): "e", line: 1, col: 24
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 25
+                    TOKEN_92(9999): "m", line: 1, col: 25
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 26
+                    TOKEN_84(9999): "e", line: 1, col: 26
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 27
+                    TOKEN_93(9999): "n", line: 1, col: 27
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 28
+                    TOKEN_99(9999): "t", line: 1, col: 28
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 29
+                    TOKEN_98(9999): "s", line: 1, col: 29
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 30
               SetOpRhs(9999)
                 HAS(9999)
-                  TOKEN_40(9999): "H", line: 1, col: 31
-                  TOKEN_33(9999): "A", line: 1, col: 32
-                  TOKEN_51(9999): "S", line: 1, col: 33
+                  TOKEN_46(9999): "HAS", line: 1, col: 31
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 34
                 ALL(9999)
-                  TOKEN_33(9999): "A", line: 1, col: 35
-                  TOKEN_44(9999): "L", line: 1, col: 36
-                  TOKEN_44(9999): "L", line: 1, col: 37
+                  TOKEN_34(9999): "ALL", line: 1, col: 35
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 38
@@ -101,15 +93,13 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_40(9999): "H", line: 1, col: 40
+                              TOKEN_45(9999): "H", line: 1, col: 40
                       TOKEN_3(9999): """, line: 1, col: 41
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 42
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 43
-          TOKEN_46(9999): "N", line: 1, col: 44
-          TOKEN_36(9999): "D", line: 1, col: 45
+          TOKEN_35(9999): "AND", line: 1, col: 43
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 46
@@ -120,37 +110,32 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 47
+                      TOKEN_84(9999): "e", line: 1, col: 47
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 48
+                      TOKEN_91(9999): "l", line: 1, col: 48
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 49
+                      TOKEN_84(9999): "e", line: 1, col: 49
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 50
+                      TOKEN_92(9999): "m", line: 1, col: 50
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 51
+                      TOKEN_84(9999): "e", line: 1, col: 51
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 52
+                      TOKEN_93(9999): "n", line: 1, col: 52
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 53
+                      TOKEN_99(9999): "t", line: 1, col: 53
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 54
+                      TOKEN_98(9999): "s", line: 1, col: 54
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 55
                 SetOpRhs(9999)
                   HAS(9999)
-                    TOKEN_40(9999): "H", line: 1, col: 56
-                    TOKEN_33(9999): "A", line: 1, col: 57
-                    TOKEN_51(9999): "S", line: 1, col: 58
+                    TOKEN_46(9999): "HAS", line: 1, col: 56
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 59
                   ONLY(9999)
-                    TOKEN_47(9999): "O", line: 1, col: 60
-                    TOKEN_46(9999): "N", line: 1, col: 61
-                    TOKEN_44(9999): "L", line: 1, col: 62
-                    TOKEN_57(9999): "Y", line: 1, col: 63
+                    TOKEN_58(9999): "ONLY", line: 1, col: 60
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 64
@@ -162,15 +147,13 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 66
+                                TOKEN_45(9999): "H", line: 1, col: 66
                         TOKEN_3(9999): """, line: 1, col: 67
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 68
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 69
-            TOKEN_46(9999): "N", line: 1, col: 70
-            TOKEN_36(9999): "D", line: 1, col: 71
+            TOKEN_35(9999): "AND", line: 1, col: 69
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 72
@@ -181,36 +164,32 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 73
+                        TOKEN_84(9999): "e", line: 1, col: 73
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 74
+                        TOKEN_91(9999): "l", line: 1, col: 74
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 75
+                        TOKEN_84(9999): "e", line: 1, col: 75
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 76
+                        TOKEN_92(9999): "m", line: 1, col: 76
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 77
+                        TOKEN_84(9999): "e", line: 1, col: 77
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 78
+                        TOKEN_93(9999): "n", line: 1, col: 78
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 79
+                        TOKEN_99(9999): "t", line: 1, col: 79
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 80
+                        TOKEN_98(9999): "s", line: 1, col: 80
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 81
                   SetOpRhs(9999)
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 82
-                      TOKEN_33(9999): "A", line: 1, col: 83
-                      TOKEN_51(9999): "S", line: 1, col: 84
+                      TOKEN_46(9999): "HAS", line: 1, col: 82
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 85
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 86
-                      TOKEN_46(9999): "N", line: 1, col: 87
-                      TOKEN_57(9999): "Y", line: 1, col: 88
+                      TOKEN_36(9999): "ANY", line: 1, col: 86
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 89
@@ -222,15 +201,13 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 91
+                                  TOKEN_45(9999): "H", line: 1, col: 91
                           TOKEN_3(9999): """, line: 1, col: 92
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 93
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 94
-              TOKEN_46(9999): "N", line: 1, col: 95
-              TOKEN_36(9999): "D", line: 1, col: 96
+              TOKEN_35(9999): "AND", line: 1, col: 94
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 97
@@ -241,37 +218,32 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 98
+                          TOKEN_84(9999): "e", line: 1, col: 98
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 99
+                          TOKEN_91(9999): "l", line: 1, col: 99
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 100
+                          TOKEN_84(9999): "e", line: 1, col: 100
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 101
+                          TOKEN_92(9999): "m", line: 1, col: 101
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 102
+                          TOKEN_84(9999): "e", line: 1, col: 102
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 103
+                          TOKEN_93(9999): "n", line: 1, col: 103
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 104
+                          TOKEN_99(9999): "t", line: 1, col: 104
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 105
+                          TOKEN_98(9999): "s", line: 1, col: 105
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 106
                     SetOpRhs(9999)
                       HAS(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 107
-                        TOKEN_33(9999): "A", line: 1, col: 108
-                        TOKEN_51(9999): "S", line: 1, col: 109
+                        TOKEN_46(9999): "HAS", line: 1, col: 107
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 110
                       ONLY(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 111
-                        TOKEN_46(9999): "N", line: 1, col: 112
-                        TOKEN_44(9999): "L", line: 1, col: 113
-                        TOKEN_57(9999): "Y", line: 1, col: 114
+                        TOKEN_58(9999): "ONLY", line: 1, col: 111
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 115
@@ -283,5 +255,5 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 117
+                                    TOKEN_45(9999): "H", line: 1, col: 117
                             TOKEN_3(9999): """, line: 1, col: 118

--- a/tests/outputs/Filter_034.out
+++ b/tests/outputs/Filter_034.out
@@ -8,29 +8,27 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
             SetOpRhs(9999)
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 10
-                TOKEN_33(9999): "A", line: 1, col: 11
-                TOKEN_51(9999): "S", line: 1, col: 12
+                TOKEN_46(9999): "HAS", line: 1, col: 10
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 13
@@ -41,7 +39,7 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_40(9999): "H", line: 1, col: 15
+                          TOKEN_45(9999): "H", line: 1, col: 15
                   TOKEN_3(9999): """, line: 1, col: 16
 Error: in tests/cases/Filter_034.inp: line 1:
     unexpected token ",", expected <EOF>

--- a/tests/outputs/Filter_035.out
+++ b/tests/outputs/Filter_035.out
@@ -8,29 +8,27 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
             SetOpRhs(9999)
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 10
-                TOKEN_33(9999): "A", line: 1, col: 11
-                TOKEN_51(9999): "S", line: 1, col: 12
+                TOKEN_46(9999): "HAS", line: 1, col: 10
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 13
@@ -41,15 +39,13 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_40(9999): "H", line: 1, col: 15
+                          TOKEN_45(9999): "H", line: 1, col: 15
                   TOKEN_3(9999): """, line: 1, col: 16
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 17
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 18
-        TOKEN_46(9999): "N", line: 1, col: 19
-        TOKEN_36(9999): "D", line: 1, col: 20
+        TOKEN_35(9999): "AND", line: 1, col: 18
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 21
@@ -60,36 +56,32 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 22
+                    TOKEN_84(9999): "e", line: 1, col: 22
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 23
+                    TOKEN_91(9999): "l", line: 1, col: 23
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 24
+                    TOKEN_84(9999): "e", line: 1, col: 24
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 25
+                    TOKEN_92(9999): "m", line: 1, col: 25
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 26
+                    TOKEN_84(9999): "e", line: 1, col: 26
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 27
+                    TOKEN_93(9999): "n", line: 1, col: 27
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 28
+                    TOKEN_99(9999): "t", line: 1, col: 28
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 29
+                    TOKEN_98(9999): "s", line: 1, col: 29
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 30
               SetOpRhs(9999)
                 HAS(9999)
-                  TOKEN_40(9999): "H", line: 1, col: 31
-                  TOKEN_33(9999): "A", line: 1, col: 32
-                  TOKEN_51(9999): "S", line: 1, col: 33
+                  TOKEN_46(9999): "HAS", line: 1, col: 31
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 34
                 ALL(9999)
-                  TOKEN_33(9999): "A", line: 1, col: 35
-                  TOKEN_44(9999): "L", line: 1, col: 36
-                  TOKEN_44(9999): "L", line: 1, col: 37
+                  TOKEN_34(9999): "ALL", line: 1, col: 35
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 38
@@ -101,7 +93,7 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_40(9999): "H", line: 1, col: 40
+                              TOKEN_45(9999): "H", line: 1, col: 40
                       TOKEN_3(9999): """, line: 1, col: 41
                   Comma(9999)
                     TOKEN_12(9999): ",", line: 1, col: 42
@@ -112,12 +104,12 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_40(9999): "H", line: 1, col: 44
+                              TOKEN_45(9999): "H", line: 1, col: 44
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 45
+                              TOKEN_84(9999): "e", line: 1, col: 45
                       TOKEN_3(9999): """, line: 1, col: 46
                   Comma(9999)
                     TOKEN_12(9999): ",", line: 1, col: 47
@@ -128,12 +120,12 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_39(9999): "G", line: 1, col: 49
+                              TOKEN_44(9999): "G", line: 1, col: 49
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_65(9999): "a", line: 1, col: 50
+                              TOKEN_80(9999): "a", line: 1, col: 50
                       TOKEN_3(9999): """, line: 1, col: 51
                   Comma(9999)
                     TOKEN_12(9999): ",", line: 1, col: 52
@@ -144,20 +136,18 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_52(9999): "T", line: 1, col: 54
+                              TOKEN_65(9999): "T", line: 1, col: 54
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_65(9999): "a", line: 1, col: 55
+                              TOKEN_80(9999): "a", line: 1, col: 55
                       TOKEN_3(9999): """, line: 1, col: 56
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 57
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 58
-          TOKEN_46(9999): "N", line: 1, col: 59
-          TOKEN_36(9999): "D", line: 1, col: 60
+          TOKEN_35(9999): "AND", line: 1, col: 58
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 61
@@ -168,37 +158,32 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 62
+                      TOKEN_84(9999): "e", line: 1, col: 62
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 63
+                      TOKEN_91(9999): "l", line: 1, col: 63
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 64
+                      TOKEN_84(9999): "e", line: 1, col: 64
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 65
+                      TOKEN_92(9999): "m", line: 1, col: 65
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 66
+                      TOKEN_84(9999): "e", line: 1, col: 66
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 67
+                      TOKEN_93(9999): "n", line: 1, col: 67
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 68
+                      TOKEN_99(9999): "t", line: 1, col: 68
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 69
+                      TOKEN_98(9999): "s", line: 1, col: 69
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 70
                 SetOpRhs(9999)
                   HAS(9999)
-                    TOKEN_40(9999): "H", line: 1, col: 71
-                    TOKEN_33(9999): "A", line: 1, col: 72
-                    TOKEN_51(9999): "S", line: 1, col: 73
+                    TOKEN_46(9999): "HAS", line: 1, col: 71
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 74
                   ONLY(9999)
-                    TOKEN_47(9999): "O", line: 1, col: 75
-                    TOKEN_46(9999): "N", line: 1, col: 76
-                    TOKEN_44(9999): "L", line: 1, col: 77
-                    TOKEN_57(9999): "Y", line: 1, col: 78
+                    TOKEN_58(9999): "ONLY", line: 1, col: 75
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 79
@@ -210,7 +195,7 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 81
+                                TOKEN_45(9999): "H", line: 1, col: 81
                         TOKEN_3(9999): """, line: 1, col: 82
                     Comma(9999)
                       TOKEN_12(9999): ",", line: 1, col: 83
@@ -221,12 +206,12 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 85
+                                TOKEN_45(9999): "H", line: 1, col: 85
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_69(9999): "e", line: 1, col: 86
+                                TOKEN_84(9999): "e", line: 1, col: 86
                         TOKEN_3(9999): """, line: 1, col: 87
                     Comma(9999)
                       TOKEN_12(9999): ",", line: 1, col: 88
@@ -237,12 +222,12 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_39(9999): "G", line: 1, col: 90
+                                TOKEN_44(9999): "G", line: 1, col: 90
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_65(9999): "a", line: 1, col: 91
+                                TOKEN_80(9999): "a", line: 1, col: 91
                         TOKEN_3(9999): """, line: 1, col: 92
                     Comma(9999)
                       TOKEN_12(9999): ",", line: 1, col: 93
@@ -253,20 +238,18 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_52(9999): "T", line: 1, col: 95
+                                TOKEN_65(9999): "T", line: 1, col: 95
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_65(9999): "a", line: 1, col: 96
+                                TOKEN_80(9999): "a", line: 1, col: 96
                         TOKEN_3(9999): """, line: 1, col: 97
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 98
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 99
-            TOKEN_46(9999): "N", line: 1, col: 100
-            TOKEN_36(9999): "D", line: 1, col: 101
+            TOKEN_35(9999): "AND", line: 1, col: 99
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 102
@@ -277,36 +260,32 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 103
+                        TOKEN_84(9999): "e", line: 1, col: 103
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 104
+                        TOKEN_91(9999): "l", line: 1, col: 104
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 105
+                        TOKEN_84(9999): "e", line: 1, col: 105
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 106
+                        TOKEN_92(9999): "m", line: 1, col: 106
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 107
+                        TOKEN_84(9999): "e", line: 1, col: 107
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 108
+                        TOKEN_93(9999): "n", line: 1, col: 108
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 109
+                        TOKEN_99(9999): "t", line: 1, col: 109
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 110
+                        TOKEN_98(9999): "s", line: 1, col: 110
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 111
                   SetOpRhs(9999)
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 112
-                      TOKEN_33(9999): "A", line: 1, col: 113
-                      TOKEN_51(9999): "S", line: 1, col: 114
+                      TOKEN_46(9999): "HAS", line: 1, col: 112
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 115
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 116
-                      TOKEN_46(9999): "N", line: 1, col: 117
-                      TOKEN_57(9999): "Y", line: 1, col: 118
+                      TOKEN_36(9999): "ANY", line: 1, col: 116
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 119
@@ -318,7 +297,7 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 121
+                                  TOKEN_45(9999): "H", line: 1, col: 121
                           TOKEN_3(9999): """, line: 1, col: 122
                       Comma(9999)
                         TOKEN_12(9999): ",", line: 1, col: 123
@@ -332,12 +311,12 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 126
+                                  TOKEN_45(9999): "H", line: 1, col: 126
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_69(9999): "e", line: 1, col: 127
+                                  TOKEN_84(9999): "e", line: 1, col: 127
                           TOKEN_3(9999): """, line: 1, col: 128
                       Comma(9999)
                         TOKEN_12(9999): ",", line: 1, col: 129
@@ -351,12 +330,12 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_39(9999): "G", line: 1, col: 132
+                                  TOKEN_44(9999): "G", line: 1, col: 132
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 133
+                                  TOKEN_80(9999): "a", line: 1, col: 133
                           TOKEN_3(9999): """, line: 1, col: 134
                       Comma(9999)
                         TOKEN_12(9999): ",", line: 1, col: 135
@@ -370,20 +349,18 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_52(9999): "T", line: 1, col: 138
+                                  TOKEN_65(9999): "T", line: 1, col: 138
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 139
+                                  TOKEN_80(9999): "a", line: 1, col: 139
                           TOKEN_3(9999): """, line: 1, col: 140
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 141
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 142
-              TOKEN_46(9999): "N", line: 1, col: 143
-              TOKEN_36(9999): "D", line: 1, col: 144
+              TOKEN_35(9999): "AND", line: 1, col: 142
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 145
@@ -394,37 +371,32 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 146
+                          TOKEN_84(9999): "e", line: 1, col: 146
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 147
+                          TOKEN_91(9999): "l", line: 1, col: 147
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 148
+                          TOKEN_84(9999): "e", line: 1, col: 148
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 149
+                          TOKEN_92(9999): "m", line: 1, col: 149
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 150
+                          TOKEN_84(9999): "e", line: 1, col: 150
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 151
+                          TOKEN_93(9999): "n", line: 1, col: 151
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 152
+                          TOKEN_99(9999): "t", line: 1, col: 152
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 153
+                          TOKEN_98(9999): "s", line: 1, col: 153
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 154
                     SetOpRhs(9999)
                       HAS(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 155
-                        TOKEN_33(9999): "A", line: 1, col: 156
-                        TOKEN_51(9999): "S", line: 1, col: 157
+                        TOKEN_46(9999): "HAS", line: 1, col: 155
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 158
                       ONLY(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 159
-                        TOKEN_46(9999): "N", line: 1, col: 160
-                        TOKEN_44(9999): "L", line: 1, col: 161
-                        TOKEN_57(9999): "Y", line: 1, col: 162
+                        TOKEN_58(9999): "ONLY", line: 1, col: 159
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 163
@@ -436,7 +408,7 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 165
+                                    TOKEN_45(9999): "H", line: 1, col: 165
                             TOKEN_3(9999): """, line: 1, col: 166
                         Comma(9999)
                           TOKEN_12(9999): ",", line: 1, col: 167
@@ -447,12 +419,12 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 169
+                                    TOKEN_45(9999): "H", line: 1, col: 169
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 170
+                                    TOKEN_84(9999): "e", line: 1, col: 170
                             TOKEN_3(9999): """, line: 1, col: 171
                         Comma(9999)
                           TOKEN_12(9999): ",", line: 1, col: 172
@@ -463,12 +435,12 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_39(9999): "G", line: 1, col: 174
+                                    TOKEN_44(9999): "G", line: 1, col: 174
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 175
+                                    TOKEN_80(9999): "a", line: 1, col: 175
                             TOKEN_3(9999): """, line: 1, col: 176
                         Comma(9999)
                           TOKEN_12(9999): ",", line: 1, col: 177
@@ -479,12 +451,12 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_52(9999): "T", line: 1, col: 179
+                                    TOKEN_65(9999): "T", line: 1, col: 179
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 180
+                                    TOKEN_80(9999): "a", line: 1, col: 180
                             TOKEN_3(9999): """, line: 1, col: 181
                             Spaces(9999)
                               Space(9999)

--- a/tests/outputs/Filter_036.out
+++ b/tests/outputs/Filter_036.out
@@ -8,21 +8,21 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
             SetZipOpRhs(9999)
               PropertyZipAddon(9999)
                 Colon(9999)
@@ -30,60 +30,58 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 10
+                      TOKEN_84(9999): "e", line: 1, col: 10
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 11
+                      TOKEN_91(9999): "l", line: 1, col: 11
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 12
+                      TOKEN_84(9999): "e", line: 1, col: 12
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 13
+                      TOKEN_92(9999): "m", line: 1, col: 13
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 14
+                      TOKEN_84(9999): "e", line: 1, col: 14
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 15
+                      TOKEN_93(9999): "n", line: 1, col: 15
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 16
+                      TOKEN_99(9999): "t", line: 1, col: 16
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 17
+                      TOKEN_98(9999): "s", line: 1, col: 17
                 Colon(9999)
                   TOKEN_26(9999): ":", line: 1, col: 18
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 19
+                      TOKEN_84(9999): "e", line: 1, col: 19
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 20
+                      TOKEN_91(9999): "l", line: 1, col: 20
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 21
+                      TOKEN_84(9999): "e", line: 1, col: 21
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 22
+                      TOKEN_92(9999): "m", line: 1, col: 22
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 23
+                      TOKEN_84(9999): "e", line: 1, col: 23
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 24
+                      TOKEN_93(9999): "n", line: 1, col: 24
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 25
+                      TOKEN_99(9999): "t", line: 1, col: 25
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 26
+                      TOKEN_78(9999): "_", line: 1, col: 26
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 27
+                      TOKEN_82(9999): "c", line: 1, col: 27
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 28
+                      TOKEN_94(9999): "o", line: 1, col: 28
                     LowercaseLetter(9999)
-                      TOKEN_85(9999): "u", line: 1, col: 29
+                      TOKEN_100(9999): "u", line: 1, col: 29
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 30
+                      TOKEN_93(9999): "n", line: 1, col: 30
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 31
+                      TOKEN_99(9999): "t", line: 1, col: 31
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 32
+                      TOKEN_98(9999): "s", line: 1, col: 32
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 33
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 34
-                TOKEN_33(9999): "A", line: 1, col: 35
-                TOKEN_51(9999): "S", line: 1, col: 36
+                TOKEN_46(9999): "HAS", line: 1, col: 34
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 37
@@ -95,7 +93,7 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           UppercaseLetter(9999)
-                            TOKEN_40(9999): "H", line: 1, col: 39
+                            TOKEN_45(9999): "H", line: 1, col: 39
                     TOKEN_3(9999): """, line: 1, col: 40
                 Colon(9999)
                   TOKEN_26(9999): ":", line: 1, col: 41

--- a/tests/outputs/Filter_037.out
+++ b/tests/outputs/Filter_037.out
@@ -8,21 +8,21 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
             SetZipOpRhs(9999)
               PropertyZipAddon(9999)
                 Colon(9999)
@@ -30,49 +30,47 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 10
+                      TOKEN_84(9999): "e", line: 1, col: 10
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 11
+                      TOKEN_91(9999): "l", line: 1, col: 11
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 12
+                      TOKEN_84(9999): "e", line: 1, col: 12
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 13
+                      TOKEN_92(9999): "m", line: 1, col: 13
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 14
+                      TOKEN_84(9999): "e", line: 1, col: 14
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 15
+                      TOKEN_93(9999): "n", line: 1, col: 15
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 16
+                      TOKEN_99(9999): "t", line: 1, col: 16
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 17
+                      TOKEN_78(9999): "_", line: 1, col: 17
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 18
+                      TOKEN_82(9999): "c", line: 1, col: 18
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 19
+                      TOKEN_94(9999): "o", line: 1, col: 19
                     LowercaseLetter(9999)
-                      TOKEN_85(9999): "u", line: 1, col: 20
+                      TOKEN_100(9999): "u", line: 1, col: 20
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 21
+                      TOKEN_93(9999): "n", line: 1, col: 21
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 22
+                      TOKEN_99(9999): "t", line: 1, col: 22
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 23
+                      TOKEN_98(9999): "s", line: 1, col: 23
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 24
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 25
-                TOKEN_33(9999): "A", line: 1, col: 26
-                TOKEN_51(9999): "S", line: 1, col: 27
+                TOKEN_46(9999): "HAS", line: 1, col: 25
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 28
 Error: in tests/cases/Filter_037.inp: line 1:
-    unexpected token "I", expected one of "<", ">", "=", "!", """,
+    unexpected token "IS", expected one of "<", ">", "!", "=", """,
     "+", "-", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".",
     "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
     "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
-    "_", "O", or "A"
+    "_", "ONLY", "ALL", or "ANY"
 
 elements:element_counts HAS IS 'H':6,'He':7
                             ^

--- a/tests/outputs/Filter_038.out
+++ b/tests/outputs/Filter_038.out
@@ -8,29 +8,27 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
             SetOpRhs(9999)
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 10
-                TOKEN_33(9999): "A", line: 1, col: 11
-                TOKEN_51(9999): "S", line: 1, col: 12
+                TOKEN_46(9999): "HAS", line: 1, col: 10
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 13
@@ -41,7 +39,7 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_40(9999): "H", line: 1, col: 15
+                          TOKEN_45(9999): "H", line: 1, col: 15
                   TOKEN_3(9999): """, line: 1, col: 16
 Error: in tests/cases/Filter_038.inp: line 1:
     unexpected token ":", expected <EOF>

--- a/tests/outputs/Filter_039.out
+++ b/tests/outputs/Filter_039.out
@@ -8,21 +8,21 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
             SetZipOpRhs(9999)
               PropertyZipAddon(9999)
                 Colon(9999)
@@ -30,40 +30,38 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 10
+                      TOKEN_84(9999): "e", line: 1, col: 10
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 11
+                      TOKEN_91(9999): "l", line: 1, col: 11
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 12
+                      TOKEN_84(9999): "e", line: 1, col: 12
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 13
+                      TOKEN_92(9999): "m", line: 1, col: 13
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 14
+                      TOKEN_84(9999): "e", line: 1, col: 14
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 15
+                      TOKEN_93(9999): "n", line: 1, col: 15
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 16
+                      TOKEN_99(9999): "t", line: 1, col: 16
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 17
+                      TOKEN_78(9999): "_", line: 1, col: 17
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 18
+                      TOKEN_82(9999): "c", line: 1, col: 18
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 19
+                      TOKEN_94(9999): "o", line: 1, col: 19
                     LowercaseLetter(9999)
-                      TOKEN_85(9999): "u", line: 1, col: 20
+                      TOKEN_100(9999): "u", line: 1, col: 20
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 21
+                      TOKEN_93(9999): "n", line: 1, col: 21
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 22
+                      TOKEN_99(9999): "t", line: 1, col: 22
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 23
+                      TOKEN_98(9999): "s", line: 1, col: 23
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 24
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 25
-                TOKEN_33(9999): "A", line: 1, col: 26
-                TOKEN_51(9999): "S", line: 1, col: 27
+                TOKEN_46(9999): "HAS", line: 1, col: 25
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 28
@@ -75,7 +73,7 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           UppercaseLetter(9999)
-                            TOKEN_40(9999): "H", line: 1, col: 30
+                            TOKEN_45(9999): "H", line: 1, col: 30
                     TOKEN_3(9999): """, line: 1, col: 31
                 Colon(9999)
                   TOKEN_26(9999): ":", line: 1, col: 32
@@ -88,9 +86,7 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 34
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 35
-        TOKEN_46(9999): "N", line: 1, col: 36
-        TOKEN_36(9999): "D", line: 1, col: 37
+        TOKEN_35(9999): "AND", line: 1, col: 35
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 38
@@ -101,21 +97,21 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 39
+                    TOKEN_84(9999): "e", line: 1, col: 39
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 40
+                    TOKEN_91(9999): "l", line: 1, col: 40
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 41
+                    TOKEN_84(9999): "e", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 42
+                    TOKEN_92(9999): "m", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 43
+                    TOKEN_84(9999): "e", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 44
+                    TOKEN_93(9999): "n", line: 1, col: 44
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 45
+                    TOKEN_99(9999): "t", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 46
+                    TOKEN_98(9999): "s", line: 1, col: 46
               SetZipOpRhs(9999)
                 PropertyZipAddon(9999)
                   Colon(9999)
@@ -123,47 +119,43 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 48
+                        TOKEN_84(9999): "e", line: 1, col: 48
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 49
+                        TOKEN_91(9999): "l", line: 1, col: 49
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 50
+                        TOKEN_84(9999): "e", line: 1, col: 50
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 51
+                        TOKEN_92(9999): "m", line: 1, col: 51
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 52
+                        TOKEN_84(9999): "e", line: 1, col: 52
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 53
+                        TOKEN_93(9999): "n", line: 1, col: 53
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 54
+                        TOKEN_99(9999): "t", line: 1, col: 54
                       LowercaseLetter(9999)
-                        TOKEN_63(9999): "_", line: 1, col: 55
+                        TOKEN_78(9999): "_", line: 1, col: 55
                       LowercaseLetter(9999)
-                        TOKEN_67(9999): "c", line: 1, col: 56
+                        TOKEN_82(9999): "c", line: 1, col: 56
                       LowercaseLetter(9999)
-                        TOKEN_79(9999): "o", line: 1, col: 57
+                        TOKEN_94(9999): "o", line: 1, col: 57
                       LowercaseLetter(9999)
-                        TOKEN_85(9999): "u", line: 1, col: 58
+                        TOKEN_100(9999): "u", line: 1, col: 58
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 59
+                        TOKEN_93(9999): "n", line: 1, col: 59
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 60
+                        TOKEN_99(9999): "t", line: 1, col: 60
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 61
+                        TOKEN_98(9999): "s", line: 1, col: 61
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 62
                 HAS(9999)
-                  TOKEN_40(9999): "H", line: 1, col: 63
-                  TOKEN_33(9999): "A", line: 1, col: 64
-                  TOKEN_51(9999): "S", line: 1, col: 65
+                  TOKEN_46(9999): "HAS", line: 1, col: 63
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 66
                 ALL(9999)
-                  TOKEN_33(9999): "A", line: 1, col: 67
-                  TOKEN_44(9999): "L", line: 1, col: 68
-                  TOKEN_44(9999): "L", line: 1, col: 69
+                  TOKEN_34(9999): "ALL", line: 1, col: 67
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 70
@@ -176,7 +168,7 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 72
+                                TOKEN_45(9999): "H", line: 1, col: 72
                         TOKEN_3(9999): """, line: 1, col: 73
                     Colon(9999)
                       TOKEN_26(9999): ":", line: 1, col: 74
@@ -195,12 +187,12 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 78
+                                TOKEN_45(9999): "H", line: 1, col: 78
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_69(9999): "e", line: 1, col: 79
+                                TOKEN_84(9999): "e", line: 1, col: 79
                         TOKEN_3(9999): """, line: 1, col: 80
                     Colon(9999)
                       TOKEN_26(9999): ":", line: 1, col: 81
@@ -213,9 +205,7 @@ Filter(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 83
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 84
-          TOKEN_46(9999): "N", line: 1, col: 85
-          TOKEN_36(9999): "D", line: 1, col: 86
+          TOKEN_35(9999): "AND", line: 1, col: 84
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 87
@@ -226,21 +216,21 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 88
+                      TOKEN_84(9999): "e", line: 1, col: 88
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 89
+                      TOKEN_91(9999): "l", line: 1, col: 89
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 90
+                      TOKEN_84(9999): "e", line: 1, col: 90
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 91
+                      TOKEN_92(9999): "m", line: 1, col: 91
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 92
+                      TOKEN_84(9999): "e", line: 1, col: 92
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 93
+                      TOKEN_93(9999): "n", line: 1, col: 93
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 94
+                      TOKEN_99(9999): "t", line: 1, col: 94
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 95
+                      TOKEN_98(9999): "s", line: 1, col: 95
                 SetZipOpRhs(9999)
                   PropertyZipAddon(9999)
                     Colon(9999)
@@ -248,48 +238,43 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 97
+                          TOKEN_84(9999): "e", line: 1, col: 97
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 98
+                          TOKEN_91(9999): "l", line: 1, col: 98
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 99
+                          TOKEN_84(9999): "e", line: 1, col: 99
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 100
+                          TOKEN_92(9999): "m", line: 1, col: 100
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 101
+                          TOKEN_84(9999): "e", line: 1, col: 101
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 102
+                          TOKEN_93(9999): "n", line: 1, col: 102
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 103
+                          TOKEN_99(9999): "t", line: 1, col: 103
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 104
+                          TOKEN_78(9999): "_", line: 1, col: 104
                         LowercaseLetter(9999)
-                          TOKEN_67(9999): "c", line: 1, col: 105
+                          TOKEN_82(9999): "c", line: 1, col: 105
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 106
+                          TOKEN_94(9999): "o", line: 1, col: 106
                         LowercaseLetter(9999)
-                          TOKEN_85(9999): "u", line: 1, col: 107
+                          TOKEN_100(9999): "u", line: 1, col: 107
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 108
+                          TOKEN_93(9999): "n", line: 1, col: 108
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 109
+                          TOKEN_99(9999): "t", line: 1, col: 109
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 110
+                          TOKEN_98(9999): "s", line: 1, col: 110
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 111
                   HAS(9999)
-                    TOKEN_40(9999): "H", line: 1, col: 112
-                    TOKEN_33(9999): "A", line: 1, col: 113
-                    TOKEN_51(9999): "S", line: 1, col: 114
+                    TOKEN_46(9999): "HAS", line: 1, col: 112
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 115
                   ONLY(9999)
-                    TOKEN_47(9999): "O", line: 1, col: 116
-                    TOKEN_46(9999): "N", line: 1, col: 117
-                    TOKEN_44(9999): "L", line: 1, col: 118
-                    TOKEN_57(9999): "Y", line: 1, col: 119
+                    TOKEN_58(9999): "ONLY", line: 1, col: 116
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 120
@@ -302,7 +287,7 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 122
+                                  TOKEN_45(9999): "H", line: 1, col: 122
                           TOKEN_3(9999): """, line: 1, col: 123
                       Colon(9999)
                         TOKEN_26(9999): ":", line: 1, col: 124
@@ -315,9 +300,7 @@ Filter(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 126
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 127
-            TOKEN_46(9999): "N", line: 1, col: 128
-            TOKEN_36(9999): "D", line: 1, col: 129
+            TOKEN_35(9999): "AND", line: 1, col: 127
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 130
@@ -328,21 +311,21 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 131
+                        TOKEN_84(9999): "e", line: 1, col: 131
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 132
+                        TOKEN_91(9999): "l", line: 1, col: 132
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 133
+                        TOKEN_84(9999): "e", line: 1, col: 133
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 134
+                        TOKEN_92(9999): "m", line: 1, col: 134
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 135
+                        TOKEN_84(9999): "e", line: 1, col: 135
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 136
+                        TOKEN_93(9999): "n", line: 1, col: 136
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 137
+                        TOKEN_99(9999): "t", line: 1, col: 137
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 138
+                        TOKEN_98(9999): "s", line: 1, col: 138
                   SetZipOpRhs(9999)
                     PropertyZipAddon(9999)
                       Colon(9999)
@@ -350,47 +333,43 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 140
+                            TOKEN_84(9999): "e", line: 1, col: 140
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 141
+                            TOKEN_91(9999): "l", line: 1, col: 141
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 142
+                            TOKEN_84(9999): "e", line: 1, col: 142
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 143
+                            TOKEN_92(9999): "m", line: 1, col: 143
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 144
+                            TOKEN_84(9999): "e", line: 1, col: 144
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 145
+                            TOKEN_93(9999): "n", line: 1, col: 145
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 146
+                            TOKEN_99(9999): "t", line: 1, col: 146
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 147
+                            TOKEN_78(9999): "_", line: 1, col: 147
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 148
+                            TOKEN_82(9999): "c", line: 1, col: 148
                           LowercaseLetter(9999)
-                            TOKEN_79(9999): "o", line: 1, col: 149
+                            TOKEN_94(9999): "o", line: 1, col: 149
                           LowercaseLetter(9999)
-                            TOKEN_85(9999): "u", line: 1, col: 150
+                            TOKEN_100(9999): "u", line: 1, col: 150
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 151
+                            TOKEN_93(9999): "n", line: 1, col: 151
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 152
+                            TOKEN_99(9999): "t", line: 1, col: 152
                           LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 153
+                            TOKEN_98(9999): "s", line: 1, col: 153
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 154
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 155
-                      TOKEN_33(9999): "A", line: 1, col: 156
-                      TOKEN_51(9999): "S", line: 1, col: 157
+                      TOKEN_46(9999): "HAS", line: 1, col: 155
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 158
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 159
-                      TOKEN_46(9999): "N", line: 1, col: 160
-                      TOKEN_57(9999): "Y", line: 1, col: 161
+                      TOKEN_36(9999): "ANY", line: 1, col: 159
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 162
@@ -403,7 +382,7 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 164
+                                    TOKEN_45(9999): "H", line: 1, col: 164
                             TOKEN_3(9999): """, line: 1, col: 165
                         Colon(9999)
                           TOKEN_26(9999): ":", line: 1, col: 166
@@ -422,12 +401,12 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 170
+                                    TOKEN_45(9999): "H", line: 1, col: 170
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 171
+                                    TOKEN_84(9999): "e", line: 1, col: 171
                             TOKEN_3(9999): """, line: 1, col: 172
                         Colon(9999)
                           TOKEN_26(9999): ":", line: 1, col: 173
@@ -440,9 +419,7 @@ Filter(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 175
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 176
-              TOKEN_46(9999): "N", line: 1, col: 177
-              TOKEN_36(9999): "D", line: 1, col: 178
+              TOKEN_35(9999): "AND", line: 1, col: 176
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 179
@@ -453,21 +430,21 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 180
+                          TOKEN_84(9999): "e", line: 1, col: 180
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 181
+                          TOKEN_91(9999): "l", line: 1, col: 181
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 182
+                          TOKEN_84(9999): "e", line: 1, col: 182
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 183
+                          TOKEN_92(9999): "m", line: 1, col: 183
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 184
+                          TOKEN_84(9999): "e", line: 1, col: 184
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 185
+                          TOKEN_93(9999): "n", line: 1, col: 185
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 186
+                          TOKEN_99(9999): "t", line: 1, col: 186
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 187
+                          TOKEN_98(9999): "s", line: 1, col: 187
                     SetZipOpRhs(9999)
                       PropertyZipAddon(9999)
                         Colon(9999)
@@ -475,48 +452,43 @@ Filter(9999)
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 189
+                              TOKEN_84(9999): "e", line: 1, col: 189
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 190
+                              TOKEN_91(9999): "l", line: 1, col: 190
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 191
+                              TOKEN_84(9999): "e", line: 1, col: 191
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 192
+                              TOKEN_92(9999): "m", line: 1, col: 192
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 193
+                              TOKEN_84(9999): "e", line: 1, col: 193
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 194
+                              TOKEN_93(9999): "n", line: 1, col: 194
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 195
+                              TOKEN_99(9999): "t", line: 1, col: 195
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 196
+                              TOKEN_78(9999): "_", line: 1, col: 196
                             LowercaseLetter(9999)
-                              TOKEN_67(9999): "c", line: 1, col: 197
+                              TOKEN_82(9999): "c", line: 1, col: 197
                             LowercaseLetter(9999)
-                              TOKEN_79(9999): "o", line: 1, col: 198
+                              TOKEN_94(9999): "o", line: 1, col: 198
                             LowercaseLetter(9999)
-                              TOKEN_85(9999): "u", line: 1, col: 199
+                              TOKEN_100(9999): "u", line: 1, col: 199
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 200
+                              TOKEN_93(9999): "n", line: 1, col: 200
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 201
+                              TOKEN_99(9999): "t", line: 1, col: 201
                             LowercaseLetter(9999)
-                              TOKEN_83(9999): "s", line: 1, col: 202
+                              TOKEN_98(9999): "s", line: 1, col: 202
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 203
                       HAS(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 204
-                        TOKEN_33(9999): "A", line: 1, col: 205
-                        TOKEN_51(9999): "S", line: 1, col: 206
+                        TOKEN_46(9999): "HAS", line: 1, col: 204
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 207
                       ONLY(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 208
-                        TOKEN_46(9999): "N", line: 1, col: 209
-                        TOKEN_44(9999): "L", line: 1, col: 210
-                        TOKEN_57(9999): "Y", line: 1, col: 211
+                        TOKEN_58(9999): "ONLY", line: 1, col: 208
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 212
@@ -529,7 +501,7 @@ Filter(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 214
+                                      TOKEN_45(9999): "H", line: 1, col: 214
                               TOKEN_3(9999): """, line: 1, col: 215
                           Colon(9999)
                             TOKEN_26(9999): ":", line: 1, col: 216
@@ -548,12 +520,12 @@ Filter(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 220
+                                      TOKEN_45(9999): "H", line: 1, col: 220
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_69(9999): "e", line: 1, col: 221
+                                      TOKEN_84(9999): "e", line: 1, col: 221
                               TOKEN_3(9999): """, line: 1, col: 222
                           Colon(9999)
                             TOKEN_26(9999): ":", line: 1, col: 223

--- a/tests/outputs/Filter_040.out
+++ b/tests/outputs/Filter_040.out
@@ -8,37 +8,37 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17

--- a/tests/outputs/Filter_041.out
+++ b/tests/outputs/Filter_041.out
@@ -8,37 +8,37 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17

--- a/tests/outputs/Filter_042.out
+++ b/tests/outputs/Filter_042.out
@@ -8,37 +8,37 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17
@@ -55,20 +55,18 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_40(9999): "H", line: 1, col: 21
+                          TOKEN_45(9999): "H", line: 1, col: 21
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 22
+                          TOKEN_84(9999): "e", line: 1, col: 22
                   TOKEN_3(9999): """, line: 1, col: 23
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 24
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 25
-        TOKEN_46(9999): "N", line: 1, col: 26
-        TOKEN_36(9999): "D", line: 1, col: 27
+        TOKEN_35(9999): "AND", line: 1, col: 25
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 28
@@ -79,37 +77,37 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 29
+                    TOKEN_82(9999): "c", line: 1, col: 29
                   LowercaseLetter(9999)
-                    TOKEN_72(9999): "h", line: 1, col: 30
+                    TOKEN_87(9999): "h", line: 1, col: 30
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 31
+                    TOKEN_84(9999): "e", line: 1, col: 31
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 32
+                    TOKEN_92(9999): "m", line: 1, col: 32
                   LowercaseLetter(9999)
-                    TOKEN_73(9999): "i", line: 1, col: 33
+                    TOKEN_88(9999): "i", line: 1, col: 33
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 34
+                    TOKEN_82(9999): "c", line: 1, col: 34
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 35
+                    TOKEN_80(9999): "a", line: 1, col: 35
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 36
+                    TOKEN_91(9999): "l", line: 1, col: 36
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 37
+                    TOKEN_78(9999): "_", line: 1, col: 37
                   LowercaseLetter(9999)
-                    TOKEN_70(9999): "f", line: 1, col: 38
+                    TOKEN_85(9999): "f", line: 1, col: 38
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 39
+                    TOKEN_94(9999): "o", line: 1, col: 39
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 40
+                    TOKEN_97(9999): "r", line: 1, col: 40
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 41
+                    TOKEN_92(9999): "m", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_85(9999): "u", line: 1, col: 42
+                    TOKEN_100(9999): "u", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 43
+                    TOKEN_91(9999): "l", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 44
+                    TOKEN_80(9999): "a", line: 1, col: 44
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 45
@@ -126,20 +124,18 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           UppercaseLetter(9999)
-                            TOKEN_40(9999): "H", line: 1, col: 49
+                            TOKEN_45(9999): "H", line: 1, col: 49
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 50
+                            TOKEN_84(9999): "e", line: 1, col: 50
                     TOKEN_3(9999): """, line: 1, col: 51
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 52
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 53
-          TOKEN_46(9999): "N", line: 1, col: 54
-          TOKEN_36(9999): "D", line: 1, col: 55
+          TOKEN_35(9999): "AND", line: 1, col: 53
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 56
@@ -150,37 +146,37 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 57
+                      TOKEN_82(9999): "c", line: 1, col: 57
                     LowercaseLetter(9999)
-                      TOKEN_72(9999): "h", line: 1, col: 58
+                      TOKEN_87(9999): "h", line: 1, col: 58
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 59
+                      TOKEN_84(9999): "e", line: 1, col: 59
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 60
+                      TOKEN_92(9999): "m", line: 1, col: 60
                     LowercaseLetter(9999)
-                      TOKEN_73(9999): "i", line: 1, col: 61
+                      TOKEN_88(9999): "i", line: 1, col: 61
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 62
+                      TOKEN_82(9999): "c", line: 1, col: 62
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 63
+                      TOKEN_80(9999): "a", line: 1, col: 63
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 64
+                      TOKEN_91(9999): "l", line: 1, col: 64
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 65
+                      TOKEN_78(9999): "_", line: 1, col: 65
                     LowercaseLetter(9999)
-                      TOKEN_70(9999): "f", line: 1, col: 66
+                      TOKEN_85(9999): "f", line: 1, col: 66
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 67
+                      TOKEN_94(9999): "o", line: 1, col: 67
                     LowercaseLetter(9999)
-                      TOKEN_82(9999): "r", line: 1, col: 68
+                      TOKEN_97(9999): "r", line: 1, col: 68
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 69
+                      TOKEN_92(9999): "m", line: 1, col: 69
                     LowercaseLetter(9999)
-                      TOKEN_85(9999): "u", line: 1, col: 70
+                      TOKEN_100(9999): "u", line: 1, col: 70
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 71
+                      TOKEN_91(9999): "l", line: 1, col: 71
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 72
+                      TOKEN_80(9999): "a", line: 1, col: 72
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 73
@@ -197,20 +193,18 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_40(9999): "H", line: 1, col: 77
+                              TOKEN_45(9999): "H", line: 1, col: 77
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 78
+                              TOKEN_84(9999): "e", line: 1, col: 78
                       TOKEN_3(9999): """, line: 1, col: 79
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 80
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 81
-            TOKEN_46(9999): "N", line: 1, col: 82
-            TOKEN_36(9999): "D", line: 1, col: 83
+            TOKEN_35(9999): "AND", line: 1, col: 81
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 84
@@ -221,37 +215,37 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_67(9999): "c", line: 1, col: 85
+                        TOKEN_82(9999): "c", line: 1, col: 85
                       LowercaseLetter(9999)
-                        TOKEN_72(9999): "h", line: 1, col: 86
+                        TOKEN_87(9999): "h", line: 1, col: 86
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 87
+                        TOKEN_84(9999): "e", line: 1, col: 87
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 88
+                        TOKEN_92(9999): "m", line: 1, col: 88
                       LowercaseLetter(9999)
-                        TOKEN_73(9999): "i", line: 1, col: 89
+                        TOKEN_88(9999): "i", line: 1, col: 89
                       LowercaseLetter(9999)
-                        TOKEN_67(9999): "c", line: 1, col: 90
+                        TOKEN_82(9999): "c", line: 1, col: 90
                       LowercaseLetter(9999)
-                        TOKEN_65(9999): "a", line: 1, col: 91
+                        TOKEN_80(9999): "a", line: 1, col: 91
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 92
+                        TOKEN_91(9999): "l", line: 1, col: 92
                       LowercaseLetter(9999)
-                        TOKEN_63(9999): "_", line: 1, col: 93
+                        TOKEN_78(9999): "_", line: 1, col: 93
                       LowercaseLetter(9999)
-                        TOKEN_70(9999): "f", line: 1, col: 94
+                        TOKEN_85(9999): "f", line: 1, col: 94
                       LowercaseLetter(9999)
-                        TOKEN_79(9999): "o", line: 1, col: 95
+                        TOKEN_94(9999): "o", line: 1, col: 95
                       LowercaseLetter(9999)
-                        TOKEN_82(9999): "r", line: 1, col: 96
+                        TOKEN_97(9999): "r", line: 1, col: 96
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 97
+                        TOKEN_92(9999): "m", line: 1, col: 97
                       LowercaseLetter(9999)
-                        TOKEN_85(9999): "u", line: 1, col: 98
+                        TOKEN_100(9999): "u", line: 1, col: 98
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 99
+                        TOKEN_91(9999): "l", line: 1, col: 99
                       LowercaseLetter(9999)
-                        TOKEN_65(9999): "a", line: 1, col: 100
+                        TOKEN_80(9999): "a", line: 1, col: 100
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 101
@@ -269,20 +263,18 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 106
+                                TOKEN_45(9999): "H", line: 1, col: 106
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_69(9999): "e", line: 1, col: 107
+                                TOKEN_84(9999): "e", line: 1, col: 107
                         TOKEN_3(9999): """, line: 1, col: 108
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 109
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 110
-              TOKEN_46(9999): "N", line: 1, col: 111
-              TOKEN_36(9999): "D", line: 1, col: 112
+              TOKEN_35(9999): "AND", line: 1, col: 110
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 113
@@ -293,37 +285,37 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_67(9999): "c", line: 1, col: 114
+                          TOKEN_82(9999): "c", line: 1, col: 114
                         LowercaseLetter(9999)
-                          TOKEN_72(9999): "h", line: 1, col: 115
+                          TOKEN_87(9999): "h", line: 1, col: 115
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 116
+                          TOKEN_84(9999): "e", line: 1, col: 116
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 117
+                          TOKEN_92(9999): "m", line: 1, col: 117
                         LowercaseLetter(9999)
-                          TOKEN_73(9999): "i", line: 1, col: 118
+                          TOKEN_88(9999): "i", line: 1, col: 118
                         LowercaseLetter(9999)
-                          TOKEN_67(9999): "c", line: 1, col: 119
+                          TOKEN_82(9999): "c", line: 1, col: 119
                         LowercaseLetter(9999)
-                          TOKEN_65(9999): "a", line: 1, col: 120
+                          TOKEN_80(9999): "a", line: 1, col: 120
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 121
+                          TOKEN_91(9999): "l", line: 1, col: 121
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 122
+                          TOKEN_78(9999): "_", line: 1, col: 122
                         LowercaseLetter(9999)
-                          TOKEN_70(9999): "f", line: 1, col: 123
+                          TOKEN_85(9999): "f", line: 1, col: 123
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 124
+                          TOKEN_94(9999): "o", line: 1, col: 124
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 125
+                          TOKEN_97(9999): "r", line: 1, col: 125
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 126
+                          TOKEN_92(9999): "m", line: 1, col: 126
                         LowercaseLetter(9999)
-                          TOKEN_85(9999): "u", line: 1, col: 127
+                          TOKEN_100(9999): "u", line: 1, col: 127
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 128
+                          TOKEN_91(9999): "l", line: 1, col: 128
                         LowercaseLetter(9999)
-                          TOKEN_65(9999): "a", line: 1, col: 129
+                          TOKEN_80(9999): "a", line: 1, col: 129
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 130
@@ -341,20 +333,18 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 135
+                                  TOKEN_45(9999): "H", line: 1, col: 135
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_69(9999): "e", line: 1, col: 136
+                                  TOKEN_84(9999): "e", line: 1, col: 136
                           TOKEN_3(9999): """, line: 1, col: 137
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 138
               AND(9999)
-                TOKEN_33(9999): "A", line: 1, col: 139
-                TOKEN_46(9999): "N", line: 1, col: 140
-                TOKEN_36(9999): "D", line: 1, col: 141
+                TOKEN_35(9999): "AND", line: 1, col: 139
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 142
@@ -365,37 +355,37 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 143
+                            TOKEN_82(9999): "c", line: 1, col: 143
                           LowercaseLetter(9999)
-                            TOKEN_72(9999): "h", line: 1, col: 144
+                            TOKEN_87(9999): "h", line: 1, col: 144
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 145
+                            TOKEN_84(9999): "e", line: 1, col: 145
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 146
+                            TOKEN_92(9999): "m", line: 1, col: 146
                           LowercaseLetter(9999)
-                            TOKEN_73(9999): "i", line: 1, col: 147
+                            TOKEN_88(9999): "i", line: 1, col: 147
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 148
+                            TOKEN_82(9999): "c", line: 1, col: 148
                           LowercaseLetter(9999)
-                            TOKEN_65(9999): "a", line: 1, col: 149
+                            TOKEN_80(9999): "a", line: 1, col: 149
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 150
+                            TOKEN_91(9999): "l", line: 1, col: 150
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 151
+                            TOKEN_78(9999): "_", line: 1, col: 151
                           LowercaseLetter(9999)
-                            TOKEN_70(9999): "f", line: 1, col: 152
+                            TOKEN_85(9999): "f", line: 1, col: 152
                           LowercaseLetter(9999)
-                            TOKEN_79(9999): "o", line: 1, col: 153
+                            TOKEN_94(9999): "o", line: 1, col: 153
                           LowercaseLetter(9999)
-                            TOKEN_82(9999): "r", line: 1, col: 154
+                            TOKEN_97(9999): "r", line: 1, col: 154
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 155
+                            TOKEN_92(9999): "m", line: 1, col: 155
                           LowercaseLetter(9999)
-                            TOKEN_85(9999): "u", line: 1, col: 156
+                            TOKEN_100(9999): "u", line: 1, col: 156
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 157
+                            TOKEN_91(9999): "l", line: 1, col: 157
                           LowercaseLetter(9999)
-                            TOKEN_65(9999): "a", line: 1, col: 158
+                            TOKEN_80(9999): "a", line: 1, col: 158
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 159
@@ -413,10 +403,10 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 164
+                                    TOKEN_45(9999): "H", line: 1, col: 164
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 165
+                                    TOKEN_84(9999): "e", line: 1, col: 165
                             TOKEN_3(9999): """, line: 1, col: 166

--- a/tests/outputs/Filter_043.out
+++ b/tests/outputs/Filter_043.out
@@ -8,23 +8,23 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 1
+                  TOKEN_93(9999): "n", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 2
+                  TOKEN_84(9999): "e", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 3
+                  TOKEN_91(9999): "l", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 4
+                  TOKEN_84(9999): "e", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 5
+                  TOKEN_92(9999): "m", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 6
+                  TOKEN_84(9999): "e", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 7
+                  TOKEN_93(9999): "n", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 8
+                  TOKEN_99(9999): "t", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 9
+                  TOKEN_98(9999): "s", line: 1, col: 9
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 10
@@ -45,9 +45,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 15
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 16
-        TOKEN_46(9999): "N", line: 1, col: 17
-        TOKEN_36(9999): "D", line: 1, col: 18
+        TOKEN_35(9999): "AND", line: 1, col: 16
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 19
@@ -58,23 +56,23 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 20
+                    TOKEN_93(9999): "n", line: 1, col: 20
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 21
+                    TOKEN_84(9999): "e", line: 1, col: 21
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 22
+                    TOKEN_91(9999): "l", line: 1, col: 22
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 23
+                    TOKEN_84(9999): "e", line: 1, col: 23
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 24
+                    TOKEN_92(9999): "m", line: 1, col: 24
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 25
+                    TOKEN_84(9999): "e", line: 1, col: 25
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 26
+                    TOKEN_93(9999): "n", line: 1, col: 26
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 27
+                    TOKEN_99(9999): "t", line: 1, col: 27
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 28
+                    TOKEN_98(9999): "s", line: 1, col: 28
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 29
@@ -95,9 +93,7 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 34
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 35
-          TOKEN_46(9999): "N", line: 1, col: 36
-          TOKEN_36(9999): "D", line: 1, col: 37
+          TOKEN_35(9999): "AND", line: 1, col: 35
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 38
@@ -108,23 +104,23 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 39
+                      TOKEN_93(9999): "n", line: 1, col: 39
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 40
+                      TOKEN_84(9999): "e", line: 1, col: 40
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 41
+                      TOKEN_91(9999): "l", line: 1, col: 41
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 42
+                      TOKEN_84(9999): "e", line: 1, col: 42
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 43
+                      TOKEN_92(9999): "m", line: 1, col: 43
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 44
+                      TOKEN_84(9999): "e", line: 1, col: 44
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 45
+                      TOKEN_93(9999): "n", line: 1, col: 45
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 46
+                      TOKEN_99(9999): "t", line: 1, col: 46
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 47
+                      TOKEN_98(9999): "s", line: 1, col: 47
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 48
@@ -145,9 +141,7 @@ Filter(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 53
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 54
-            TOKEN_46(9999): "N", line: 1, col: 55
-            TOKEN_36(9999): "D", line: 1, col: 56
+            TOKEN_35(9999): "AND", line: 1, col: 54
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 57
@@ -158,23 +152,23 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 58
+                        TOKEN_93(9999): "n", line: 1, col: 58
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 59
+                        TOKEN_84(9999): "e", line: 1, col: 59
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 60
+                        TOKEN_91(9999): "l", line: 1, col: 60
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 61
+                        TOKEN_84(9999): "e", line: 1, col: 61
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 62
+                        TOKEN_92(9999): "m", line: 1, col: 62
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 63
+                        TOKEN_84(9999): "e", line: 1, col: 63
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 64
+                        TOKEN_93(9999): "n", line: 1, col: 64
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 65
+                        TOKEN_99(9999): "t", line: 1, col: 65
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 66
+                        TOKEN_98(9999): "s", line: 1, col: 66
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 67
@@ -196,9 +190,7 @@ Filter(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 73
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 74
-              TOKEN_46(9999): "N", line: 1, col: 75
-              TOKEN_36(9999): "D", line: 1, col: 76
+              TOKEN_35(9999): "AND", line: 1, col: 74
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 77
@@ -209,23 +201,23 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 78
+                          TOKEN_93(9999): "n", line: 1, col: 78
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 79
+                          TOKEN_84(9999): "e", line: 1, col: 79
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 80
+                          TOKEN_91(9999): "l", line: 1, col: 80
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 81
+                          TOKEN_84(9999): "e", line: 1, col: 81
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 82
+                          TOKEN_92(9999): "m", line: 1, col: 82
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 83
+                          TOKEN_84(9999): "e", line: 1, col: 83
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 84
+                          TOKEN_93(9999): "n", line: 1, col: 84
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 85
+                          TOKEN_99(9999): "t", line: 1, col: 85
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 86
+                          TOKEN_98(9999): "s", line: 1, col: 86
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 87
@@ -247,9 +239,7 @@ Filter(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 93
               AND(9999)
-                TOKEN_33(9999): "A", line: 1, col: 94
-                TOKEN_46(9999): "N", line: 1, col: 95
-                TOKEN_36(9999): "D", line: 1, col: 96
+                TOKEN_35(9999): "AND", line: 1, col: 94
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 97
@@ -260,23 +250,23 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 98
+                            TOKEN_93(9999): "n", line: 1, col: 98
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 99
+                            TOKEN_84(9999): "e", line: 1, col: 99
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 100
+                            TOKEN_91(9999): "l", line: 1, col: 100
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 101
+                            TOKEN_84(9999): "e", line: 1, col: 101
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 102
+                            TOKEN_92(9999): "m", line: 1, col: 102
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 103
+                            TOKEN_84(9999): "e", line: 1, col: 103
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 104
+                            TOKEN_93(9999): "n", line: 1, col: 104
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 105
+                            TOKEN_99(9999): "t", line: 1, col: 105
                           LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 106
+                            TOKEN_98(9999): "s", line: 1, col: 106
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 107
@@ -298,9 +288,7 @@ Filter(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 113
                 AND(9999)
-                  TOKEN_33(9999): "A", line: 1, col: 114
-                  TOKEN_46(9999): "N", line: 1, col: 115
-                  TOKEN_36(9999): "D", line: 1, col: 116
+                  TOKEN_35(9999): "AND", line: 1, col: 114
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 117
@@ -311,23 +299,23 @@ Filter(9999)
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 118
+                              TOKEN_93(9999): "n", line: 1, col: 118
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 119
+                              TOKEN_84(9999): "e", line: 1, col: 119
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 120
+                              TOKEN_91(9999): "l", line: 1, col: 120
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 121
+                              TOKEN_84(9999): "e", line: 1, col: 121
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 122
+                              TOKEN_92(9999): "m", line: 1, col: 122
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 123
+                              TOKEN_84(9999): "e", line: 1, col: 123
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 124
+                              TOKEN_93(9999): "n", line: 1, col: 124
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 125
+                              TOKEN_99(9999): "t", line: 1, col: 125
                             LowercaseLetter(9999)
-                              TOKEN_83(9999): "s", line: 1, col: 126
+                              TOKEN_98(9999): "s", line: 1, col: 126
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 127

--- a/tests/outputs/Filter_044.out
+++ b/tests/outputs/Filter_044.out
@@ -8,23 +8,23 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 1
+                  TOKEN_93(9999): "n", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 2
+                  TOKEN_84(9999): "e", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 3
+                  TOKEN_91(9999): "l", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 4
+                  TOKEN_84(9999): "e", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 5
+                  TOKEN_92(9999): "m", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 6
+                  TOKEN_84(9999): "e", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 7
+                  TOKEN_93(9999): "n", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 8
+                  TOKEN_99(9999): "t", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 9
+                  TOKEN_98(9999): "s", line: 1, col: 9
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 10
@@ -45,9 +45,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 15
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 16
-        TOKEN_46(9999): "N", line: 1, col: 17
-        TOKEN_36(9999): "D", line: 1, col: 18
+        TOKEN_35(9999): "AND", line: 1, col: 16
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 19
@@ -58,23 +56,23 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 20
+                    TOKEN_93(9999): "n", line: 1, col: 20
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 21
+                    TOKEN_84(9999): "e", line: 1, col: 21
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 22
+                    TOKEN_91(9999): "l", line: 1, col: 22
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 23
+                    TOKEN_84(9999): "e", line: 1, col: 23
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 24
+                    TOKEN_92(9999): "m", line: 1, col: 24
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 25
+                    TOKEN_84(9999): "e", line: 1, col: 25
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 26
+                    TOKEN_93(9999): "n", line: 1, col: 26
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 27
+                    TOKEN_99(9999): "t", line: 1, col: 27
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 28
+                    TOKEN_98(9999): "s", line: 1, col: 28
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 29
@@ -95,9 +93,7 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 34
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 35
-          TOKEN_46(9999): "N", line: 1, col: 36
-          TOKEN_36(9999): "D", line: 1, col: 37
+          TOKEN_35(9999): "AND", line: 1, col: 35
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 38
@@ -108,23 +104,23 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 39
+                      TOKEN_93(9999): "n", line: 1, col: 39
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 40
+                      TOKEN_84(9999): "e", line: 1, col: 40
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 41
+                      TOKEN_91(9999): "l", line: 1, col: 41
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 42
+                      TOKEN_84(9999): "e", line: 1, col: 42
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 43
+                      TOKEN_92(9999): "m", line: 1, col: 43
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 44
+                      TOKEN_84(9999): "e", line: 1, col: 44
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 45
+                      TOKEN_93(9999): "n", line: 1, col: 45
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 46
+                      TOKEN_99(9999): "t", line: 1, col: 46
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 47
+                      TOKEN_98(9999): "s", line: 1, col: 47
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 48
@@ -145,9 +141,7 @@ Filter(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 53
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 54
-            TOKEN_46(9999): "N", line: 1, col: 55
-            TOKEN_36(9999): "D", line: 1, col: 56
+            TOKEN_35(9999): "AND", line: 1, col: 54
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 57
@@ -158,23 +152,23 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 58
+                        TOKEN_93(9999): "n", line: 1, col: 58
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 59
+                        TOKEN_84(9999): "e", line: 1, col: 59
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 60
+                        TOKEN_91(9999): "l", line: 1, col: 60
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 61
+                        TOKEN_84(9999): "e", line: 1, col: 61
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 62
+                        TOKEN_92(9999): "m", line: 1, col: 62
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 63
+                        TOKEN_84(9999): "e", line: 1, col: 63
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 64
+                        TOKEN_93(9999): "n", line: 1, col: 64
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 65
+                        TOKEN_99(9999): "t", line: 1, col: 65
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 66
+                        TOKEN_98(9999): "s", line: 1, col: 66
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 67
@@ -196,9 +190,7 @@ Filter(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 73
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 74
-              TOKEN_46(9999): "N", line: 1, col: 75
-              TOKEN_36(9999): "D", line: 1, col: 76
+              TOKEN_35(9999): "AND", line: 1, col: 74
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 77
@@ -209,23 +201,23 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 78
+                          TOKEN_93(9999): "n", line: 1, col: 78
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 79
+                          TOKEN_84(9999): "e", line: 1, col: 79
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 80
+                          TOKEN_91(9999): "l", line: 1, col: 80
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 81
+                          TOKEN_84(9999): "e", line: 1, col: 81
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 82
+                          TOKEN_92(9999): "m", line: 1, col: 82
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 83
+                          TOKEN_84(9999): "e", line: 1, col: 83
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 84
+                          TOKEN_93(9999): "n", line: 1, col: 84
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 85
+                          TOKEN_99(9999): "t", line: 1, col: 85
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 86
+                          TOKEN_98(9999): "s", line: 1, col: 86
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 87
@@ -247,9 +239,7 @@ Filter(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 93
               AND(9999)
-                TOKEN_33(9999): "A", line: 1, col: 94
-                TOKEN_46(9999): "N", line: 1, col: 95
-                TOKEN_36(9999): "D", line: 1, col: 96
+                TOKEN_35(9999): "AND", line: 1, col: 94
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 97
@@ -260,23 +250,23 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 98
+                            TOKEN_93(9999): "n", line: 1, col: 98
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 99
+                            TOKEN_84(9999): "e", line: 1, col: 99
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 100
+                            TOKEN_91(9999): "l", line: 1, col: 100
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 101
+                            TOKEN_84(9999): "e", line: 1, col: 101
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 102
+                            TOKEN_92(9999): "m", line: 1, col: 102
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 103
+                            TOKEN_84(9999): "e", line: 1, col: 103
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 104
+                            TOKEN_93(9999): "n", line: 1, col: 104
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 105
+                            TOKEN_99(9999): "t", line: 1, col: 105
                           LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 106
+                            TOKEN_98(9999): "s", line: 1, col: 106
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 107

--- a/tests/outputs/Filter_045.out
+++ b/tests/outputs/Filter_045.out
@@ -4,9 +4,7 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         NOT(9999)
-          TOKEN_46(9999): "N", line: 1, col: 1
-          TOKEN_47(9999): "O", line: 1, col: 2
-          TOKEN_52(9999): "T", line: 1, col: 3
+          TOKEN_56(9999): "NOT", line: 1, col: 1
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 4
@@ -23,37 +21,37 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_67(9999): "c", line: 1, col: 7
+                        TOKEN_82(9999): "c", line: 1, col: 7
                       LowercaseLetter(9999)
-                        TOKEN_72(9999): "h", line: 1, col: 8
+                        TOKEN_87(9999): "h", line: 1, col: 8
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 9
+                        TOKEN_84(9999): "e", line: 1, col: 9
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 10
+                        TOKEN_92(9999): "m", line: 1, col: 10
                       LowercaseLetter(9999)
-                        TOKEN_73(9999): "i", line: 1, col: 11
+                        TOKEN_88(9999): "i", line: 1, col: 11
                       LowercaseLetter(9999)
-                        TOKEN_67(9999): "c", line: 1, col: 12
+                        TOKEN_82(9999): "c", line: 1, col: 12
                       LowercaseLetter(9999)
-                        TOKEN_65(9999): "a", line: 1, col: 13
+                        TOKEN_80(9999): "a", line: 1, col: 13
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 14
+                        TOKEN_91(9999): "l", line: 1, col: 14
                       LowercaseLetter(9999)
-                        TOKEN_63(9999): "_", line: 1, col: 15
+                        TOKEN_78(9999): "_", line: 1, col: 15
                       LowercaseLetter(9999)
-                        TOKEN_70(9999): "f", line: 1, col: 16
+                        TOKEN_85(9999): "f", line: 1, col: 16
                       LowercaseLetter(9999)
-                        TOKEN_79(9999): "o", line: 1, col: 17
+                        TOKEN_94(9999): "o", line: 1, col: 17
                       LowercaseLetter(9999)
-                        TOKEN_82(9999): "r", line: 1, col: 18
+                        TOKEN_97(9999): "r", line: 1, col: 18
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 19
+                        TOKEN_92(9999): "m", line: 1, col: 19
                       LowercaseLetter(9999)
-                        TOKEN_85(9999): "u", line: 1, col: 20
+                        TOKEN_100(9999): "u", line: 1, col: 20
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 21
+                        TOKEN_91(9999): "l", line: 1, col: 21
                       LowercaseLetter(9999)
-                        TOKEN_65(9999): "a", line: 1, col: 22
+                        TOKEN_80(9999): "a", line: 1, col: 22
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 23
@@ -75,15 +73,13 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_76(9999): "l", line: 1, col: 28
+                                TOKEN_91(9999): "l", line: 1, col: 28
                         TOKEN_3(9999): """, line: 1, col: 29
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 30
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 31
-              TOKEN_46(9999): "N", line: 1, col: 32
-              TOKEN_36(9999): "D", line: 1, col: 33
+              TOKEN_35(9999): "AND", line: 1, col: 31
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 34
@@ -94,39 +90,39 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 35
+                          TOKEN_95(9999): "p", line: 1, col: 35
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 36
+                          TOKEN_97(9999): "r", line: 1, col: 36
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 37
+                          TOKEN_94(9999): "o", line: 1, col: 37
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 38
+                          TOKEN_99(9999): "t", line: 1, col: 38
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 39
+                          TOKEN_94(9999): "o", line: 1, col: 39
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 40
+                          TOKEN_99(9999): "t", line: 1, col: 40
                         LowercaseLetter(9999)
-                          TOKEN_89(9999): "y", line: 1, col: 41
+                          TOKEN_104(9999): "y", line: 1, col: 41
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 42
+                          TOKEN_95(9999): "p", line: 1, col: 42
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 43
+                          TOKEN_84(9999): "e", line: 1, col: 43
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 44
+                          TOKEN_78(9999): "_", line: 1, col: 44
                         LowercaseLetter(9999)
-                          TOKEN_70(9999): "f", line: 1, col: 45
+                          TOKEN_85(9999): "f", line: 1, col: 45
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 46
+                          TOKEN_94(9999): "o", line: 1, col: 46
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 47
+                          TOKEN_97(9999): "r", line: 1, col: 47
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 48
+                          TOKEN_92(9999): "m", line: 1, col: 48
                         LowercaseLetter(9999)
-                          TOKEN_85(9999): "u", line: 1, col: 49
+                          TOKEN_100(9999): "u", line: 1, col: 49
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 50
+                          TOKEN_91(9999): "l", line: 1, col: 50
                         LowercaseLetter(9999)
-                          TOKEN_65(9999): "a", line: 1, col: 51
+                          TOKEN_80(9999): "a", line: 1, col: 51
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 52
@@ -149,8 +145,7 @@ Filter(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 58
           OR(9999)
-            TOKEN_47(9999): "O", line: 1, col: 59
-            TOKEN_50(9999): "R", line: 1, col: 60
+            TOKEN_59(9999): "OR", line: 1, col: 59
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 61
@@ -162,39 +157,39 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 62
+                          TOKEN_95(9999): "p", line: 1, col: 62
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 63
+                          TOKEN_97(9999): "r", line: 1, col: 63
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 64
+                          TOKEN_94(9999): "o", line: 1, col: 64
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 65
+                          TOKEN_99(9999): "t", line: 1, col: 65
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 66
+                          TOKEN_94(9999): "o", line: 1, col: 66
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 67
+                          TOKEN_99(9999): "t", line: 1, col: 67
                         LowercaseLetter(9999)
-                          TOKEN_89(9999): "y", line: 1, col: 68
+                          TOKEN_104(9999): "y", line: 1, col: 68
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 69
+                          TOKEN_95(9999): "p", line: 1, col: 69
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 70
+                          TOKEN_84(9999): "e", line: 1, col: 70
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 71
+                          TOKEN_78(9999): "_", line: 1, col: 71
                         LowercaseLetter(9999)
-                          TOKEN_70(9999): "f", line: 1, col: 72
+                          TOKEN_85(9999): "f", line: 1, col: 72
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 73
+                          TOKEN_94(9999): "o", line: 1, col: 73
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 74
+                          TOKEN_97(9999): "r", line: 1, col: 74
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 75
+                          TOKEN_92(9999): "m", line: 1, col: 75
                         LowercaseLetter(9999)
-                          TOKEN_85(9999): "u", line: 1, col: 76
+                          TOKEN_100(9999): "u", line: 1, col: 76
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 77
+                          TOKEN_91(9999): "l", line: 1, col: 77
                         LowercaseLetter(9999)
-                          TOKEN_65(9999): "a", line: 1, col: 78
+                          TOKEN_80(9999): "a", line: 1, col: 78
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 79
@@ -211,7 +206,7 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 83
+                                  TOKEN_45(9999): "H", line: 1, col: 83
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Digit(9999)
@@ -220,24 +215,20 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_47(9999): "O", line: 1, col: 85
+                                  TOKEN_57(9999): "O", line: 1, col: 85
                           TOKEN_3(9999): """, line: 1, col: 86
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 87
               AND(9999)
-                TOKEN_33(9999): "A", line: 1, col: 88
-                TOKEN_46(9999): "N", line: 1, col: 89
-                TOKEN_36(9999): "D", line: 1, col: 90
+                TOKEN_35(9999): "AND", line: 1, col: 88
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 91
               ExpressionClause(9999)
                 ExpressionPhrase(9999)
                   NOT(9999)
-                    TOKEN_46(9999): "N", line: 1, col: 92
-                    TOKEN_47(9999): "O", line: 1, col: 93
-                    TOKEN_52(9999): "T", line: 1, col: 94
+                    TOKEN_56(9999): "NOT", line: 1, col: 92
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 95
@@ -246,37 +237,37 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 96
+                            TOKEN_82(9999): "c", line: 1, col: 96
                           LowercaseLetter(9999)
-                            TOKEN_72(9999): "h", line: 1, col: 97
+                            TOKEN_87(9999): "h", line: 1, col: 97
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 98
+                            TOKEN_84(9999): "e", line: 1, col: 98
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 99
+                            TOKEN_92(9999): "m", line: 1, col: 99
                           LowercaseLetter(9999)
-                            TOKEN_73(9999): "i", line: 1, col: 100
+                            TOKEN_88(9999): "i", line: 1, col: 100
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 101
+                            TOKEN_82(9999): "c", line: 1, col: 101
                           LowercaseLetter(9999)
-                            TOKEN_65(9999): "a", line: 1, col: 102
+                            TOKEN_80(9999): "a", line: 1, col: 102
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 103
+                            TOKEN_91(9999): "l", line: 1, col: 103
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 104
+                            TOKEN_78(9999): "_", line: 1, col: 104
                           LowercaseLetter(9999)
-                            TOKEN_70(9999): "f", line: 1, col: 105
+                            TOKEN_85(9999): "f", line: 1, col: 105
                           LowercaseLetter(9999)
-                            TOKEN_79(9999): "o", line: 1, col: 106
+                            TOKEN_94(9999): "o", line: 1, col: 106
                           LowercaseLetter(9999)
-                            TOKEN_82(9999): "r", line: 1, col: 107
+                            TOKEN_97(9999): "r", line: 1, col: 107
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 108
+                            TOKEN_92(9999): "m", line: 1, col: 108
                           LowercaseLetter(9999)
-                            TOKEN_85(9999): "u", line: 1, col: 109
+                            TOKEN_100(9999): "u", line: 1, col: 109
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 110
+                            TOKEN_91(9999): "l", line: 1, col: 110
                           LowercaseLetter(9999)
-                            TOKEN_65(9999): "a", line: 1, col: 111
+                            TOKEN_80(9999): "a", line: 1, col: 111
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 112
@@ -293,12 +284,12 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_52(9999): "T", line: 1, col: 116
+                                    TOKEN_65(9999): "T", line: 1, col: 116
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_73(9999): "i", line: 1, col: 117
+                                    TOKEN_88(9999): "i", line: 1, col: 117
                             TOKEN_3(9999): """, line: 1, col: 118
                             Spaces(9999)
                               Space(9999)

--- a/tests/outputs/Filter_046.out
+++ b/tests/outputs/Filter_046.out
@@ -14,9 +14,7 @@ Filter(9999)
                 ExpressionClause(9999)
                   ExpressionPhrase(9999)
                     NOT(9999)
-                      TOKEN_46(9999): "N", line: 1, col: 3
-                      TOKEN_47(9999): "O", line: 1, col: 4
-                      TOKEN_52(9999): "T", line: 1, col: 5
+                      TOKEN_56(9999): "NOT", line: 1, col: 3
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 6
@@ -30,21 +28,21 @@ Filter(9999)
                               Property(9999)
                                 Identifier(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_63(9999): "_", line: 1, col: 8
+                                    TOKEN_78(9999): "_", line: 1, col: 8
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 9
+                                    TOKEN_84(9999): "e", line: 1, col: 9
                                   LowercaseLetter(9999)
-                                    TOKEN_88(9999): "x", line: 1, col: 10
+                                    TOKEN_103(9999): "x", line: 1, col: 10
                                   LowercaseLetter(9999)
-                                    TOKEN_77(9999): "m", line: 1, col: 11
+                                    TOKEN_92(9999): "m", line: 1, col: 11
                                   LowercaseLetter(9999)
-                                    TOKEN_80(9999): "p", line: 1, col: 12
+                                    TOKEN_95(9999): "p", line: 1, col: 12
                                   LowercaseLetter(9999)
-                                    TOKEN_76(9999): "l", line: 1, col: 13
+                                    TOKEN_91(9999): "l", line: 1, col: 13
                                   LowercaseLetter(9999)
-                                    TOKEN_63(9999): "_", line: 1, col: 14
+                                    TOKEN_78(9999): "_", line: 1, col: 14
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 15
+                                    TOKEN_80(9999): "a", line: 1, col: 15
                               ValueOpRhs(9999)
                                 Operator(9999)
                                   TOKEN_30(9999): ">", line: 1, col: 16
@@ -52,21 +50,21 @@ Filter(9999)
                                   Property(9999)
                                     Identifier(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_63(9999): "_", line: 1, col: 17
+                                        TOKEN_78(9999): "_", line: 1, col: 17
                                       LowercaseLetter(9999)
-                                        TOKEN_69(9999): "e", line: 1, col: 18
+                                        TOKEN_84(9999): "e", line: 1, col: 18
                                       LowercaseLetter(9999)
-                                        TOKEN_88(9999): "x", line: 1, col: 19
+                                        TOKEN_103(9999): "x", line: 1, col: 19
                                       LowercaseLetter(9999)
-                                        TOKEN_77(9999): "m", line: 1, col: 20
+                                        TOKEN_92(9999): "m", line: 1, col: 20
                                       LowercaseLetter(9999)
-                                        TOKEN_80(9999): "p", line: 1, col: 21
+                                        TOKEN_95(9999): "p", line: 1, col: 21
                                       LowercaseLetter(9999)
-                                        TOKEN_76(9999): "l", line: 1, col: 22
+                                        TOKEN_91(9999): "l", line: 1, col: 22
                                       LowercaseLetter(9999)
-                                        TOKEN_63(9999): "_", line: 1, col: 23
+                                        TOKEN_78(9999): "_", line: 1, col: 23
                                       LowercaseLetter(9999)
-                                        TOKEN_66(9999): "b", line: 1, col: 24
+                                        TOKEN_81(9999): "b", line: 1, col: 24
                     ClosingBrace(9999)
                       TOKEN_9(9999): ")", line: 1, col: 25
               ClosingBrace(9999)
@@ -75,9 +73,7 @@ Filter(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 27
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 28
-              TOKEN_46(9999): "N", line: 1, col: 29
-              TOKEN_36(9999): "D", line: 1, col: 30
+              TOKEN_35(9999): "AND", line: 1, col: 28
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 31
@@ -88,21 +84,21 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 32
+                          TOKEN_78(9999): "_", line: 1, col: 32
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 33
+                          TOKEN_84(9999): "e", line: 1, col: 33
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 34
+                          TOKEN_103(9999): "x", line: 1, col: 34
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 35
+                          TOKEN_92(9999): "m", line: 1, col: 35
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 36
+                          TOKEN_95(9999): "p", line: 1, col: 36
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 37
+                          TOKEN_91(9999): "l", line: 1, col: 37
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 38
+                          TOKEN_78(9999): "_", line: 1, col: 38
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 39
+                          TOKEN_103(9999): "x", line: 1, col: 39
                     ValueOpRhs(9999)
                       Operator(9999)
                         TOKEN_30(9999): ">", line: 1, col: 40

--- a/tests/outputs/Filter_047.out
+++ b/tests/outputs/Filter_047.out
@@ -8,23 +8,23 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 1
+                  TOKEN_93(9999): "n", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 2
+                  TOKEN_84(9999): "e", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 3
+                  TOKEN_91(9999): "l", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 4
+                  TOKEN_84(9999): "e", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 5
+                  TOKEN_92(9999): "m", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 6
+                  TOKEN_84(9999): "e", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 7
+                  TOKEN_93(9999): "n", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 8
+                  TOKEN_99(9999): "t", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 9
+                  TOKEN_98(9999): "s", line: 1, col: 9
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 10

--- a/tests/outputs/Filter_048.out
+++ b/tests/outputs/Filter_048.out
@@ -8,41 +8,41 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 1
+                  TOKEN_78(9999): "_", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 2
+                  TOKEN_84(9999): "e", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 3
+                  TOKEN_103(9999): "x", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 5
+                  TOKEN_95(9999): "p", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 6
+                  TOKEN_91(9999): "l", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 7
+                  TOKEN_78(9999): "_", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 8
+                  TOKEN_82(9999): "c", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 9
+                  TOKEN_84(9999): "e", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 10
+                  TOKEN_91(9999): "l", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 11
+                  TOKEN_91(9999): "l", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 12
+                  TOKEN_78(9999): "_", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_86(9999): "v", line: 1, col: 13
+                  TOKEN_101(9999): "v", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 14
+                  TOKEN_94(9999): "o", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 16
+                  TOKEN_100(9999): "u", line: 1, col: 16
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 17
+                  TOKEN_92(9999): "m", line: 1, col: 17
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 18
+                  TOKEN_84(9999): "e", line: 1, col: 18
             ValueOpRhs(9999)
               Operator(9999)
                 TOKEN_28(9999): "<", line: 1, col: 19

--- a/tests/outputs/Filter_049.out
+++ b/tests/outputs/Filter_049.out
@@ -8,33 +8,33 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 1
+                  TOKEN_78(9999): "_", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 2
+                  TOKEN_84(9999): "e", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 3
+                  TOKEN_103(9999): "x", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 5
+                  TOKEN_95(9999): "p", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 6
+                  TOKEN_91(9999): "l", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 7
+                  TOKEN_78(9999): "_", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_66(9999): "b", line: 1, col: 8
+                  TOKEN_81(9999): "b", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 9
+                  TOKEN_80(9999): "a", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 10
+                  TOKEN_93(9999): "n", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_68(9999): "d", line: 1, col: 11
+                  TOKEN_83(9999): "d", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_71(9999): "g", line: 1, col: 12
+                  TOKEN_86(9999): "g", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 13
+                  TOKEN_80(9999): "a", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 14
+                  TOKEN_95(9999): "p", line: 1, col: 14
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 15
@@ -57,9 +57,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 21
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 22
-        TOKEN_46(9999): "N", line: 1, col: 23
-        TOKEN_36(9999): "D", line: 1, col: 24
+        TOKEN_35(9999): "AND", line: 1, col: 22
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 25
@@ -70,51 +68,51 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 26
+                    TOKEN_78(9999): "_", line: 1, col: 26
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 27
+                    TOKEN_84(9999): "e", line: 1, col: 27
                   LowercaseLetter(9999)
-                    TOKEN_88(9999): "x", line: 1, col: 28
+                    TOKEN_103(9999): "x", line: 1, col: 28
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 29
+                    TOKEN_92(9999): "m", line: 1, col: 29
                   LowercaseLetter(9999)
-                    TOKEN_80(9999): "p", line: 1, col: 30
+                    TOKEN_95(9999): "p", line: 1, col: 30
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 31
+                    TOKEN_91(9999): "l", line: 1, col: 31
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 32
+                    TOKEN_78(9999): "_", line: 1, col: 32
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 33
+                    TOKEN_92(9999): "m", line: 1, col: 33
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 34
+                    TOKEN_94(9999): "o", line: 1, col: 34
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 35
+                    TOKEN_91(9999): "l", line: 1, col: 35
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 36
+                    TOKEN_84(9999): "e", line: 1, col: 36
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 37
+                    TOKEN_82(9999): "c", line: 1, col: 37
                   LowercaseLetter(9999)
-                    TOKEN_85(9999): "u", line: 1, col: 38
+                    TOKEN_100(9999): "u", line: 1, col: 38
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 39
+                    TOKEN_91(9999): "l", line: 1, col: 39
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 40
+                    TOKEN_80(9999): "a", line: 1, col: 40
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 41
+                    TOKEN_97(9999): "r", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 42
+                    TOKEN_78(9999): "_", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_87(9999): "w", line: 1, col: 43
+                    TOKEN_102(9999): "w", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 44
+                    TOKEN_84(9999): "e", line: 1, col: 44
                   LowercaseLetter(9999)
-                    TOKEN_73(9999): "i", line: 1, col: 45
+                    TOKEN_88(9999): "i", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_71(9999): "g", line: 1, col: 46
+                    TOKEN_86(9999): "g", line: 1, col: 46
                   LowercaseLetter(9999)
-                    TOKEN_72(9999): "h", line: 1, col: 47
+                    TOKEN_87(9999): "h", line: 1, col: 47
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 48
+                    TOKEN_99(9999): "t", line: 1, col: 48
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 49

--- a/tests/outputs/Filter_050.out
+++ b/tests/outputs/Filter_050.out
@@ -8,25 +8,25 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 1
+                  TOKEN_78(9999): "_", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 2
+                  TOKEN_84(9999): "e", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 3
+                  TOKEN_103(9999): "x", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 5
+                  TOKEN_95(9999): "p", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 6
+                  TOKEN_91(9999): "l", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 7
+                  TOKEN_78(9999): "_", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 8
+                  TOKEN_80(9999): "a", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 9
+                  TOKEN_80(9999): "a", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 10
+                  TOKEN_103(9999): "x", line: 1, col: 10
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 11
@@ -46,7 +46,7 @@ Filter(9999)
                     Digit(9999)
                       TOKEN_17(9999): "1", line: 1, col: 17
                   Exponent(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 18
+                    TOKEN_84(9999): "e", line: 1, col: 18
                     Digits(9999)
                       Digit(9999)
                         TOKEN_24(9999): "8", line: 1, col: 19
@@ -54,8 +54,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 20
     OR(9999)
-      TOKEN_47(9999): "O", line: 1, col: 21
-      TOKEN_50(9999): "R", line: 1, col: 22
+      TOKEN_59(9999): "OR", line: 1, col: 21
       Spaces(9999)
         Space(9999)
           TOKEN_1(9999): " ", line: 1, col: 23
@@ -67,23 +66,23 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 24
+                    TOKEN_93(9999): "n", line: 1, col: 24
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 25
+                    TOKEN_84(9999): "e", line: 1, col: 25
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 26
+                    TOKEN_91(9999): "l", line: 1, col: 26
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 27
+                    TOKEN_84(9999): "e", line: 1, col: 27
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 28
+                    TOKEN_92(9999): "m", line: 1, col: 28
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 29
+                    TOKEN_84(9999): "e", line: 1, col: 29
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 30
+                    TOKEN_93(9999): "n", line: 1, col: 30
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 31
+                    TOKEN_99(9999): "t", line: 1, col: 31
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 32
+                    TOKEN_98(9999): "s", line: 1, col: 32
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 33
@@ -105,18 +104,14 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 39
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 40
-          TOKEN_46(9999): "N", line: 1, col: 41
-          TOKEN_36(9999): "D", line: 1, col: 42
+          TOKEN_35(9999): "AND", line: 1, col: 40
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 43
         ExpressionClause(9999)
           ExpressionPhrase(9999)
             NOT(9999)
-              TOKEN_46(9999): "N", line: 1, col: 44
-              TOKEN_47(9999): "O", line: 1, col: 45
-              TOKEN_52(9999): "T", line: 1, col: 46
+              TOKEN_56(9999): "NOT", line: 1, col: 44
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 47
@@ -133,21 +128,21 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 50
+                            TOKEN_78(9999): "_", line: 1, col: 50
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 51
+                            TOKEN_84(9999): "e", line: 1, col: 51
                           LowercaseLetter(9999)
-                            TOKEN_88(9999): "x", line: 1, col: 52
+                            TOKEN_103(9999): "x", line: 1, col: 52
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 53
+                            TOKEN_92(9999): "m", line: 1, col: 53
                           LowercaseLetter(9999)
-                            TOKEN_80(9999): "p", line: 1, col: 54
+                            TOKEN_95(9999): "p", line: 1, col: 54
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 55
+                            TOKEN_91(9999): "l", line: 1, col: 55
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 56
+                            TOKEN_78(9999): "_", line: 1, col: 56
                           LowercaseLetter(9999)
-                            TOKEN_88(9999): "x", line: 1, col: 57
+                            TOKEN_103(9999): "x", line: 1, col: 57
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 58
@@ -165,22 +160,22 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_51(9999): "S", line: 1, col: 63
+                                    TOKEN_63(9999): "S", line: 1, col: 63
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_79(9999): "o", line: 1, col: 64
+                                    TOKEN_94(9999): "o", line: 1, col: 64
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_77(9999): "m", line: 1, col: 65
+                                    TOKEN_92(9999): "m", line: 1, col: 65
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 66
+                                    TOKEN_84(9999): "e", line: 1, col: 66
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Space(9999)
@@ -189,39 +184,38 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_83(9999): "s", line: 1, col: 68
+                                    TOKEN_98(9999): "s", line: 1, col: 68
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_84(9999): "t", line: 1, col: 69
+                                    TOKEN_99(9999): "t", line: 1, col: 69
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_82(9999): "r", line: 1, col: 70
+                                    TOKEN_97(9999): "r", line: 1, col: 70
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_73(9999): "i", line: 1, col: 71
+                                    TOKEN_88(9999): "i", line: 1, col: 71
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_78(9999): "n", line: 1, col: 72
+                                    TOKEN_93(9999): "n", line: 1, col: 72
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_71(9999): "g", line: 1, col: 73
+                                    TOKEN_86(9999): "g", line: 1, col: 73
                             TOKEN_3(9999): """, line: 1, col: 74
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 75
               OR(9999)
-                TOKEN_47(9999): "O", line: 1, col: 76
-                TOKEN_50(9999): "R", line: 1, col: 77
+                TOKEN_59(9999): "OR", line: 1, col: 76
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 78
@@ -229,9 +223,7 @@ Filter(9999)
                 ExpressionClause(9999)
                   ExpressionPhrase(9999)
                     NOT(9999)
-                      TOKEN_46(9999): "N", line: 1, col: 79
-                      TOKEN_47(9999): "O", line: 1, col: 80
-                      TOKEN_52(9999): "T", line: 1, col: 81
+                      TOKEN_56(9999): "NOT", line: 1, col: 79
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 82
@@ -240,21 +232,21 @@ Filter(9999)
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 83
+                              TOKEN_78(9999): "_", line: 1, col: 83
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 84
+                              TOKEN_84(9999): "e", line: 1, col: 84
                             LowercaseLetter(9999)
-                              TOKEN_88(9999): "x", line: 1, col: 85
+                              TOKEN_103(9999): "x", line: 1, col: 85
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 86
+                              TOKEN_92(9999): "m", line: 1, col: 86
                             LowercaseLetter(9999)
-                              TOKEN_80(9999): "p", line: 1, col: 87
+                              TOKEN_95(9999): "p", line: 1, col: 87
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 88
+                              TOKEN_91(9999): "l", line: 1, col: 88
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 89
+                              TOKEN_78(9999): "_", line: 1, col: 89
                             LowercaseLetter(9999)
-                              TOKEN_65(9999): "a", line: 1, col: 90
+                              TOKEN_80(9999): "a", line: 1, col: 90
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 91

--- a/tests/outputs/Filter_051.out
+++ b/tests/outputs/Filter_051.out
@@ -8,45 +8,45 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 1
+                  TOKEN_78(9999): "_", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 2
+                  TOKEN_84(9999): "e", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 3
+                  TOKEN_103(9999): "x", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 5
+                  TOKEN_95(9999): "p", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 6
+                  TOKEN_91(9999): "l", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 7
+                  TOKEN_78(9999): "_", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 8
+                  TOKEN_92(9999): "m", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 9
+                  TOKEN_84(9999): "e", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 10
+                  TOKEN_91(9999): "l", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 11
+                  TOKEN_99(9999): "t", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 12
+                  TOKEN_88(9999): "i", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 13
+                  TOKEN_93(9999): "n", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_71(9999): "g", line: 1, col: 14
+                  TOKEN_86(9999): "g", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 15
+                  TOKEN_78(9999): "_", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 16
+                  TOKEN_95(9999): "p", line: 1, col: 16
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 17
+                  TOKEN_94(9999): "o", line: 1, col: 17
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 18
+                  TOKEN_88(9999): "i", line: 1, col: 18
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 19
+                  TOKEN_93(9999): "n", line: 1, col: 19
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 20
+                  TOKEN_99(9999): "t", line: 1, col: 20
             ValueOpRhs(9999)
               Operator(9999)
                 TOKEN_28(9999): "<", line: 1, col: 21
@@ -63,9 +63,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 25
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 26
-        TOKEN_46(9999): "N", line: 1, col: 27
-        TOKEN_36(9999): "D", line: 1, col: 28
+        TOKEN_35(9999): "AND", line: 1, col: 26
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 29
@@ -76,23 +74,23 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 30
+                    TOKEN_93(9999): "n", line: 1, col: 30
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 31
+                    TOKEN_84(9999): "e", line: 1, col: 31
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 32
+                    TOKEN_91(9999): "l", line: 1, col: 32
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 33
+                    TOKEN_84(9999): "e", line: 1, col: 33
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 34
+                    TOKEN_92(9999): "m", line: 1, col: 34
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 35
+                    TOKEN_84(9999): "e", line: 1, col: 35
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 36
+                    TOKEN_93(9999): "n", line: 1, col: 36
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 37
+                    TOKEN_99(9999): "t", line: 1, col: 37
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 38
+                    TOKEN_98(9999): "s", line: 1, col: 38
               ValueOpRhs(9999)
                 Operator(9999)
                   TOKEN_29(9999): "=", line: 1, col: 39
@@ -105,9 +103,7 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 41
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 42
-          TOKEN_46(9999): "N", line: 1, col: 43
-          TOKEN_36(9999): "D", line: 1, col: 44
+          TOKEN_35(9999): "AND", line: 1, col: 42
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 45
@@ -118,21 +114,21 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 46
+                      TOKEN_84(9999): "e", line: 1, col: 46
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 47
+                      TOKEN_91(9999): "l", line: 1, col: 47
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 48
+                      TOKEN_84(9999): "e", line: 1, col: 48
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 49
+                      TOKEN_92(9999): "m", line: 1, col: 49
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 50
+                      TOKEN_84(9999): "e", line: 1, col: 50
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 51
+                      TOKEN_93(9999): "n", line: 1, col: 51
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 52
+                      TOKEN_99(9999): "t", line: 1, col: 52
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 53
+                      TOKEN_98(9999): "s", line: 1, col: 53
                 ValueOpRhs(9999)
                   Operator(9999)
                     TOKEN_29(9999): "=", line: 1, col: 54
@@ -143,12 +139,12 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_51(9999): "S", line: 1, col: 56
+                              TOKEN_63(9999): "S", line: 1, col: 56
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_73(9999): "i", line: 1, col: 57
+                              TOKEN_88(9999): "i", line: 1, col: 57
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Punctuator(9999)
@@ -157,7 +153,7 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_47(9999): "O", line: 1, col: 59
+                              TOKEN_57(9999): "O", line: 1, col: 59
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Digit(9999)

--- a/tests/outputs/Filter_052.out
+++ b/tests/outputs/Filter_052.out
@@ -4,9 +4,7 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         NOT(9999)
-          TOKEN_46(9999): "N", line: 1, col: 1
-          TOKEN_47(9999): "O", line: 1, col: 2
-          TOKEN_52(9999): "T", line: 1, col: 3
+          TOKEN_56(9999): "NOT", line: 1, col: 1
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 4
@@ -15,7 +13,7 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 5
+                  TOKEN_80(9999): "a", line: 1, col: 5
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 6
@@ -29,13 +27,12 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_66(9999): "b", line: 1, col: 9
+                      TOKEN_81(9999): "b", line: 1, col: 9
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 10
     OR(9999)
-      TOKEN_47(9999): "O", line: 1, col: 11
-      TOKEN_50(9999): "R", line: 1, col: 12
+      TOKEN_59(9999): "OR", line: 1, col: 11
       Spaces(9999)
         Space(9999)
           TOKEN_1(9999): " ", line: 1, col: 13
@@ -47,7 +44,7 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 14
+                    TOKEN_82(9999): "c", line: 1, col: 14
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 15
@@ -70,9 +67,7 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 21
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 22
-          TOKEN_46(9999): "N", line: 1, col: 23
-          TOKEN_36(9999): "D", line: 1, col: 24
+          TOKEN_35(9999): "AND", line: 1, col: 22
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 25
@@ -83,7 +78,7 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_70(9999): "f", line: 1, col: 26
+                      TOKEN_85(9999): "f", line: 1, col: 26
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 27
@@ -100,7 +95,7 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_35(9999): "C", line: 1, col: 31
+                              TOKEN_38(9999): "C", line: 1, col: 31
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Digit(9999)
@@ -113,7 +108,7 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_40(9999): "H", line: 1, col: 34
+                              TOKEN_45(9999): "H", line: 1, col: 34
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Digit(9999)

--- a/tests/outputs/Filter_053.out
+++ b/tests/outputs/Filter_053.out
@@ -8,7 +8,7 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 1
+                  TOKEN_80(9999): "a", line: 1, col: 1
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 2
@@ -28,18 +28,14 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 7
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 8
-        TOKEN_46(9999): "N", line: 1, col: 9
-        TOKEN_36(9999): "D", line: 1, col: 10
+        TOKEN_35(9999): "AND", line: 1, col: 8
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 11
       ExpressionClause(9999)
         ExpressionPhrase(9999)
           NOT(9999)
-            TOKEN_46(9999): "N", line: 1, col: 12
-            TOKEN_47(9999): "O", line: 1, col: 13
-            TOKEN_52(9999): "T", line: 1, col: 14
+            TOKEN_56(9999): "NOT", line: 1, col: 12
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 15
@@ -48,7 +44,7 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_66(9999): "b", line: 1, col: 16
+                    TOKEN_81(9999): "b", line: 1, col: 16
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 17
@@ -62,13 +58,12 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_67(9999): "c", line: 1, col: 20
+                        TOKEN_82(9999): "c", line: 1, col: 20
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 21
     OR(9999)
-      TOKEN_47(9999): "O", line: 1, col: 22
-      TOKEN_50(9999): "R", line: 1, col: 23
+      TOKEN_59(9999): "OR", line: 1, col: 22
       Spaces(9999)
         Space(9999)
           TOKEN_1(9999): " ", line: 1, col: 24
@@ -80,7 +75,7 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 25
+                    TOKEN_82(9999): "c", line: 1, col: 25
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 26

--- a/tests/outputs/Filter_054.out
+++ b/tests/outputs/Filter_054.out
@@ -8,29 +8,27 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
             SetOpRhs(9999)
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 10
-                TOKEN_33(9999): "A", line: 1, col: 11
-                TOKEN_51(9999): "S", line: 1, col: 12
+                TOKEN_46(9999): "HAS", line: 1, col: 10
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 13
@@ -41,15 +39,13 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_40(9999): "H", line: 1, col: 15
+                          TOKEN_45(9999): "H", line: 1, col: 15
                   TOKEN_3(9999): """, line: 1, col: 16
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 17
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 18
-        TOKEN_46(9999): "N", line: 1, col: 19
-        TOKEN_36(9999): "D", line: 1, col: 20
+        TOKEN_35(9999): "AND", line: 1, col: 18
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 21
@@ -60,36 +56,32 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 22
+                    TOKEN_84(9999): "e", line: 1, col: 22
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 23
+                    TOKEN_91(9999): "l", line: 1, col: 23
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 24
+                    TOKEN_84(9999): "e", line: 1, col: 24
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 25
+                    TOKEN_92(9999): "m", line: 1, col: 25
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 26
+                    TOKEN_84(9999): "e", line: 1, col: 26
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 27
+                    TOKEN_93(9999): "n", line: 1, col: 27
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 28
+                    TOKEN_99(9999): "t", line: 1, col: 28
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 29
+                    TOKEN_98(9999): "s", line: 1, col: 29
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 30
               SetOpRhs(9999)
                 HAS(9999)
-                  TOKEN_40(9999): "H", line: 1, col: 31
-                  TOKEN_33(9999): "A", line: 1, col: 32
-                  TOKEN_51(9999): "S", line: 1, col: 33
+                  TOKEN_46(9999): "HAS", line: 1, col: 31
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 34
                 ALL(9999)
-                  TOKEN_33(9999): "A", line: 1, col: 35
-                  TOKEN_44(9999): "L", line: 1, col: 36
-                  TOKEN_44(9999): "L", line: 1, col: 37
+                  TOKEN_34(9999): "ALL", line: 1, col: 35
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 38
@@ -101,7 +93,7 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_40(9999): "H", line: 1, col: 40
+                              TOKEN_45(9999): "H", line: 1, col: 40
                       TOKEN_3(9999): """, line: 1, col: 41
                   Comma(9999)
                     TOKEN_12(9999): ",", line: 1, col: 42
@@ -112,12 +104,12 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_40(9999): "H", line: 1, col: 44
+                              TOKEN_45(9999): "H", line: 1, col: 44
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 45
+                              TOKEN_84(9999): "e", line: 1, col: 45
                       TOKEN_3(9999): """, line: 1, col: 46
                   Comma(9999)
                     TOKEN_12(9999): ",", line: 1, col: 47
@@ -128,12 +120,12 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_39(9999): "G", line: 1, col: 49
+                              TOKEN_44(9999): "G", line: 1, col: 49
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_65(9999): "a", line: 1, col: 50
+                              TOKEN_80(9999): "a", line: 1, col: 50
                       TOKEN_3(9999): """, line: 1, col: 51
                   Comma(9999)
                     TOKEN_12(9999): ",", line: 1, col: 52
@@ -144,20 +136,18 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_52(9999): "T", line: 1, col: 54
+                              TOKEN_65(9999): "T", line: 1, col: 54
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_65(9999): "a", line: 1, col: 55
+                              TOKEN_80(9999): "a", line: 1, col: 55
                       TOKEN_3(9999): """, line: 1, col: 56
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 57
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 58
-          TOKEN_46(9999): "N", line: 1, col: 59
-          TOKEN_36(9999): "D", line: 1, col: 60
+          TOKEN_35(9999): "AND", line: 1, col: 58
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 61
@@ -168,37 +158,32 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 62
+                      TOKEN_84(9999): "e", line: 1, col: 62
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 63
+                      TOKEN_91(9999): "l", line: 1, col: 63
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 64
+                      TOKEN_84(9999): "e", line: 1, col: 64
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 65
+                      TOKEN_92(9999): "m", line: 1, col: 65
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 66
+                      TOKEN_84(9999): "e", line: 1, col: 66
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 67
+                      TOKEN_93(9999): "n", line: 1, col: 67
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 68
+                      TOKEN_99(9999): "t", line: 1, col: 68
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 69
+                      TOKEN_98(9999): "s", line: 1, col: 69
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 70
                 SetOpRhs(9999)
                   HAS(9999)
-                    TOKEN_40(9999): "H", line: 1, col: 71
-                    TOKEN_33(9999): "A", line: 1, col: 72
-                    TOKEN_51(9999): "S", line: 1, col: 73
+                    TOKEN_46(9999): "HAS", line: 1, col: 71
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 74
                   ONLY(9999)
-                    TOKEN_47(9999): "O", line: 1, col: 75
-                    TOKEN_46(9999): "N", line: 1, col: 76
-                    TOKEN_44(9999): "L", line: 1, col: 77
-                    TOKEN_57(9999): "Y", line: 1, col: 78
+                    TOKEN_58(9999): "ONLY", line: 1, col: 75
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 79
@@ -210,7 +195,7 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 81
+                                TOKEN_45(9999): "H", line: 1, col: 81
                         TOKEN_3(9999): """, line: 1, col: 82
                     Comma(9999)
                       TOKEN_12(9999): ",", line: 1, col: 83
@@ -221,12 +206,12 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 85
+                                TOKEN_45(9999): "H", line: 1, col: 85
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_69(9999): "e", line: 1, col: 86
+                                TOKEN_84(9999): "e", line: 1, col: 86
                         TOKEN_3(9999): """, line: 1, col: 87
                     Comma(9999)
                       TOKEN_12(9999): ",", line: 1, col: 88
@@ -237,12 +222,12 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_39(9999): "G", line: 1, col: 90
+                                TOKEN_44(9999): "G", line: 1, col: 90
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_65(9999): "a", line: 1, col: 91
+                                TOKEN_80(9999): "a", line: 1, col: 91
                         TOKEN_3(9999): """, line: 1, col: 92
                     Comma(9999)
                       TOKEN_12(9999): ",", line: 1, col: 93
@@ -253,20 +238,18 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_52(9999): "T", line: 1, col: 95
+                                TOKEN_65(9999): "T", line: 1, col: 95
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_65(9999): "a", line: 1, col: 96
+                                TOKEN_80(9999): "a", line: 1, col: 96
                         TOKEN_3(9999): """, line: 1, col: 97
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 98
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 99
-            TOKEN_46(9999): "N", line: 1, col: 100
-            TOKEN_36(9999): "D", line: 1, col: 101
+            TOKEN_35(9999): "AND", line: 1, col: 99
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 102
@@ -277,36 +260,32 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 103
+                        TOKEN_84(9999): "e", line: 1, col: 103
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 104
+                        TOKEN_91(9999): "l", line: 1, col: 104
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 105
+                        TOKEN_84(9999): "e", line: 1, col: 105
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 106
+                        TOKEN_92(9999): "m", line: 1, col: 106
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 107
+                        TOKEN_84(9999): "e", line: 1, col: 107
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 108
+                        TOKEN_93(9999): "n", line: 1, col: 108
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 109
+                        TOKEN_99(9999): "t", line: 1, col: 109
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 110
+                        TOKEN_98(9999): "s", line: 1, col: 110
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 111
                   SetOpRhs(9999)
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 112
-                      TOKEN_33(9999): "A", line: 1, col: 113
-                      TOKEN_51(9999): "S", line: 1, col: 114
+                      TOKEN_46(9999): "HAS", line: 1, col: 112
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 115
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 116
-                      TOKEN_46(9999): "N", line: 1, col: 117
-                      TOKEN_57(9999): "Y", line: 1, col: 118
+                      TOKEN_36(9999): "ANY", line: 1, col: 116
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 119
@@ -318,7 +297,7 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 121
+                                  TOKEN_45(9999): "H", line: 1, col: 121
                           TOKEN_3(9999): """, line: 1, col: 122
                       Comma(9999)
                         TOKEN_12(9999): ",", line: 1, col: 123
@@ -332,12 +311,12 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 126
+                                  TOKEN_45(9999): "H", line: 1, col: 126
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_69(9999): "e", line: 1, col: 127
+                                  TOKEN_84(9999): "e", line: 1, col: 127
                           TOKEN_3(9999): """, line: 1, col: 128
                       Comma(9999)
                         TOKEN_12(9999): ",", line: 1, col: 129
@@ -351,12 +330,12 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_39(9999): "G", line: 1, col: 132
+                                  TOKEN_44(9999): "G", line: 1, col: 132
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 133
+                                  TOKEN_80(9999): "a", line: 1, col: 133
                           TOKEN_3(9999): """, line: 1, col: 134
                       Comma(9999)
                         TOKEN_12(9999): ",", line: 1, col: 135
@@ -370,10 +349,10 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_52(9999): "T", line: 1, col: 138
+                                  TOKEN_65(9999): "T", line: 1, col: 138
                           EscapedChar(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 LowercaseLetter(9999)
-                                  TOKEN_65(9999): "a", line: 1, col: 139
+                                  TOKEN_80(9999): "a", line: 1, col: 139
                           TOKEN_3(9999): """, line: 1, col: 140

--- a/tests/outputs/Filter_055.out
+++ b/tests/outputs/Filter_055.out
@@ -8,21 +8,21 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
             SetZipOpRhs(9999)
               PropertyZipAddon(9999)
                 Colon(9999)
@@ -30,54 +30,52 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 10
+                      TOKEN_78(9999): "_", line: 1, col: 10
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 11
+                      TOKEN_84(9999): "e", line: 1, col: 11
                     LowercaseLetter(9999)
-                      TOKEN_88(9999): "x", line: 1, col: 12
+                      TOKEN_103(9999): "x", line: 1, col: 12
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 13
+                      TOKEN_92(9999): "m", line: 1, col: 13
                     LowercaseLetter(9999)
-                      TOKEN_80(9999): "p", line: 1, col: 14
+                      TOKEN_95(9999): "p", line: 1, col: 14
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 15
+                      TOKEN_91(9999): "l", line: 1, col: 15
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 16
+                      TOKEN_78(9999): "_", line: 1, col: 16
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 17
+                      TOKEN_84(9999): "e", line: 1, col: 17
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 18
+                      TOKEN_91(9999): "l", line: 1, col: 18
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 19
+                      TOKEN_84(9999): "e", line: 1, col: 19
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 20
+                      TOKEN_92(9999): "m", line: 1, col: 20
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 21
+                      TOKEN_84(9999): "e", line: 1, col: 21
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 22
+                      TOKEN_93(9999): "n", line: 1, col: 22
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 23
+                      TOKEN_99(9999): "t", line: 1, col: 23
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 24
+                      TOKEN_78(9999): "_", line: 1, col: 24
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 25
+                      TOKEN_82(9999): "c", line: 1, col: 25
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 26
+                      TOKEN_94(9999): "o", line: 1, col: 26
                     LowercaseLetter(9999)
-                      TOKEN_85(9999): "u", line: 1, col: 27
+                      TOKEN_100(9999): "u", line: 1, col: 27
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 28
+                      TOKEN_93(9999): "n", line: 1, col: 28
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 29
+                      TOKEN_99(9999): "t", line: 1, col: 29
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 30
+                      TOKEN_98(9999): "s", line: 1, col: 30
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 31
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 32
-                TOKEN_33(9999): "A", line: 1, col: 33
-                TOKEN_51(9999): "S", line: 1, col: 34
+                TOKEN_46(9999): "HAS", line: 1, col: 32
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 35
@@ -89,7 +87,7 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           UppercaseLetter(9999)
-                            TOKEN_40(9999): "H", line: 1, col: 37
+                            TOKEN_45(9999): "H", line: 1, col: 37
                     TOKEN_3(9999): """, line: 1, col: 38
                 Colon(9999)
                   TOKEN_26(9999): ":", line: 1, col: 39
@@ -102,9 +100,7 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 41
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 42
-        TOKEN_46(9999): "N", line: 1, col: 43
-        TOKEN_36(9999): "D", line: 1, col: 44
+        TOKEN_35(9999): "AND", line: 1, col: 42
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 45
@@ -115,21 +111,21 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 46
+                    TOKEN_84(9999): "e", line: 1, col: 46
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 47
+                    TOKEN_91(9999): "l", line: 1, col: 47
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 48
+                    TOKEN_84(9999): "e", line: 1, col: 48
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 49
+                    TOKEN_92(9999): "m", line: 1, col: 49
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 50
+                    TOKEN_84(9999): "e", line: 1, col: 50
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 51
+                    TOKEN_93(9999): "n", line: 1, col: 51
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 52
+                    TOKEN_99(9999): "t", line: 1, col: 52
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 53
+                    TOKEN_98(9999): "s", line: 1, col: 53
               SetZipOpRhs(9999)
                 PropertyZipAddon(9999)
                   Colon(9999)
@@ -137,61 +133,57 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_63(9999): "_", line: 1, col: 55
+                        TOKEN_78(9999): "_", line: 1, col: 55
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 56
+                        TOKEN_84(9999): "e", line: 1, col: 56
                       LowercaseLetter(9999)
-                        TOKEN_88(9999): "x", line: 1, col: 57
+                        TOKEN_103(9999): "x", line: 1, col: 57
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 58
+                        TOKEN_92(9999): "m", line: 1, col: 58
                       LowercaseLetter(9999)
-                        TOKEN_80(9999): "p", line: 1, col: 59
+                        TOKEN_95(9999): "p", line: 1, col: 59
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 60
+                        TOKEN_91(9999): "l", line: 1, col: 60
                       LowercaseLetter(9999)
-                        TOKEN_63(9999): "_", line: 1, col: 61
+                        TOKEN_78(9999): "_", line: 1, col: 61
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 62
+                        TOKEN_84(9999): "e", line: 1, col: 62
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 63
+                        TOKEN_91(9999): "l", line: 1, col: 63
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 64
+                        TOKEN_84(9999): "e", line: 1, col: 64
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 65
+                        TOKEN_92(9999): "m", line: 1, col: 65
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 66
+                        TOKEN_84(9999): "e", line: 1, col: 66
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 67
+                        TOKEN_93(9999): "n", line: 1, col: 67
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 68
+                        TOKEN_99(9999): "t", line: 1, col: 68
                       LowercaseLetter(9999)
-                        TOKEN_63(9999): "_", line: 1, col: 69
+                        TOKEN_78(9999): "_", line: 1, col: 69
                       LowercaseLetter(9999)
-                        TOKEN_67(9999): "c", line: 1, col: 70
+                        TOKEN_82(9999): "c", line: 1, col: 70
                       LowercaseLetter(9999)
-                        TOKEN_79(9999): "o", line: 1, col: 71
+                        TOKEN_94(9999): "o", line: 1, col: 71
                       LowercaseLetter(9999)
-                        TOKEN_85(9999): "u", line: 1, col: 72
+                        TOKEN_100(9999): "u", line: 1, col: 72
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 73
+                        TOKEN_93(9999): "n", line: 1, col: 73
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 74
+                        TOKEN_99(9999): "t", line: 1, col: 74
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 75
+                        TOKEN_98(9999): "s", line: 1, col: 75
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 76
                 HAS(9999)
-                  TOKEN_40(9999): "H", line: 1, col: 77
-                  TOKEN_33(9999): "A", line: 1, col: 78
-                  TOKEN_51(9999): "S", line: 1, col: 79
+                  TOKEN_46(9999): "HAS", line: 1, col: 77
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 80
                 ALL(9999)
-                  TOKEN_33(9999): "A", line: 1, col: 81
-                  TOKEN_44(9999): "L", line: 1, col: 82
-                  TOKEN_44(9999): "L", line: 1, col: 83
+                  TOKEN_34(9999): "ALL", line: 1, col: 81
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 84
@@ -204,7 +196,7 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 86
+                                TOKEN_45(9999): "H", line: 1, col: 86
                         TOKEN_3(9999): """, line: 1, col: 87
                     Colon(9999)
                       TOKEN_26(9999): ":", line: 1, col: 88
@@ -223,12 +215,12 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 92
+                                TOKEN_45(9999): "H", line: 1, col: 92
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_69(9999): "e", line: 1, col: 93
+                                TOKEN_84(9999): "e", line: 1, col: 93
                         TOKEN_3(9999): """, line: 1, col: 94
                     Colon(9999)
                       TOKEN_26(9999): ":", line: 1, col: 95
@@ -241,9 +233,7 @@ Filter(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 97
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 98
-          TOKEN_46(9999): "N", line: 1, col: 99
-          TOKEN_36(9999): "D", line: 1, col: 100
+          TOKEN_35(9999): "AND", line: 1, col: 98
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 101
@@ -254,21 +244,21 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 102
+                      TOKEN_84(9999): "e", line: 1, col: 102
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 103
+                      TOKEN_91(9999): "l", line: 1, col: 103
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 104
+                      TOKEN_84(9999): "e", line: 1, col: 104
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 105
+                      TOKEN_92(9999): "m", line: 1, col: 105
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 106
+                      TOKEN_84(9999): "e", line: 1, col: 106
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 107
+                      TOKEN_93(9999): "n", line: 1, col: 107
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 108
+                      TOKEN_99(9999): "t", line: 1, col: 108
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 109
+                      TOKEN_98(9999): "s", line: 1, col: 109
                 SetZipOpRhs(9999)
                   PropertyZipAddon(9999)
                     Colon(9999)
@@ -276,62 +266,57 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 111
+                          TOKEN_78(9999): "_", line: 1, col: 111
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 112
+                          TOKEN_84(9999): "e", line: 1, col: 112
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 113
+                          TOKEN_103(9999): "x", line: 1, col: 113
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 114
+                          TOKEN_92(9999): "m", line: 1, col: 114
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 115
+                          TOKEN_95(9999): "p", line: 1, col: 115
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 116
+                          TOKEN_91(9999): "l", line: 1, col: 116
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 117
+                          TOKEN_78(9999): "_", line: 1, col: 117
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 118
+                          TOKEN_84(9999): "e", line: 1, col: 118
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 119
+                          TOKEN_91(9999): "l", line: 1, col: 119
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 120
+                          TOKEN_84(9999): "e", line: 1, col: 120
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 121
+                          TOKEN_92(9999): "m", line: 1, col: 121
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 122
+                          TOKEN_84(9999): "e", line: 1, col: 122
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 123
+                          TOKEN_93(9999): "n", line: 1, col: 123
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 124
+                          TOKEN_99(9999): "t", line: 1, col: 124
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 125
+                          TOKEN_78(9999): "_", line: 1, col: 125
                         LowercaseLetter(9999)
-                          TOKEN_67(9999): "c", line: 1, col: 126
+                          TOKEN_82(9999): "c", line: 1, col: 126
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 127
+                          TOKEN_94(9999): "o", line: 1, col: 127
                         LowercaseLetter(9999)
-                          TOKEN_85(9999): "u", line: 1, col: 128
+                          TOKEN_100(9999): "u", line: 1, col: 128
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 129
+                          TOKEN_93(9999): "n", line: 1, col: 129
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 130
+                          TOKEN_99(9999): "t", line: 1, col: 130
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 131
+                          TOKEN_98(9999): "s", line: 1, col: 131
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 132
                   HAS(9999)
-                    TOKEN_40(9999): "H", line: 1, col: 133
-                    TOKEN_33(9999): "A", line: 1, col: 134
-                    TOKEN_51(9999): "S", line: 1, col: 135
+                    TOKEN_46(9999): "HAS", line: 1, col: 133
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 136
                   ONLY(9999)
-                    TOKEN_47(9999): "O", line: 1, col: 137
-                    TOKEN_46(9999): "N", line: 1, col: 138
-                    TOKEN_44(9999): "L", line: 1, col: 139
-                    TOKEN_57(9999): "Y", line: 1, col: 140
+                    TOKEN_58(9999): "ONLY", line: 1, col: 137
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 141
@@ -344,7 +329,7 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 143
+                                  TOKEN_45(9999): "H", line: 1, col: 143
                           TOKEN_3(9999): """, line: 1, col: 144
                       Colon(9999)
                         TOKEN_26(9999): ":", line: 1, col: 145
@@ -357,9 +342,7 @@ Filter(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 147
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 148
-            TOKEN_46(9999): "N", line: 1, col: 149
-            TOKEN_36(9999): "D", line: 1, col: 150
+            TOKEN_35(9999): "AND", line: 1, col: 148
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 151
@@ -370,21 +353,21 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 152
+                        TOKEN_84(9999): "e", line: 1, col: 152
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 153
+                        TOKEN_91(9999): "l", line: 1, col: 153
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 154
+                        TOKEN_84(9999): "e", line: 1, col: 154
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 155
+                        TOKEN_92(9999): "m", line: 1, col: 155
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 156
+                        TOKEN_84(9999): "e", line: 1, col: 156
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 157
+                        TOKEN_93(9999): "n", line: 1, col: 157
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 158
+                        TOKEN_99(9999): "t", line: 1, col: 158
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 159
+                        TOKEN_98(9999): "s", line: 1, col: 159
                   SetZipOpRhs(9999)
                     PropertyZipAddon(9999)
                       Colon(9999)
@@ -392,61 +375,57 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 161
+                            TOKEN_78(9999): "_", line: 1, col: 161
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 162
+                            TOKEN_84(9999): "e", line: 1, col: 162
                           LowercaseLetter(9999)
-                            TOKEN_88(9999): "x", line: 1, col: 163
+                            TOKEN_103(9999): "x", line: 1, col: 163
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 164
+                            TOKEN_92(9999): "m", line: 1, col: 164
                           LowercaseLetter(9999)
-                            TOKEN_80(9999): "p", line: 1, col: 165
+                            TOKEN_95(9999): "p", line: 1, col: 165
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 166
+                            TOKEN_91(9999): "l", line: 1, col: 166
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 167
+                            TOKEN_78(9999): "_", line: 1, col: 167
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 168
+                            TOKEN_84(9999): "e", line: 1, col: 168
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 169
+                            TOKEN_91(9999): "l", line: 1, col: 169
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 170
+                            TOKEN_84(9999): "e", line: 1, col: 170
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 171
+                            TOKEN_92(9999): "m", line: 1, col: 171
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 172
+                            TOKEN_84(9999): "e", line: 1, col: 172
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 173
+                            TOKEN_93(9999): "n", line: 1, col: 173
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 174
+                            TOKEN_99(9999): "t", line: 1, col: 174
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 175
+                            TOKEN_78(9999): "_", line: 1, col: 175
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 176
+                            TOKEN_82(9999): "c", line: 1, col: 176
                           LowercaseLetter(9999)
-                            TOKEN_79(9999): "o", line: 1, col: 177
+                            TOKEN_94(9999): "o", line: 1, col: 177
                           LowercaseLetter(9999)
-                            TOKEN_85(9999): "u", line: 1, col: 178
+                            TOKEN_100(9999): "u", line: 1, col: 178
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 179
+                            TOKEN_93(9999): "n", line: 1, col: 179
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 180
+                            TOKEN_99(9999): "t", line: 1, col: 180
                           LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 181
+                            TOKEN_98(9999): "s", line: 1, col: 181
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 182
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 183
-                      TOKEN_33(9999): "A", line: 1, col: 184
-                      TOKEN_51(9999): "S", line: 1, col: 185
+                      TOKEN_46(9999): "HAS", line: 1, col: 183
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 186
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 187
-                      TOKEN_46(9999): "N", line: 1, col: 188
-                      TOKEN_57(9999): "Y", line: 1, col: 189
+                      TOKEN_36(9999): "ANY", line: 1, col: 187
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 190
@@ -459,7 +438,7 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 192
+                                    TOKEN_45(9999): "H", line: 1, col: 192
                             TOKEN_3(9999): """, line: 1, col: 193
                         Colon(9999)
                           TOKEN_26(9999): ":", line: 1, col: 194
@@ -478,12 +457,12 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 198
+                                    TOKEN_45(9999): "H", line: 1, col: 198
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 199
+                                    TOKEN_84(9999): "e", line: 1, col: 199
                             TOKEN_3(9999): """, line: 1, col: 200
                         Colon(9999)
                           TOKEN_26(9999): ":", line: 1, col: 201
@@ -496,9 +475,7 @@ Filter(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 203
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 204
-              TOKEN_46(9999): "N", line: 1, col: 205
-              TOKEN_36(9999): "D", line: 1, col: 206
+              TOKEN_35(9999): "AND", line: 1, col: 204
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 207
@@ -509,21 +486,21 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 208
+                          TOKEN_84(9999): "e", line: 1, col: 208
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 209
+                          TOKEN_91(9999): "l", line: 1, col: 209
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 210
+                          TOKEN_84(9999): "e", line: 1, col: 210
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 211
+                          TOKEN_92(9999): "m", line: 1, col: 211
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 212
+                          TOKEN_84(9999): "e", line: 1, col: 212
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 213
+                          TOKEN_93(9999): "n", line: 1, col: 213
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 214
+                          TOKEN_99(9999): "t", line: 1, col: 214
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 215
+                          TOKEN_98(9999): "s", line: 1, col: 215
                     SetZipOpRhs(9999)
                       PropertyZipAddon(9999)
                         Colon(9999)
@@ -531,62 +508,57 @@ Filter(9999)
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 217
+                              TOKEN_78(9999): "_", line: 1, col: 217
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 218
+                              TOKEN_84(9999): "e", line: 1, col: 218
                             LowercaseLetter(9999)
-                              TOKEN_88(9999): "x", line: 1, col: 219
+                              TOKEN_103(9999): "x", line: 1, col: 219
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 220
+                              TOKEN_92(9999): "m", line: 1, col: 220
                             LowercaseLetter(9999)
-                              TOKEN_80(9999): "p", line: 1, col: 221
+                              TOKEN_95(9999): "p", line: 1, col: 221
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 222
+                              TOKEN_91(9999): "l", line: 1, col: 222
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 223
+                              TOKEN_78(9999): "_", line: 1, col: 223
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 224
+                              TOKEN_84(9999): "e", line: 1, col: 224
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 225
+                              TOKEN_91(9999): "l", line: 1, col: 225
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 226
+                              TOKEN_84(9999): "e", line: 1, col: 226
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 227
+                              TOKEN_92(9999): "m", line: 1, col: 227
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 228
+                              TOKEN_84(9999): "e", line: 1, col: 228
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 229
+                              TOKEN_93(9999): "n", line: 1, col: 229
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 230
+                              TOKEN_99(9999): "t", line: 1, col: 230
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 231
+                              TOKEN_78(9999): "_", line: 1, col: 231
                             LowercaseLetter(9999)
-                              TOKEN_67(9999): "c", line: 1, col: 232
+                              TOKEN_82(9999): "c", line: 1, col: 232
                             LowercaseLetter(9999)
-                              TOKEN_79(9999): "o", line: 1, col: 233
+                              TOKEN_94(9999): "o", line: 1, col: 233
                             LowercaseLetter(9999)
-                              TOKEN_85(9999): "u", line: 1, col: 234
+                              TOKEN_100(9999): "u", line: 1, col: 234
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 235
+                              TOKEN_93(9999): "n", line: 1, col: 235
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 236
+                              TOKEN_99(9999): "t", line: 1, col: 236
                             LowercaseLetter(9999)
-                              TOKEN_83(9999): "s", line: 1, col: 237
+                              TOKEN_98(9999): "s", line: 1, col: 237
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 238
                       HAS(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 239
-                        TOKEN_33(9999): "A", line: 1, col: 240
-                        TOKEN_51(9999): "S", line: 1, col: 241
+                        TOKEN_46(9999): "HAS", line: 1, col: 239
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 242
                       ONLY(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 243
-                        TOKEN_46(9999): "N", line: 1, col: 244
-                        TOKEN_44(9999): "L", line: 1, col: 245
-                        TOKEN_57(9999): "Y", line: 1, col: 246
+                        TOKEN_58(9999): "ONLY", line: 1, col: 243
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 247
@@ -599,7 +571,7 @@ Filter(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 249
+                                      TOKEN_45(9999): "H", line: 1, col: 249
                               TOKEN_3(9999): """, line: 1, col: 250
                           Colon(9999)
                             TOKEN_26(9999): ":", line: 1, col: 251
@@ -618,12 +590,12 @@ Filter(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 255
+                                      TOKEN_45(9999): "H", line: 1, col: 255
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_69(9999): "e", line: 1, col: 256
+                                      TOKEN_84(9999): "e", line: 1, col: 256
                               TOKEN_3(9999): """, line: 1, col: 257
                           Colon(9999)
                             TOKEN_26(9999): ":", line: 1, col: 258

--- a/tests/outputs/Filter_056.out
+++ b/tests/outputs/Filter_056.out
@@ -8,55 +8,53 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 1
+                  TOKEN_78(9999): "_", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 2
+                  TOKEN_84(9999): "e", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 3
+                  TOKEN_103(9999): "x", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 5
+                  TOKEN_95(9999): "p", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 6
+                  TOKEN_91(9999): "l", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 7
+                  TOKEN_78(9999): "_", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 8
+                  TOKEN_84(9999): "e", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 9
+                  TOKEN_91(9999): "l", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 10
+                  TOKEN_84(9999): "e", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 11
+                  TOKEN_92(9999): "m", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 12
+                  TOKEN_84(9999): "e", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 13
+                  TOKEN_93(9999): "n", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 14
+                  TOKEN_99(9999): "t", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 15
+                  TOKEN_78(9999): "_", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 16
+                  TOKEN_82(9999): "c", line: 1, col: 16
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 17
+                  TOKEN_94(9999): "o", line: 1, col: 17
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 18
+                  TOKEN_100(9999): "u", line: 1, col: 18
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 19
+                  TOKEN_93(9999): "n", line: 1, col: 19
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 20
+                  TOKEN_99(9999): "t", line: 1, col: 20
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 21
+                  TOKEN_98(9999): "s", line: 1, col: 21
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 22
             SetOpRhs(9999)
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 23
-                TOKEN_33(9999): "A", line: 1, col: 24
-                TOKEN_51(9999): "S", line: 1, col: 25
+                TOKEN_46(9999): "HAS", line: 1, col: 23
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 26
@@ -74,9 +72,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 30
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 31
-        TOKEN_46(9999): "N", line: 1, col: 32
-        TOKEN_36(9999): "D", line: 1, col: 33
+        TOKEN_35(9999): "AND", line: 1, col: 31
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 34
@@ -87,62 +83,58 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 35
+                    TOKEN_78(9999): "_", line: 1, col: 35
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 36
+                    TOKEN_84(9999): "e", line: 1, col: 36
                   LowercaseLetter(9999)
-                    TOKEN_88(9999): "x", line: 1, col: 37
+                    TOKEN_103(9999): "x", line: 1, col: 37
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 38
+                    TOKEN_92(9999): "m", line: 1, col: 38
                   LowercaseLetter(9999)
-                    TOKEN_80(9999): "p", line: 1, col: 39
+                    TOKEN_95(9999): "p", line: 1, col: 39
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 40
+                    TOKEN_91(9999): "l", line: 1, col: 40
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 41
+                    TOKEN_78(9999): "_", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 42
+                    TOKEN_84(9999): "e", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 43
+                    TOKEN_91(9999): "l", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 44
+                    TOKEN_84(9999): "e", line: 1, col: 44
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 45
+                    TOKEN_92(9999): "m", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 46
+                    TOKEN_84(9999): "e", line: 1, col: 46
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 47
+                    TOKEN_93(9999): "n", line: 1, col: 47
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 48
+                    TOKEN_99(9999): "t", line: 1, col: 48
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 49
+                    TOKEN_78(9999): "_", line: 1, col: 49
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 50
+                    TOKEN_82(9999): "c", line: 1, col: 50
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 51
+                    TOKEN_94(9999): "o", line: 1, col: 51
                   LowercaseLetter(9999)
-                    TOKEN_85(9999): "u", line: 1, col: 52
+                    TOKEN_100(9999): "u", line: 1, col: 52
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 53
+                    TOKEN_93(9999): "n", line: 1, col: 53
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 54
+                    TOKEN_99(9999): "t", line: 1, col: 54
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 55
+                    TOKEN_98(9999): "s", line: 1, col: 55
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 56
               SetOpRhs(9999)
                 HAS(9999)
-                  TOKEN_40(9999): "H", line: 1, col: 57
-                  TOKEN_33(9999): "A", line: 1, col: 58
-                  TOKEN_51(9999): "S", line: 1, col: 59
+                  TOKEN_46(9999): "HAS", line: 1, col: 57
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 60
                 ANY(9999)
-                  TOKEN_33(9999): "A", line: 1, col: 61
-                  TOKEN_46(9999): "N", line: 1, col: 62
-                  TOKEN_57(9999): "Y", line: 1, col: 63
+                  TOKEN_36(9999): "ANY", line: 1, col: 61
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 64

--- a/tests/outputs/Filter_057.out
+++ b/tests/outputs/Filter_057.out
@@ -8,21 +8,21 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
             SetZipOpRhs(9999)
               PropertyZipAddon(9999)
                 Colon(9999)
@@ -30,109 +30,105 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 10
+                      TOKEN_78(9999): "_", line: 1, col: 10
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 11
+                      TOKEN_84(9999): "e", line: 1, col: 11
                     LowercaseLetter(9999)
-                      TOKEN_88(9999): "x", line: 1, col: 12
+                      TOKEN_103(9999): "x", line: 1, col: 12
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 13
+                      TOKEN_92(9999): "m", line: 1, col: 13
                     LowercaseLetter(9999)
-                      TOKEN_80(9999): "p", line: 1, col: 14
+                      TOKEN_95(9999): "p", line: 1, col: 14
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 15
+                      TOKEN_91(9999): "l", line: 1, col: 15
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 16
+                      TOKEN_78(9999): "_", line: 1, col: 16
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 17
+                      TOKEN_84(9999): "e", line: 1, col: 17
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 18
+                      TOKEN_91(9999): "l", line: 1, col: 18
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 19
+                      TOKEN_84(9999): "e", line: 1, col: 19
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 20
+                      TOKEN_92(9999): "m", line: 1, col: 20
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 21
+                      TOKEN_84(9999): "e", line: 1, col: 21
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 22
+                      TOKEN_93(9999): "n", line: 1, col: 22
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 23
+                      TOKEN_99(9999): "t", line: 1, col: 23
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 24
+                      TOKEN_78(9999): "_", line: 1, col: 24
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 25
+                      TOKEN_82(9999): "c", line: 1, col: 25
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 26
+                      TOKEN_94(9999): "o", line: 1, col: 26
                     LowercaseLetter(9999)
-                      TOKEN_85(9999): "u", line: 1, col: 27
+                      TOKEN_100(9999): "u", line: 1, col: 27
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 28
+                      TOKEN_93(9999): "n", line: 1, col: 28
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 29
+                      TOKEN_99(9999): "t", line: 1, col: 29
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 30
+                      TOKEN_98(9999): "s", line: 1, col: 30
                 Colon(9999)
                   TOKEN_26(9999): ":", line: 1, col: 31
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 32
+                      TOKEN_78(9999): "_", line: 1, col: 32
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 33
+                      TOKEN_84(9999): "e", line: 1, col: 33
                     LowercaseLetter(9999)
-                      TOKEN_88(9999): "x", line: 1, col: 34
+                      TOKEN_103(9999): "x", line: 1, col: 34
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 35
+                      TOKEN_92(9999): "m", line: 1, col: 35
                     LowercaseLetter(9999)
-                      TOKEN_80(9999): "p", line: 1, col: 36
+                      TOKEN_95(9999): "p", line: 1, col: 36
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 37
+                      TOKEN_91(9999): "l", line: 1, col: 37
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 38
+                      TOKEN_78(9999): "_", line: 1, col: 38
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 39
+                      TOKEN_84(9999): "e", line: 1, col: 39
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 40
+                      TOKEN_91(9999): "l", line: 1, col: 40
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 41
+                      TOKEN_84(9999): "e", line: 1, col: 41
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 42
+                      TOKEN_92(9999): "m", line: 1, col: 42
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 43
+                      TOKEN_84(9999): "e", line: 1, col: 43
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 44
+                      TOKEN_93(9999): "n", line: 1, col: 44
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 45
+                      TOKEN_99(9999): "t", line: 1, col: 45
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 46
+                      TOKEN_78(9999): "_", line: 1, col: 46
                     LowercaseLetter(9999)
-                      TOKEN_87(9999): "w", line: 1, col: 47
+                      TOKEN_102(9999): "w", line: 1, col: 47
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 48
+                      TOKEN_84(9999): "e", line: 1, col: 48
                     LowercaseLetter(9999)
-                      TOKEN_73(9999): "i", line: 1, col: 49
+                      TOKEN_88(9999): "i", line: 1, col: 49
                     LowercaseLetter(9999)
-                      TOKEN_71(9999): "g", line: 1, col: 50
+                      TOKEN_86(9999): "g", line: 1, col: 50
                     LowercaseLetter(9999)
-                      TOKEN_72(9999): "h", line: 1, col: 51
+                      TOKEN_87(9999): "h", line: 1, col: 51
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 52
+                      TOKEN_99(9999): "t", line: 1, col: 52
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 53
+                      TOKEN_98(9999): "s", line: 1, col: 53
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 54
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 55
-                TOKEN_33(9999): "A", line: 1, col: 56
-                TOKEN_51(9999): "S", line: 1, col: 57
+                TOKEN_46(9999): "HAS", line: 1, col: 55
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 58
               ANY(9999)
-                TOKEN_33(9999): "A", line: 1, col: 59
-                TOKEN_46(9999): "N", line: 1, col: 60
-                TOKEN_57(9999): "Y", line: 1, col: 61
+                TOKEN_36(9999): "ANY", line: 1, col: 59
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 62
@@ -157,12 +153,12 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_40(9999): "H", line: 1, col: 68
+                              TOKEN_45(9999): "H", line: 1, col: 68
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 69
+                              TOKEN_84(9999): "e", line: 1, col: 69
                       TOKEN_3(9999): """, line: 1, col: 70
                   Colon(9999)
                     TOKEN_26(9999): ":", line: 1, col: 71
@@ -209,12 +205,12 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_52(9999): "T", line: 1, col: 86
+                              TOKEN_65(9999): "T", line: 1, col: 86
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_73(9999): "i", line: 1, col: 87
+                              TOKEN_88(9999): "i", line: 1, col: 87
                       TOKEN_3(9999): """, line: 1, col: 88
                   Colon(9999)
                     TOKEN_26(9999): ":", line: 1, col: 89
@@ -256,12 +252,12 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             UppercaseLetter(9999)
-                              TOKEN_39(9999): "G", line: 1, col: 102
+                              TOKEN_44(9999): "G", line: 1, col: 102
                       EscapedChar(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_65(9999): "a", line: 1, col: 103
+                              TOKEN_80(9999): "a", line: 1, col: 103
                       TOKEN_3(9999): """, line: 1, col: 104
                   Colon(9999)
                     TOKEN_26(9999): ":", line: 1, col: 105

--- a/tests/outputs/Filter_058.out
+++ b/tests/outputs/Filter_058.out
@@ -8,37 +8,37 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 17
@@ -55,7 +55,7 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_40(9999): "H", line: 1, col: 21
+                          TOKEN_45(9999): "H", line: 1, col: 21
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Digit(9999)
@@ -64,15 +64,13 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_47(9999): "O", line: 1, col: 23
+                          TOKEN_57(9999): "O", line: 1, col: 23
                   TOKEN_3(9999): """, line: 1, col: 24
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 25
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 26
-        TOKEN_46(9999): "N", line: 1, col: 27
-        TOKEN_36(9999): "D", line: 1, col: 28
+        TOKEN_35(9999): "AND", line: 1, col: 26
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 29
@@ -83,39 +81,39 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_80(9999): "p", line: 1, col: 30
+                    TOKEN_95(9999): "p", line: 1, col: 30
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 31
+                    TOKEN_97(9999): "r", line: 1, col: 31
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 32
+                    TOKEN_94(9999): "o", line: 1, col: 32
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 33
+                    TOKEN_99(9999): "t", line: 1, col: 33
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 34
+                    TOKEN_94(9999): "o", line: 1, col: 34
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 35
+                    TOKEN_99(9999): "t", line: 1, col: 35
                   LowercaseLetter(9999)
-                    TOKEN_89(9999): "y", line: 1, col: 36
+                    TOKEN_104(9999): "y", line: 1, col: 36
                   LowercaseLetter(9999)
-                    TOKEN_80(9999): "p", line: 1, col: 37
+                    TOKEN_95(9999): "p", line: 1, col: 37
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 38
+                    TOKEN_84(9999): "e", line: 1, col: 38
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 39
+                    TOKEN_78(9999): "_", line: 1, col: 39
                   LowercaseLetter(9999)
-                    TOKEN_70(9999): "f", line: 1, col: 40
+                    TOKEN_85(9999): "f", line: 1, col: 40
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 41
+                    TOKEN_94(9999): "o", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 42
+                    TOKEN_97(9999): "r", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 43
+                    TOKEN_92(9999): "m", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_85(9999): "u", line: 1, col: 44
+                    TOKEN_100(9999): "u", line: 1, col: 44
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 45
+                    TOKEN_91(9999): "l", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 46
+                    TOKEN_80(9999): "a", line: 1, col: 46
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 47
@@ -138,5 +136,5 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           UppercaseLetter(9999)
-                            TOKEN_34(9999): "B", line: 1, col: 53
+                            TOKEN_37(9999): "B", line: 1, col: 53
                     TOKEN_3(9999): """, line: 1, col: 54

--- a/tests/outputs/Filter_059.out
+++ b/tests/outputs/Filter_059.out
@@ -8,52 +8,45 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 1
+                  TOKEN_95(9999): "p", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 2
+                  TOKEN_97(9999): "r", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 3
+                  TOKEN_94(9999): "o", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 4
+                  TOKEN_99(9999): "t", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 5
+                  TOKEN_94(9999): "o", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 6
+                  TOKEN_99(9999): "t", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_89(9999): "y", line: 1, col: 7
+                  TOKEN_104(9999): "y", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 8
+                  TOKEN_95(9999): "p", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 9
+                  TOKEN_84(9999): "e", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 10
+                  TOKEN_78(9999): "_", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 11
+                  TOKEN_85(9999): "f", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 12
+                  TOKEN_94(9999): "o", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 13
+                  TOKEN_97(9999): "r", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 14
+                  TOKEN_92(9999): "m", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 15
+                  TOKEN_100(9999): "u", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 16
+                  TOKEN_91(9999): "l", line: 1, col: 16
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 17
+                  TOKEN_80(9999): "a", line: 1, col: 17
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 18
             FuzzyStringOpRhs(9999)
               CONTAINS(9999)
-                TOKEN_35(9999): "C", line: 1, col: 19
-                TOKEN_47(9999): "O", line: 1, col: 20
-                TOKEN_46(9999): "N", line: 1, col: 21
-                TOKEN_52(9999): "T", line: 1, col: 22
-                TOKEN_33(9999): "A", line: 1, col: 23
-                TOKEN_41(9999): "I", line: 1, col: 24
-                TOKEN_46(9999): "N", line: 1, col: 25
-                TOKEN_51(9999): "S", line: 1, col: 26
+                TOKEN_39(9999): "CONTAINS", line: 1, col: 19
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 27
@@ -64,7 +57,7 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_35(9999): "C", line: 1, col: 29
+                          TOKEN_38(9999): "C", line: 1, col: 29
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Digit(9999)
@@ -74,9 +67,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 32
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 33
-        TOKEN_46(9999): "N", line: 1, col: 34
-        TOKEN_36(9999): "D", line: 1, col: 35
+        TOKEN_35(9999): "AND", line: 1, col: 33
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 36
@@ -87,58 +78,50 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_80(9999): "p", line: 1, col: 37
+                    TOKEN_95(9999): "p", line: 1, col: 37
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 38
+                    TOKEN_97(9999): "r", line: 1, col: 38
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 39
+                    TOKEN_94(9999): "o", line: 1, col: 39
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 40
+                    TOKEN_99(9999): "t", line: 1, col: 40
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 41
+                    TOKEN_94(9999): "o", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 42
+                    TOKEN_99(9999): "t", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_89(9999): "y", line: 1, col: 43
+                    TOKEN_104(9999): "y", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_80(9999): "p", line: 1, col: 44
+                    TOKEN_95(9999): "p", line: 1, col: 44
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 45
+                    TOKEN_84(9999): "e", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 46
+                    TOKEN_78(9999): "_", line: 1, col: 46
                   LowercaseLetter(9999)
-                    TOKEN_70(9999): "f", line: 1, col: 47
+                    TOKEN_85(9999): "f", line: 1, col: 47
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 48
+                    TOKEN_94(9999): "o", line: 1, col: 48
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 49
+                    TOKEN_97(9999): "r", line: 1, col: 49
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 50
+                    TOKEN_92(9999): "m", line: 1, col: 50
                   LowercaseLetter(9999)
-                    TOKEN_85(9999): "u", line: 1, col: 51
+                    TOKEN_100(9999): "u", line: 1, col: 51
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 52
+                    TOKEN_91(9999): "l", line: 1, col: 52
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 53
+                    TOKEN_80(9999): "a", line: 1, col: 53
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 54
               FuzzyStringOpRhs(9999)
                 STARTS(9999)
-                  TOKEN_51(9999): "S", line: 1, col: 55
-                  TOKEN_52(9999): "T", line: 1, col: 56
-                  TOKEN_33(9999): "A", line: 1, col: 57
-                  TOKEN_50(9999): "R", line: 1, col: 58
-                  TOKEN_52(9999): "T", line: 1, col: 59
-                  TOKEN_51(9999): "S", line: 1, col: 60
+                  TOKEN_64(9999): "STARTS", line: 1, col: 55
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 61
                 WITH(9999)
-                  TOKEN_55(9999): "W", line: 1, col: 62
-                  TOKEN_41(9999): "I", line: 1, col: 63
-                  TOKEN_52(9999): "T", line: 1, col: 64
-                  TOKEN_40(9999): "H", line: 1, col: 65
+                  TOKEN_70(9999): "WITH", line: 1, col: 62
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 66

--- a/tests/outputs/Filter_060.out
+++ b/tests/outputs/Filter_060.out
@@ -8,50 +8,45 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 1
+                  TOKEN_95(9999): "p", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 2
+                  TOKEN_97(9999): "r", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 3
+                  TOKEN_94(9999): "o", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 4
+                  TOKEN_99(9999): "t", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 5
+                  TOKEN_94(9999): "o", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 6
+                  TOKEN_99(9999): "t", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_89(9999): "y", line: 1, col: 7
+                  TOKEN_104(9999): "y", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 8
+                  TOKEN_95(9999): "p", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 9
+                  TOKEN_84(9999): "e", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 10
+                  TOKEN_78(9999): "_", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 11
+                  TOKEN_85(9999): "f", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 12
+                  TOKEN_94(9999): "o", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 13
+                  TOKEN_97(9999): "r", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 14
+                  TOKEN_92(9999): "m", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 15
+                  TOKEN_100(9999): "u", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 16
+                  TOKEN_91(9999): "l", line: 1, col: 16
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 17
+                  TOKEN_80(9999): "a", line: 1, col: 17
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 18
             FuzzyStringOpRhs(9999)
               STARTS(9999)
-                TOKEN_51(9999): "S", line: 1, col: 19
-                TOKEN_52(9999): "T", line: 1, col: 20
-                TOKEN_33(9999): "A", line: 1, col: 21
-                TOKEN_50(9999): "R", line: 1, col: 22
-                TOKEN_52(9999): "T", line: 1, col: 23
-                TOKEN_51(9999): "S", line: 1, col: 24
+                TOKEN_64(9999): "STARTS", line: 1, col: 19
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 25
@@ -62,7 +57,7 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_34(9999): "B", line: 1, col: 27
+                          TOKEN_37(9999): "B", line: 1, col: 27
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Digit(9999)
@@ -72,9 +67,7 @@ Filter(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 30
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 31
-        TOKEN_46(9999): "N", line: 1, col: 32
-        TOKEN_36(9999): "D", line: 1, col: 33
+        TOKEN_35(9999): "AND", line: 1, col: 31
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 34
@@ -85,56 +78,50 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_80(9999): "p", line: 1, col: 35
+                    TOKEN_95(9999): "p", line: 1, col: 35
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 36
+                    TOKEN_97(9999): "r", line: 1, col: 36
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 37
+                    TOKEN_94(9999): "o", line: 1, col: 37
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 38
+                    TOKEN_99(9999): "t", line: 1, col: 38
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 39
+                    TOKEN_94(9999): "o", line: 1, col: 39
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 40
+                    TOKEN_99(9999): "t", line: 1, col: 40
                   LowercaseLetter(9999)
-                    TOKEN_89(9999): "y", line: 1, col: 41
+                    TOKEN_104(9999): "y", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_80(9999): "p", line: 1, col: 42
+                    TOKEN_95(9999): "p", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 43
+                    TOKEN_84(9999): "e", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 44
+                    TOKEN_78(9999): "_", line: 1, col: 44
                   LowercaseLetter(9999)
-                    TOKEN_70(9999): "f", line: 1, col: 45
+                    TOKEN_85(9999): "f", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 46
+                    TOKEN_94(9999): "o", line: 1, col: 46
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 47
+                    TOKEN_97(9999): "r", line: 1, col: 47
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 48
+                    TOKEN_92(9999): "m", line: 1, col: 48
                   LowercaseLetter(9999)
-                    TOKEN_85(9999): "u", line: 1, col: 49
+                    TOKEN_100(9999): "u", line: 1, col: 49
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 50
+                    TOKEN_91(9999): "l", line: 1, col: 50
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 51
+                    TOKEN_80(9999): "a", line: 1, col: 51
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 52
               FuzzyStringOpRhs(9999)
                 ENDS(9999)
-                  TOKEN_37(9999): "E", line: 1, col: 53
-                  TOKEN_46(9999): "N", line: 1, col: 54
-                  TOKEN_36(9999): "D", line: 1, col: 55
-                  TOKEN_51(9999): "S", line: 1, col: 56
+                  TOKEN_42(9999): "ENDS", line: 1, col: 53
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 57
                 WITH(9999)
-                  TOKEN_55(9999): "W", line: 1, col: 58
-                  TOKEN_41(9999): "I", line: 1, col: 59
-                  TOKEN_52(9999): "T", line: 1, col: 60
-                  TOKEN_40(9999): "H", line: 1, col: 61
+                  TOKEN_70(9999): "WITH", line: 1, col: 58
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 62
@@ -145,7 +132,7 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           UppercaseLetter(9999)
-                            TOKEN_36(9999): "D", line: 1, col: 64
+                            TOKEN_40(9999): "D", line: 1, col: 64
                     EscapedChar(9999)
                       UnescapedChar(9999)
                         Digit(9999)

--- a/tests/outputs/Filter_061.out
+++ b/tests/outputs/Filter_061.out
@@ -8,59 +8,59 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 1
+                  TOKEN_78(9999): "_", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 2
+                  TOKEN_84(9999): "e", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_88(9999): "x", line: 1, col: 3
+                  TOKEN_103(9999): "x", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 5
+                  TOKEN_95(9999): "p", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 6
+                  TOKEN_91(9999): "l", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 7
+                  TOKEN_78(9999): "_", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 9
+                  TOKEN_94(9999): "o", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 10
+                  TOKEN_92(9999): "m", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 11
+                  TOKEN_84(9999): "e", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 12
+                  TOKEN_78(9999): "_", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 13
+                  TOKEN_98(9999): "s", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 14
+                  TOKEN_99(9999): "t", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 15
+                  TOKEN_97(9999): "r", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 16
+                  TOKEN_88(9999): "i", line: 1, col: 16
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 17
+                  TOKEN_93(9999): "n", line: 1, col: 17
                 LowercaseLetter(9999)
-                  TOKEN_71(9999): "g", line: 1, col: 18
+                  TOKEN_86(9999): "g", line: 1, col: 18
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 19
+                  TOKEN_78(9999): "_", line: 1, col: 19
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 20
+                  TOKEN_95(9999): "p", line: 1, col: 20
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 21
+                  TOKEN_97(9999): "r", line: 1, col: 21
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 22
+                  TOKEN_94(9999): "o", line: 1, col: 22
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 23
+                  TOKEN_95(9999): "p", line: 1, col: 23
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 24
+                  TOKEN_84(9999): "e", line: 1, col: 24
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 25
+                  TOKEN_97(9999): "r", line: 1, col: 25
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 26
+                  TOKEN_99(9999): "t", line: 1, col: 26
                 LowercaseLetter(9999)
-                  TOKEN_89(9999): "y", line: 1, col: 27
+                  TOKEN_104(9999): "y", line: 1, col: 27
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 28

--- a/tests/outputs/Filter_062.out
+++ b/tests/outputs/Filter_062.out
@@ -23,18 +23,18 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 5
+                      TOKEN_78(9999): "_", line: 1, col: 5
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 6
+                      TOKEN_84(9999): "e", line: 1, col: 6
                     LowercaseLetter(9999)
-                      TOKEN_88(9999): "x", line: 1, col: 7
+                      TOKEN_103(9999): "x", line: 1, col: 7
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 8
+                      TOKEN_92(9999): "m", line: 1, col: 8
                     LowercaseLetter(9999)
-                      TOKEN_80(9999): "p", line: 1, col: 9
+                      TOKEN_95(9999): "p", line: 1, col: 9
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 10
+                      TOKEN_91(9999): "l", line: 1, col: 10
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 11
+                      TOKEN_78(9999): "_", line: 1, col: 11
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 12
+                      TOKEN_80(9999): "a", line: 1, col: 12

--- a/tests/outputs/Filter_063.out
+++ b/tests/outputs/Filter_063.out
@@ -14,9 +14,7 @@ Filter(9999)
                 ExpressionClause(9999)
                   ExpressionPhrase(9999)
                     NOT(9999)
-                      TOKEN_46(9999): "N", line: 1, col: 3
-                      TOKEN_47(9999): "O", line: 1, col: 4
-                      TOKEN_52(9999): "T", line: 1, col: 5
+                      TOKEN_56(9999): "NOT", line: 1, col: 3
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 6
@@ -30,21 +28,21 @@ Filter(9999)
                               Property(9999)
                                 Identifier(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_63(9999): "_", line: 1, col: 8
+                                    TOKEN_78(9999): "_", line: 1, col: 8
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 9
+                                    TOKEN_84(9999): "e", line: 1, col: 9
                                   LowercaseLetter(9999)
-                                    TOKEN_88(9999): "x", line: 1, col: 10
+                                    TOKEN_103(9999): "x", line: 1, col: 10
                                   LowercaseLetter(9999)
-                                    TOKEN_77(9999): "m", line: 1, col: 11
+                                    TOKEN_92(9999): "m", line: 1, col: 11
                                   LowercaseLetter(9999)
-                                    TOKEN_80(9999): "p", line: 1, col: 12
+                                    TOKEN_95(9999): "p", line: 1, col: 12
                                   LowercaseLetter(9999)
-                                    TOKEN_76(9999): "l", line: 1, col: 13
+                                    TOKEN_91(9999): "l", line: 1, col: 13
                                   LowercaseLetter(9999)
-                                    TOKEN_63(9999): "_", line: 1, col: 14
+                                    TOKEN_78(9999): "_", line: 1, col: 14
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 15
+                                    TOKEN_80(9999): "a", line: 1, col: 15
                               ValueOpRhs(9999)
                                 Operator(9999)
                                   TOKEN_30(9999): ">", line: 1, col: 16
@@ -52,21 +50,21 @@ Filter(9999)
                                   Property(9999)
                                     Identifier(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_63(9999): "_", line: 1, col: 17
+                                        TOKEN_78(9999): "_", line: 1, col: 17
                                       LowercaseLetter(9999)
-                                        TOKEN_69(9999): "e", line: 1, col: 18
+                                        TOKEN_84(9999): "e", line: 1, col: 18
                                       LowercaseLetter(9999)
-                                        TOKEN_88(9999): "x", line: 1, col: 19
+                                        TOKEN_103(9999): "x", line: 1, col: 19
                                       LowercaseLetter(9999)
-                                        TOKEN_77(9999): "m", line: 1, col: 20
+                                        TOKEN_92(9999): "m", line: 1, col: 20
                                       LowercaseLetter(9999)
-                                        TOKEN_80(9999): "p", line: 1, col: 21
+                                        TOKEN_95(9999): "p", line: 1, col: 21
                                       LowercaseLetter(9999)
-                                        TOKEN_76(9999): "l", line: 1, col: 22
+                                        TOKEN_91(9999): "l", line: 1, col: 22
                                       LowercaseLetter(9999)
-                                        TOKEN_63(9999): "_", line: 1, col: 23
+                                        TOKEN_78(9999): "_", line: 1, col: 23
                                       LowercaseLetter(9999)
-                                        TOKEN_66(9999): "b", line: 1, col: 24
+                                        TOKEN_81(9999): "b", line: 1, col: 24
                     ClosingBrace(9999)
                       TOKEN_9(9999): ")", line: 1, col: 25
               ClosingBrace(9999)
@@ -75,9 +73,7 @@ Filter(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 27
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 28
-              TOKEN_46(9999): "N", line: 1, col: 29
-              TOKEN_36(9999): "D", line: 1, col: 30
+              TOKEN_35(9999): "AND", line: 1, col: 28
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 31
@@ -88,21 +84,21 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 32
+                          TOKEN_78(9999): "_", line: 1, col: 32
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 33
+                          TOKEN_84(9999): "e", line: 1, col: 33
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 34
+                          TOKEN_103(9999): "x", line: 1, col: 34
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 35
+                          TOKEN_92(9999): "m", line: 1, col: 35
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 36
+                          TOKEN_95(9999): "p", line: 1, col: 36
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 37
+                          TOKEN_91(9999): "l", line: 1, col: 37
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 38
+                          TOKEN_78(9999): "_", line: 1, col: 38
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 39
+                          TOKEN_103(9999): "x", line: 1, col: 39
                     ValueOpRhs(9999)
                       Operator(9999)
                         TOKEN_30(9999): ">", line: 1, col: 40

--- a/tests/outputs/Filter_064.out
+++ b/tests/outputs/Filter_064.out
@@ -27,50 +27,43 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 10
+                  TOKEN_82(9999): "c", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 11
+                  TOKEN_87(9999): "h", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 12
+                  TOKEN_84(9999): "e", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 14
+                  TOKEN_88(9999): "i", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 15
+                  TOKEN_82(9999): "c", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 17
+                  TOKEN_91(9999): "l", line: 1, col: 17
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 18
+                  TOKEN_78(9999): "_", line: 1, col: 18
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 19
+                  TOKEN_85(9999): "f", line: 1, col: 19
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 20
+                  TOKEN_94(9999): "o", line: 1, col: 20
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 21
+                  TOKEN_97(9999): "r", line: 1, col: 21
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 22
+                  TOKEN_92(9999): "m", line: 1, col: 22
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 23
+                  TOKEN_100(9999): "u", line: 1, col: 23
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 24
+                  TOKEN_91(9999): "l", line: 1, col: 24
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 25
+                  TOKEN_80(9999): "a", line: 1, col: 25
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 26
             FuzzyStringOpRhs(9999)
               CONTAINS(9999)
-                TOKEN_35(9999): "C", line: 1, col: 27
-                TOKEN_47(9999): "O", line: 1, col: 28
-                TOKEN_46(9999): "N", line: 1, col: 29
-                TOKEN_52(9999): "T", line: 1, col: 30
-                TOKEN_33(9999): "A", line: 1, col: 31
-                TOKEN_41(9999): "I", line: 1, col: 32
-                TOKEN_46(9999): "N", line: 1, col: 33
-                TOKEN_51(9999): "S", line: 1, col: 34
+                TOKEN_39(9999): "CONTAINS", line: 1, col: 27
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 35
@@ -86,15 +79,13 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 38
+                          TOKEN_91(9999): "l", line: 1, col: 38
                   TOKEN_3(9999): """, line: 1, col: 39
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 40
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 41
-        TOKEN_46(9999): "N", line: 1, col: 42
-        TOKEN_36(9999): "D", line: 1, col: 43
+        TOKEN_35(9999): "AND", line: 1, col: 41
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 44
@@ -105,48 +96,43 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 45
+                    TOKEN_82(9999): "c", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_72(9999): "h", line: 1, col: 46
+                    TOKEN_87(9999): "h", line: 1, col: 46
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 47
+                    TOKEN_84(9999): "e", line: 1, col: 47
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 48
+                    TOKEN_92(9999): "m", line: 1, col: 48
                   LowercaseLetter(9999)
-                    TOKEN_73(9999): "i", line: 1, col: 49
+                    TOKEN_88(9999): "i", line: 1, col: 49
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 50
+                    TOKEN_82(9999): "c", line: 1, col: 50
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 51
+                    TOKEN_80(9999): "a", line: 1, col: 51
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 52
+                    TOKEN_91(9999): "l", line: 1, col: 52
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 53
+                    TOKEN_78(9999): "_", line: 1, col: 53
                   LowercaseLetter(9999)
-                    TOKEN_70(9999): "f", line: 1, col: 54
+                    TOKEN_85(9999): "f", line: 1, col: 54
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 55
+                    TOKEN_94(9999): "o", line: 1, col: 55
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 56
+                    TOKEN_97(9999): "r", line: 1, col: 56
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 57
+                    TOKEN_92(9999): "m", line: 1, col: 57
                   LowercaseLetter(9999)
-                    TOKEN_85(9999): "u", line: 1, col: 58
+                    TOKEN_100(9999): "u", line: 1, col: 58
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 59
+                    TOKEN_91(9999): "l", line: 1, col: 59
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 60
+                    TOKEN_80(9999): "a", line: 1, col: 60
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 61
               FuzzyStringOpRhs(9999)
                 STARTS(9999)
-                  TOKEN_51(9999): "S", line: 1, col: 62
-                  TOKEN_52(9999): "T", line: 1, col: 63
-                  TOKEN_33(9999): "A", line: 1, col: 64
-                  TOKEN_50(9999): "R", line: 1, col: 65
-                  TOKEN_52(9999): "T", line: 1, col: 66
-                  TOKEN_51(9999): "S", line: 1, col: 67
+                  TOKEN_64(9999): "STARTS", line: 1, col: 62
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 68
@@ -162,15 +148,13 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 71
+                            TOKEN_91(9999): "l", line: 1, col: 71
                     TOKEN_3(9999): """, line: 1, col: 72
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 73
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 74
-          TOKEN_46(9999): "N", line: 1, col: 75
-          TOKEN_36(9999): "D", line: 1, col: 76
+          TOKEN_35(9999): "AND", line: 1, col: 74
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 77
@@ -181,46 +165,43 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 78
+                      TOKEN_82(9999): "c", line: 1, col: 78
                     LowercaseLetter(9999)
-                      TOKEN_72(9999): "h", line: 1, col: 79
+                      TOKEN_87(9999): "h", line: 1, col: 79
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 80
+                      TOKEN_84(9999): "e", line: 1, col: 80
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 81
+                      TOKEN_92(9999): "m", line: 1, col: 81
                     LowercaseLetter(9999)
-                      TOKEN_73(9999): "i", line: 1, col: 82
+                      TOKEN_88(9999): "i", line: 1, col: 82
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 83
+                      TOKEN_82(9999): "c", line: 1, col: 83
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 84
+                      TOKEN_80(9999): "a", line: 1, col: 84
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 85
+                      TOKEN_91(9999): "l", line: 1, col: 85
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 86
+                      TOKEN_78(9999): "_", line: 1, col: 86
                     LowercaseLetter(9999)
-                      TOKEN_70(9999): "f", line: 1, col: 87
+                      TOKEN_85(9999): "f", line: 1, col: 87
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 88
+                      TOKEN_94(9999): "o", line: 1, col: 88
                     LowercaseLetter(9999)
-                      TOKEN_82(9999): "r", line: 1, col: 89
+                      TOKEN_97(9999): "r", line: 1, col: 89
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 90
+                      TOKEN_92(9999): "m", line: 1, col: 90
                     LowercaseLetter(9999)
-                      TOKEN_85(9999): "u", line: 1, col: 91
+                      TOKEN_100(9999): "u", line: 1, col: 91
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 92
+                      TOKEN_91(9999): "l", line: 1, col: 92
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 93
+                      TOKEN_80(9999): "a", line: 1, col: 93
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 94
                 FuzzyStringOpRhs(9999)
                   ENDS(9999)
-                    TOKEN_37(9999): "E", line: 1, col: 95
-                    TOKEN_46(9999): "N", line: 1, col: 96
-                    TOKEN_36(9999): "D", line: 1, col: 97
-                    TOKEN_51(9999): "S", line: 1, col: 98
+                    TOKEN_42(9999): "ENDS", line: 1, col: 95
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 99
@@ -236,7 +217,7 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 102
+                              TOKEN_91(9999): "l", line: 1, col: 102
                       TOKEN_3(9999): """, line: 1, col: 103
                       Spaces(9999)
                         Space(9999)

--- a/tests/outputs/Filter_065.out
+++ b/tests/outputs/Filter_065.out
@@ -8,47 +8,40 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 1
+                  TOKEN_82(9999): "c", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 2
+                  TOKEN_87(9999): "h", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 5
+                  TOKEN_88(9999): "i", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 6
+                  TOKEN_82(9999): "c", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 7
+                  TOKEN_80(9999): "a", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 8
+                  TOKEN_91(9999): "l", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 9
+                  TOKEN_78(9999): "_", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 10
+                  TOKEN_85(9999): "f", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 11
+                  TOKEN_94(9999): "o", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 12
+                  TOKEN_97(9999): "r", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 13
+                  TOKEN_92(9999): "m", line: 1, col: 13
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 14
+                  TOKEN_100(9999): "u", line: 1, col: 14
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 15
+                  TOKEN_91(9999): "l", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 16
+                  TOKEN_80(9999): "a", line: 1, col: 16
             FuzzyStringOpRhs(9999)
               CONTAINS(9999)
-                TOKEN_35(9999): "C", line: 1, col: 17
-                TOKEN_47(9999): "O", line: 1, col: 18
-                TOKEN_46(9999): "N", line: 1, col: 19
-                TOKEN_52(9999): "T", line: 1, col: 20
-                TOKEN_33(9999): "A", line: 1, col: 21
-                TOKEN_41(9999): "I", line: 1, col: 22
-                TOKEN_46(9999): "N", line: 1, col: 23
-                TOKEN_51(9999): "S", line: 1, col: 24
+                TOKEN_39(9999): "CONTAINS", line: 1, col: 17
               StringProperty(9999)
                 String(9999)
                   TOKEN_3(9999): """, line: 1, col: 25
@@ -61,12 +54,10 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 27
+                          TOKEN_91(9999): "l", line: 1, col: 27
                   TOKEN_3(9999): """, line: 1, col: 28
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 29
-        TOKEN_46(9999): "N", line: 1, col: 30
-        TOKEN_36(9999): "D", line: 1, col: 31
+        TOKEN_35(9999): "AND", line: 1, col: 29
       ExpressionClause(9999)
         ExpressionPhrase(9999)
           Comparison(9999)
@@ -74,45 +65,40 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 32
+                    TOKEN_82(9999): "c", line: 1, col: 32
                   LowercaseLetter(9999)
-                    TOKEN_72(9999): "h", line: 1, col: 33
+                    TOKEN_87(9999): "h", line: 1, col: 33
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 34
+                    TOKEN_84(9999): "e", line: 1, col: 34
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 35
+                    TOKEN_92(9999): "m", line: 1, col: 35
                   LowercaseLetter(9999)
-                    TOKEN_73(9999): "i", line: 1, col: 36
+                    TOKEN_88(9999): "i", line: 1, col: 36
                   LowercaseLetter(9999)
-                    TOKEN_67(9999): "c", line: 1, col: 37
+                    TOKEN_82(9999): "c", line: 1, col: 37
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 38
+                    TOKEN_80(9999): "a", line: 1, col: 38
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 39
+                    TOKEN_91(9999): "l", line: 1, col: 39
                   LowercaseLetter(9999)
-                    TOKEN_63(9999): "_", line: 1, col: 40
+                    TOKEN_78(9999): "_", line: 1, col: 40
                   LowercaseLetter(9999)
-                    TOKEN_70(9999): "f", line: 1, col: 41
+                    TOKEN_85(9999): "f", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_79(9999): "o", line: 1, col: 42
+                    TOKEN_94(9999): "o", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_82(9999): "r", line: 1, col: 43
+                    TOKEN_97(9999): "r", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 44
+                    TOKEN_92(9999): "m", line: 1, col: 44
                   LowercaseLetter(9999)
-                    TOKEN_85(9999): "u", line: 1, col: 45
+                    TOKEN_100(9999): "u", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 46
+                    TOKEN_91(9999): "l", line: 1, col: 46
                   LowercaseLetter(9999)
-                    TOKEN_65(9999): "a", line: 1, col: 47
+                    TOKEN_80(9999): "a", line: 1, col: 47
               FuzzyStringOpRhs(9999)
                 STARTS(9999)
-                  TOKEN_51(9999): "S", line: 1, col: 48
-                  TOKEN_52(9999): "T", line: 1, col: 49
-                  TOKEN_33(9999): "A", line: 1, col: 50
-                  TOKEN_50(9999): "R", line: 1, col: 51
-                  TOKEN_52(9999): "T", line: 1, col: 52
-                  TOKEN_51(9999): "S", line: 1, col: 53
+                  TOKEN_64(9999): "STARTS", line: 1, col: 48
                 StringProperty(9999)
                   String(9999)
                     TOKEN_3(9999): """, line: 1, col: 54
@@ -125,12 +111,10 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 56
+                            TOKEN_91(9999): "l", line: 1, col: 56
                     TOKEN_3(9999): """, line: 1, col: 57
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 58
-          TOKEN_46(9999): "N", line: 1, col: 59
-          TOKEN_36(9999): "D", line: 1, col: 60
+          TOKEN_35(9999): "AND", line: 1, col: 58
         ExpressionClause(9999)
           ExpressionPhrase(9999)
             Comparison(9999)
@@ -138,43 +122,40 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 61
+                      TOKEN_82(9999): "c", line: 1, col: 61
                     LowercaseLetter(9999)
-                      TOKEN_72(9999): "h", line: 1, col: 62
+                      TOKEN_87(9999): "h", line: 1, col: 62
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 63
+                      TOKEN_84(9999): "e", line: 1, col: 63
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 64
+                      TOKEN_92(9999): "m", line: 1, col: 64
                     LowercaseLetter(9999)
-                      TOKEN_73(9999): "i", line: 1, col: 65
+                      TOKEN_88(9999): "i", line: 1, col: 65
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 66
+                      TOKEN_82(9999): "c", line: 1, col: 66
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 67
+                      TOKEN_80(9999): "a", line: 1, col: 67
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 68
+                      TOKEN_91(9999): "l", line: 1, col: 68
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 69
+                      TOKEN_78(9999): "_", line: 1, col: 69
                     LowercaseLetter(9999)
-                      TOKEN_70(9999): "f", line: 1, col: 70
+                      TOKEN_85(9999): "f", line: 1, col: 70
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 71
+                      TOKEN_94(9999): "o", line: 1, col: 71
                     LowercaseLetter(9999)
-                      TOKEN_82(9999): "r", line: 1, col: 72
+                      TOKEN_97(9999): "r", line: 1, col: 72
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 73
+                      TOKEN_92(9999): "m", line: 1, col: 73
                     LowercaseLetter(9999)
-                      TOKEN_85(9999): "u", line: 1, col: 74
+                      TOKEN_100(9999): "u", line: 1, col: 74
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 75
+                      TOKEN_91(9999): "l", line: 1, col: 75
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 76
+                      TOKEN_80(9999): "a", line: 1, col: 76
                 FuzzyStringOpRhs(9999)
                   ENDS(9999)
-                    TOKEN_37(9999): "E", line: 1, col: 77
-                    TOKEN_46(9999): "N", line: 1, col: 78
-                    TOKEN_36(9999): "D", line: 1, col: 79
-                    TOKEN_51(9999): "S", line: 1, col: 80
+                    TOKEN_42(9999): "ENDS", line: 1, col: 77
                   StringProperty(9999)
                     String(9999)
                       TOKEN_3(9999): """, line: 1, col: 81
@@ -187,7 +168,7 @@ Filter(9999)
                         UnescapedChar(9999)
                           Letter(9999)
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 83
+                              TOKEN_91(9999): "l", line: 1, col: 83
                       TOKEN_3(9999): """, line: 1, col: 84
                       Spaces(9999)
                         Space(9999)

--- a/tests/outputs/Filter_066.out
+++ b/tests/outputs/Filter_066.out
@@ -14,9 +14,7 @@ Filter(9999)
                 ExpressionClause(9999)
                   ExpressionPhrase(9999)
                     NOT(9999)
-                      TOKEN_46(9999): "N", line: 1, col: 3
-                      TOKEN_47(9999): "O", line: 1, col: 4
-                      TOKEN_52(9999): "T", line: 1, col: 5
+                      TOKEN_56(9999): "NOT", line: 1, col: 3
                     OpeningBrace(9999)
                       TOKEN_8(9999): "(", line: 1, col: 6
                     Expression(9999)
@@ -27,21 +25,21 @@ Filter(9999)
                               Property(9999)
                                 Identifier(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_63(9999): "_", line: 1, col: 7
+                                    TOKEN_78(9999): "_", line: 1, col: 7
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 8
+                                    TOKEN_84(9999): "e", line: 1, col: 8
                                   LowercaseLetter(9999)
-                                    TOKEN_88(9999): "x", line: 1, col: 9
+                                    TOKEN_103(9999): "x", line: 1, col: 9
                                   LowercaseLetter(9999)
-                                    TOKEN_77(9999): "m", line: 1, col: 10
+                                    TOKEN_92(9999): "m", line: 1, col: 10
                                   LowercaseLetter(9999)
-                                    TOKEN_80(9999): "p", line: 1, col: 11
+                                    TOKEN_95(9999): "p", line: 1, col: 11
                                   LowercaseLetter(9999)
-                                    TOKEN_76(9999): "l", line: 1, col: 12
+                                    TOKEN_91(9999): "l", line: 1, col: 12
                                   LowercaseLetter(9999)
-                                    TOKEN_63(9999): "_", line: 1, col: 13
+                                    TOKEN_78(9999): "_", line: 1, col: 13
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 14
+                                    TOKEN_80(9999): "a", line: 1, col: 14
                               ValueOpRhs(9999)
                                 Operator(9999)
                                   TOKEN_30(9999): ">", line: 1, col: 15
@@ -49,29 +47,27 @@ Filter(9999)
                                   Property(9999)
                                     Identifier(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_63(9999): "_", line: 1, col: 16
+                                        TOKEN_78(9999): "_", line: 1, col: 16
                                       LowercaseLetter(9999)
-                                        TOKEN_69(9999): "e", line: 1, col: 17
+                                        TOKEN_84(9999): "e", line: 1, col: 17
                                       LowercaseLetter(9999)
-                                        TOKEN_88(9999): "x", line: 1, col: 18
+                                        TOKEN_103(9999): "x", line: 1, col: 18
                                       LowercaseLetter(9999)
-                                        TOKEN_77(9999): "m", line: 1, col: 19
+                                        TOKEN_92(9999): "m", line: 1, col: 19
                                       LowercaseLetter(9999)
-                                        TOKEN_80(9999): "p", line: 1, col: 20
+                                        TOKEN_95(9999): "p", line: 1, col: 20
                                       LowercaseLetter(9999)
-                                        TOKEN_76(9999): "l", line: 1, col: 21
+                                        TOKEN_91(9999): "l", line: 1, col: 21
                                       LowercaseLetter(9999)
-                                        TOKEN_63(9999): "_", line: 1, col: 22
+                                        TOKEN_78(9999): "_", line: 1, col: 22
                                       LowercaseLetter(9999)
-                                        TOKEN_66(9999): "b", line: 1, col: 23
+                                        TOKEN_81(9999): "b", line: 1, col: 23
                     ClosingBrace(9999)
                       TOKEN_9(9999): ")", line: 1, col: 24
               ClosingBrace(9999)
                 TOKEN_9(9999): ")", line: 1, col: 25
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 26
-              TOKEN_46(9999): "N", line: 1, col: 27
-              TOKEN_36(9999): "D", line: 1, col: 28
+              TOKEN_35(9999): "AND", line: 1, col: 26
             ExpressionClause(9999)
               ExpressionPhrase(9999)
                 Comparison(9999)
@@ -79,21 +75,21 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 29
+                          TOKEN_78(9999): "_", line: 1, col: 29
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 30
+                          TOKEN_84(9999): "e", line: 1, col: 30
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 31
+                          TOKEN_103(9999): "x", line: 1, col: 31
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 32
+                          TOKEN_92(9999): "m", line: 1, col: 32
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 33
+                          TOKEN_95(9999): "p", line: 1, col: 33
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 34
+                          TOKEN_91(9999): "l", line: 1, col: 34
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 35
+                          TOKEN_78(9999): "_", line: 1, col: 35
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 36
+                          TOKEN_103(9999): "x", line: 1, col: 36
                     ValueOpRhs(9999)
                       Operator(9999)
                         TOKEN_30(9999): ">", line: 1, col: 37

--- a/tests/outputs/Filter_067.out
+++ b/tests/outputs/Filter_067.out
@@ -14,9 +14,7 @@ Filter(9999)
                 ExpressionClause(9999)
                   ExpressionPhrase(9999)
                     NOT(9999)
-                      TOKEN_46(9999): "N", line: 1, col: 3
-                      TOKEN_47(9999): "O", line: 1, col: 4
-                      TOKEN_52(9999): "T", line: 1, col: 5
+                      TOKEN_56(9999): "NOT", line: 1, col: 3
                     OpeningBrace(9999)
                       TOKEN_8(9999): "(", line: 1, col: 6
                     Expression(9999)
@@ -27,21 +25,21 @@ Filter(9999)
                               Property(9999)
                                 Identifier(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_63(9999): "_", line: 1, col: 7
+                                    TOKEN_78(9999): "_", line: 1, col: 7
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 8
+                                    TOKEN_84(9999): "e", line: 1, col: 8
                                   LowercaseLetter(9999)
-                                    TOKEN_88(9999): "x", line: 1, col: 9
+                                    TOKEN_103(9999): "x", line: 1, col: 9
                                   LowercaseLetter(9999)
-                                    TOKEN_77(9999): "m", line: 1, col: 10
+                                    TOKEN_92(9999): "m", line: 1, col: 10
                                   LowercaseLetter(9999)
-                                    TOKEN_80(9999): "p", line: 1, col: 11
+                                    TOKEN_95(9999): "p", line: 1, col: 11
                                   LowercaseLetter(9999)
-                                    TOKEN_76(9999): "l", line: 1, col: 12
+                                    TOKEN_91(9999): "l", line: 1, col: 12
                                   LowercaseLetter(9999)
-                                    TOKEN_63(9999): "_", line: 1, col: 13
+                                    TOKEN_78(9999): "_", line: 1, col: 13
                                   LowercaseLetter(9999)
-                                    TOKEN_65(9999): "a", line: 1, col: 14
+                                    TOKEN_80(9999): "a", line: 1, col: 14
                                   Spaces(9999)
                                     Space(9999)
                                       TOKEN_1(9999): " ", line: 1, col: 15
@@ -55,21 +53,21 @@ Filter(9999)
                                   Property(9999)
                                     Identifier(9999)
                                       LowercaseLetter(9999)
-                                        TOKEN_63(9999): "_", line: 1, col: 18
+                                        TOKEN_78(9999): "_", line: 1, col: 18
                                       LowercaseLetter(9999)
-                                        TOKEN_69(9999): "e", line: 1, col: 19
+                                        TOKEN_84(9999): "e", line: 1, col: 19
                                       LowercaseLetter(9999)
-                                        TOKEN_88(9999): "x", line: 1, col: 20
+                                        TOKEN_103(9999): "x", line: 1, col: 20
                                       LowercaseLetter(9999)
-                                        TOKEN_77(9999): "m", line: 1, col: 21
+                                        TOKEN_92(9999): "m", line: 1, col: 21
                                       LowercaseLetter(9999)
-                                        TOKEN_80(9999): "p", line: 1, col: 22
+                                        TOKEN_95(9999): "p", line: 1, col: 22
                                       LowercaseLetter(9999)
-                                        TOKEN_76(9999): "l", line: 1, col: 23
+                                        TOKEN_91(9999): "l", line: 1, col: 23
                                       LowercaseLetter(9999)
-                                        TOKEN_63(9999): "_", line: 1, col: 24
+                                        TOKEN_78(9999): "_", line: 1, col: 24
                                       LowercaseLetter(9999)
-                                        TOKEN_66(9999): "b", line: 1, col: 25
+                                        TOKEN_81(9999): "b", line: 1, col: 25
                     ClosingBrace(9999)
                       TOKEN_9(9999): ")", line: 1, col: 26
                       Spaces(9999)
@@ -78,9 +76,7 @@ Filter(9999)
               ClosingBrace(9999)
                 TOKEN_9(9999): ")", line: 1, col: 28
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 29
-              TOKEN_46(9999): "N", line: 1, col: 30
-              TOKEN_36(9999): "D", line: 1, col: 31
+              TOKEN_35(9999): "AND", line: 1, col: 29
             ExpressionClause(9999)
               ExpressionPhrase(9999)
                 Comparison(9999)
@@ -88,21 +84,21 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 32
+                          TOKEN_78(9999): "_", line: 1, col: 32
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 33
+                          TOKEN_84(9999): "e", line: 1, col: 33
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 34
+                          TOKEN_103(9999): "x", line: 1, col: 34
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 35
+                          TOKEN_92(9999): "m", line: 1, col: 35
                         LowercaseLetter(9999)
-                          TOKEN_80(9999): "p", line: 1, col: 36
+                          TOKEN_95(9999): "p", line: 1, col: 36
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 37
+                          TOKEN_91(9999): "l", line: 1, col: 37
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 38
+                          TOKEN_78(9999): "_", line: 1, col: 38
                         LowercaseLetter(9999)
-                          TOKEN_88(9999): "x", line: 1, col: 39
+                          TOKEN_103(9999): "x", line: 1, col: 39
                     ValueOpRhs(9999)
                       Operator(9999)
                         TOKEN_30(9999): ">", line: 1, col: 40

--- a/tests/outputs/Filter_068.out
+++ b/tests/outputs/Filter_068.out
@@ -8,21 +8,21 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 1
+                  TOKEN_84(9999): "e", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 2
+                  TOKEN_91(9999): "l", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 3
+                  TOKEN_84(9999): "e", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 4
+                  TOKEN_92(9999): "m", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 6
+                  TOKEN_93(9999): "n", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 8
+                  TOKEN_98(9999): "s", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
@@ -33,40 +33,38 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 11
+                      TOKEN_84(9999): "e", line: 1, col: 11
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 12
+                      TOKEN_91(9999): "l", line: 1, col: 12
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 13
+                      TOKEN_84(9999): "e", line: 1, col: 13
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 14
+                      TOKEN_92(9999): "m", line: 1, col: 14
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 15
+                      TOKEN_84(9999): "e", line: 1, col: 15
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 16
+                      TOKEN_93(9999): "n", line: 1, col: 16
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 17
+                      TOKEN_99(9999): "t", line: 1, col: 17
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 18
+                      TOKEN_78(9999): "_", line: 1, col: 18
                     LowercaseLetter(9999)
-                      TOKEN_67(9999): "c", line: 1, col: 19
+                      TOKEN_82(9999): "c", line: 1, col: 19
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 20
+                      TOKEN_94(9999): "o", line: 1, col: 20
                     LowercaseLetter(9999)
-                      TOKEN_85(9999): "u", line: 1, col: 21
+                      TOKEN_100(9999): "u", line: 1, col: 21
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 22
+                      TOKEN_93(9999): "n", line: 1, col: 22
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 23
+                      TOKEN_99(9999): "t", line: 1, col: 23
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 24
+                      TOKEN_98(9999): "s", line: 1, col: 24
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 25
               HAS(9999)
-                TOKEN_40(9999): "H", line: 1, col: 26
-                TOKEN_33(9999): "A", line: 1, col: 27
-                TOKEN_51(9999): "S", line: 1, col: 28
+                TOKEN_46(9999): "HAS", line: 1, col: 26
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 29
@@ -78,7 +76,7 @@ Filter(9999)
                       UnescapedChar(9999)
                         Letter(9999)
                           UppercaseLetter(9999)
-                            TOKEN_40(9999): "H", line: 1, col: 31
+                            TOKEN_45(9999): "H", line: 1, col: 31
                     TOKEN_3(9999): """, line: 1, col: 32
                 Colon(9999)
                   TOKEN_26(9999): ":", line: 1, col: 33
@@ -94,9 +92,7 @@ Filter(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 36
       AND(9999)
-        TOKEN_33(9999): "A", line: 1, col: 37
-        TOKEN_46(9999): "N", line: 1, col: 38
-        TOKEN_36(9999): "D", line: 1, col: 39
+        TOKEN_35(9999): "AND", line: 1, col: 37
         Spaces(9999)
           Space(9999)
             TOKEN_1(9999): " ", line: 1, col: 40
@@ -107,21 +103,21 @@ Filter(9999)
               Property(9999)
                 Identifier(9999)
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 41
+                    TOKEN_84(9999): "e", line: 1, col: 41
                   LowercaseLetter(9999)
-                    TOKEN_76(9999): "l", line: 1, col: 42
+                    TOKEN_91(9999): "l", line: 1, col: 42
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 43
+                    TOKEN_84(9999): "e", line: 1, col: 43
                   LowercaseLetter(9999)
-                    TOKEN_77(9999): "m", line: 1, col: 44
+                    TOKEN_92(9999): "m", line: 1, col: 44
                   LowercaseLetter(9999)
-                    TOKEN_69(9999): "e", line: 1, col: 45
+                    TOKEN_84(9999): "e", line: 1, col: 45
                   LowercaseLetter(9999)
-                    TOKEN_78(9999): "n", line: 1, col: 46
+                    TOKEN_93(9999): "n", line: 1, col: 46
                   LowercaseLetter(9999)
-                    TOKEN_84(9999): "t", line: 1, col: 47
+                    TOKEN_99(9999): "t", line: 1, col: 47
                   LowercaseLetter(9999)
-                    TOKEN_83(9999): "s", line: 1, col: 48
+                    TOKEN_98(9999): "s", line: 1, col: 48
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 49
@@ -135,47 +131,43 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 52
+                        TOKEN_84(9999): "e", line: 1, col: 52
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 53
+                        TOKEN_91(9999): "l", line: 1, col: 53
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 54
+                        TOKEN_84(9999): "e", line: 1, col: 54
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 55
+                        TOKEN_92(9999): "m", line: 1, col: 55
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 56
+                        TOKEN_84(9999): "e", line: 1, col: 56
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 57
+                        TOKEN_93(9999): "n", line: 1, col: 57
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 58
+                        TOKEN_99(9999): "t", line: 1, col: 58
                       LowercaseLetter(9999)
-                        TOKEN_63(9999): "_", line: 1, col: 59
+                        TOKEN_78(9999): "_", line: 1, col: 59
                       LowercaseLetter(9999)
-                        TOKEN_67(9999): "c", line: 1, col: 60
+                        TOKEN_82(9999): "c", line: 1, col: 60
                       LowercaseLetter(9999)
-                        TOKEN_79(9999): "o", line: 1, col: 61
+                        TOKEN_94(9999): "o", line: 1, col: 61
                       LowercaseLetter(9999)
-                        TOKEN_85(9999): "u", line: 1, col: 62
+                        TOKEN_100(9999): "u", line: 1, col: 62
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 63
+                        TOKEN_93(9999): "n", line: 1, col: 63
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 64
+                        TOKEN_99(9999): "t", line: 1, col: 64
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 65
+                        TOKEN_98(9999): "s", line: 1, col: 65
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 66
                 HAS(9999)
-                  TOKEN_40(9999): "H", line: 1, col: 67
-                  TOKEN_33(9999): "A", line: 1, col: 68
-                  TOKEN_51(9999): "S", line: 1, col: 69
+                  TOKEN_46(9999): "HAS", line: 1, col: 67
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 70
                 ALL(9999)
-                  TOKEN_33(9999): "A", line: 1, col: 71
-                  TOKEN_44(9999): "L", line: 1, col: 72
-                  TOKEN_44(9999): "L", line: 1, col: 73
+                  TOKEN_34(9999): "ALL", line: 1, col: 71
                   Spaces(9999)
                     Space(9999)
                       TOKEN_1(9999): " ", line: 1, col: 74
@@ -188,7 +180,7 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 76
+                                TOKEN_45(9999): "H", line: 1, col: 76
                         TOKEN_3(9999): """, line: 1, col: 77
                         Spaces(9999)
                           Space(9999)
@@ -213,12 +205,12 @@ Filter(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               UppercaseLetter(9999)
-                                TOKEN_40(9999): "H", line: 1, col: 84
+                                TOKEN_45(9999): "H", line: 1, col: 84
                         EscapedChar(9999)
                           UnescapedChar(9999)
                             Letter(9999)
                               LowercaseLetter(9999)
-                                TOKEN_69(9999): "e", line: 1, col: 85
+                                TOKEN_84(9999): "e", line: 1, col: 85
                         TOKEN_3(9999): """, line: 1, col: 86
                     Colon(9999)
                       TOKEN_26(9999): ":", line: 1, col: 87
@@ -234,9 +226,7 @@ Filter(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 90
         AND(9999)
-          TOKEN_33(9999): "A", line: 1, col: 91
-          TOKEN_46(9999): "N", line: 1, col: 92
-          TOKEN_36(9999): "D", line: 1, col: 93
+          TOKEN_35(9999): "AND", line: 1, col: 91
           Spaces(9999)
             Space(9999)
               TOKEN_1(9999): " ", line: 1, col: 94
@@ -247,21 +237,21 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 95
+                      TOKEN_84(9999): "e", line: 1, col: 95
                     LowercaseLetter(9999)
-                      TOKEN_76(9999): "l", line: 1, col: 96
+                      TOKEN_91(9999): "l", line: 1, col: 96
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 97
+                      TOKEN_84(9999): "e", line: 1, col: 97
                     LowercaseLetter(9999)
-                      TOKEN_77(9999): "m", line: 1, col: 98
+                      TOKEN_92(9999): "m", line: 1, col: 98
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 99
+                      TOKEN_84(9999): "e", line: 1, col: 99
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 100
+                      TOKEN_93(9999): "n", line: 1, col: 100
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 101
+                      TOKEN_99(9999): "t", line: 1, col: 101
                     LowercaseLetter(9999)
-                      TOKEN_83(9999): "s", line: 1, col: 102
+                      TOKEN_98(9999): "s", line: 1, col: 102
                 SetZipOpRhs(9999)
                   PropertyZipAddon(9999)
                     Colon(9999)
@@ -272,48 +262,43 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 105
+                          TOKEN_84(9999): "e", line: 1, col: 105
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 106
+                          TOKEN_91(9999): "l", line: 1, col: 106
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 107
+                          TOKEN_84(9999): "e", line: 1, col: 107
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 108
+                          TOKEN_92(9999): "m", line: 1, col: 108
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 109
+                          TOKEN_84(9999): "e", line: 1, col: 109
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 110
+                          TOKEN_93(9999): "n", line: 1, col: 110
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 111
+                          TOKEN_99(9999): "t", line: 1, col: 111
                         LowercaseLetter(9999)
-                          TOKEN_63(9999): "_", line: 1, col: 112
+                          TOKEN_78(9999): "_", line: 1, col: 112
                         LowercaseLetter(9999)
-                          TOKEN_67(9999): "c", line: 1, col: 113
+                          TOKEN_82(9999): "c", line: 1, col: 113
                         LowercaseLetter(9999)
-                          TOKEN_79(9999): "o", line: 1, col: 114
+                          TOKEN_94(9999): "o", line: 1, col: 114
                         LowercaseLetter(9999)
-                          TOKEN_85(9999): "u", line: 1, col: 115
+                          TOKEN_100(9999): "u", line: 1, col: 115
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 116
+                          TOKEN_93(9999): "n", line: 1, col: 116
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 117
+                          TOKEN_99(9999): "t", line: 1, col: 117
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 118
+                          TOKEN_98(9999): "s", line: 1, col: 118
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 119
                   HAS(9999)
-                    TOKEN_40(9999): "H", line: 1, col: 120
-                    TOKEN_33(9999): "A", line: 1, col: 121
-                    TOKEN_51(9999): "S", line: 1, col: 122
+                    TOKEN_46(9999): "HAS", line: 1, col: 120
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 123
                   ONLY(9999)
-                    TOKEN_47(9999): "O", line: 1, col: 124
-                    TOKEN_46(9999): "N", line: 1, col: 125
-                    TOKEN_44(9999): "L", line: 1, col: 126
-                    TOKEN_57(9999): "Y", line: 1, col: 127
+                    TOKEN_58(9999): "ONLY", line: 1, col: 124
                     Spaces(9999)
                       Space(9999)
                         TOKEN_1(9999): " ", line: 1, col: 128
@@ -326,7 +311,7 @@ Filter(9999)
                             UnescapedChar(9999)
                               Letter(9999)
                                 UppercaseLetter(9999)
-                                  TOKEN_40(9999): "H", line: 1, col: 130
+                                  TOKEN_45(9999): "H", line: 1, col: 130
                           TOKEN_3(9999): """, line: 1, col: 131
                           Spaces(9999)
                             Space(9999)
@@ -342,9 +327,7 @@ Filter(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 135
           AND(9999)
-            TOKEN_33(9999): "A", line: 1, col: 136
-            TOKEN_46(9999): "N", line: 1, col: 137
-            TOKEN_36(9999): "D", line: 1, col: 138
+            TOKEN_35(9999): "AND", line: 1, col: 136
             Spaces(9999)
               Space(9999)
                 TOKEN_1(9999): " ", line: 1, col: 139
@@ -355,21 +338,21 @@ Filter(9999)
                   Property(9999)
                     Identifier(9999)
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 140
+                        TOKEN_84(9999): "e", line: 1, col: 140
                       LowercaseLetter(9999)
-                        TOKEN_76(9999): "l", line: 1, col: 141
+                        TOKEN_91(9999): "l", line: 1, col: 141
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 142
+                        TOKEN_84(9999): "e", line: 1, col: 142
                       LowercaseLetter(9999)
-                        TOKEN_77(9999): "m", line: 1, col: 143
+                        TOKEN_92(9999): "m", line: 1, col: 143
                       LowercaseLetter(9999)
-                        TOKEN_69(9999): "e", line: 1, col: 144
+                        TOKEN_84(9999): "e", line: 1, col: 144
                       LowercaseLetter(9999)
-                        TOKEN_78(9999): "n", line: 1, col: 145
+                        TOKEN_93(9999): "n", line: 1, col: 145
                       LowercaseLetter(9999)
-                        TOKEN_84(9999): "t", line: 1, col: 146
+                        TOKEN_99(9999): "t", line: 1, col: 146
                       LowercaseLetter(9999)
-                        TOKEN_83(9999): "s", line: 1, col: 147
+                        TOKEN_98(9999): "s", line: 1, col: 147
                   SetZipOpRhs(9999)
                     PropertyZipAddon(9999)
                       Colon(9999)
@@ -377,47 +360,43 @@ Filter(9999)
                       Property(9999)
                         Identifier(9999)
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 149
+                            TOKEN_84(9999): "e", line: 1, col: 149
                           LowercaseLetter(9999)
-                            TOKEN_76(9999): "l", line: 1, col: 150
+                            TOKEN_91(9999): "l", line: 1, col: 150
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 151
+                            TOKEN_84(9999): "e", line: 1, col: 151
                           LowercaseLetter(9999)
-                            TOKEN_77(9999): "m", line: 1, col: 152
+                            TOKEN_92(9999): "m", line: 1, col: 152
                           LowercaseLetter(9999)
-                            TOKEN_69(9999): "e", line: 1, col: 153
+                            TOKEN_84(9999): "e", line: 1, col: 153
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 154
+                            TOKEN_93(9999): "n", line: 1, col: 154
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 155
+                            TOKEN_99(9999): "t", line: 1, col: 155
                           LowercaseLetter(9999)
-                            TOKEN_63(9999): "_", line: 1, col: 156
+                            TOKEN_78(9999): "_", line: 1, col: 156
                           LowercaseLetter(9999)
-                            TOKEN_67(9999): "c", line: 1, col: 157
+                            TOKEN_82(9999): "c", line: 1, col: 157
                           LowercaseLetter(9999)
-                            TOKEN_79(9999): "o", line: 1, col: 158
+                            TOKEN_94(9999): "o", line: 1, col: 158
                           LowercaseLetter(9999)
-                            TOKEN_85(9999): "u", line: 1, col: 159
+                            TOKEN_100(9999): "u", line: 1, col: 159
                           LowercaseLetter(9999)
-                            TOKEN_78(9999): "n", line: 1, col: 160
+                            TOKEN_93(9999): "n", line: 1, col: 160
                           LowercaseLetter(9999)
-                            TOKEN_84(9999): "t", line: 1, col: 161
+                            TOKEN_99(9999): "t", line: 1, col: 161
                           LowercaseLetter(9999)
-                            TOKEN_83(9999): "s", line: 1, col: 162
+                            TOKEN_98(9999): "s", line: 1, col: 162
                           Spaces(9999)
                             Space(9999)
                               TOKEN_1(9999): " ", line: 1, col: 163
                     HAS(9999)
-                      TOKEN_40(9999): "H", line: 1, col: 164
-                      TOKEN_33(9999): "A", line: 1, col: 165
-                      TOKEN_51(9999): "S", line: 1, col: 166
+                      TOKEN_46(9999): "HAS", line: 1, col: 164
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 167
                     ANY(9999)
-                      TOKEN_33(9999): "A", line: 1, col: 168
-                      TOKEN_46(9999): "N", line: 1, col: 169
-                      TOKEN_57(9999): "Y", line: 1, col: 170
+                      TOKEN_36(9999): "ANY", line: 1, col: 168
                       Spaces(9999)
                         Space(9999)
                           TOKEN_1(9999): " ", line: 1, col: 171
@@ -430,7 +409,7 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 173
+                                    TOKEN_45(9999): "H", line: 1, col: 173
                             TOKEN_3(9999): """, line: 1, col: 174
                             Spaces(9999)
                               Space(9999)
@@ -461,12 +440,12 @@ Filter(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   UppercaseLetter(9999)
-                                    TOKEN_40(9999): "H", line: 1, col: 184
+                                    TOKEN_45(9999): "H", line: 1, col: 184
                             EscapedChar(9999)
                               UnescapedChar(9999)
                                 Letter(9999)
                                   LowercaseLetter(9999)
-                                    TOKEN_69(9999): "e", line: 1, col: 185
+                                    TOKEN_84(9999): "e", line: 1, col: 185
                             TOKEN_3(9999): """, line: 1, col: 186
                             Spaces(9999)
                               Space(9999)
@@ -485,9 +464,7 @@ Filter(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 191
             AND(9999)
-              TOKEN_33(9999): "A", line: 1, col: 192
-              TOKEN_46(9999): "N", line: 1, col: 193
-              TOKEN_36(9999): "D", line: 1, col: 194
+              TOKEN_35(9999): "AND", line: 1, col: 192
               Spaces(9999)
                 Space(9999)
                   TOKEN_1(9999): " ", line: 1, col: 195
@@ -498,21 +475,21 @@ Filter(9999)
                     Property(9999)
                       Identifier(9999)
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 196
+                          TOKEN_84(9999): "e", line: 1, col: 196
                         LowercaseLetter(9999)
-                          TOKEN_76(9999): "l", line: 1, col: 197
+                          TOKEN_91(9999): "l", line: 1, col: 197
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 198
+                          TOKEN_84(9999): "e", line: 1, col: 198
                         LowercaseLetter(9999)
-                          TOKEN_77(9999): "m", line: 1, col: 199
+                          TOKEN_92(9999): "m", line: 1, col: 199
                         LowercaseLetter(9999)
-                          TOKEN_69(9999): "e", line: 1, col: 200
+                          TOKEN_84(9999): "e", line: 1, col: 200
                         LowercaseLetter(9999)
-                          TOKEN_78(9999): "n", line: 1, col: 201
+                          TOKEN_93(9999): "n", line: 1, col: 201
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 202
+                          TOKEN_99(9999): "t", line: 1, col: 202
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 203
+                          TOKEN_98(9999): "s", line: 1, col: 203
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 204
@@ -534,48 +511,43 @@ Filter(9999)
                         Property(9999)
                           Identifier(9999)
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 211
+                              TOKEN_84(9999): "e", line: 1, col: 211
                             LowercaseLetter(9999)
-                              TOKEN_76(9999): "l", line: 1, col: 212
+                              TOKEN_91(9999): "l", line: 1, col: 212
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 213
+                              TOKEN_84(9999): "e", line: 1, col: 213
                             LowercaseLetter(9999)
-                              TOKEN_77(9999): "m", line: 1, col: 214
+                              TOKEN_92(9999): "m", line: 1, col: 214
                             LowercaseLetter(9999)
-                              TOKEN_69(9999): "e", line: 1, col: 215
+                              TOKEN_84(9999): "e", line: 1, col: 215
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 216
+                              TOKEN_93(9999): "n", line: 1, col: 216
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 217
+                              TOKEN_99(9999): "t", line: 1, col: 217
                             LowercaseLetter(9999)
-                              TOKEN_63(9999): "_", line: 1, col: 218
+                              TOKEN_78(9999): "_", line: 1, col: 218
                             LowercaseLetter(9999)
-                              TOKEN_67(9999): "c", line: 1, col: 219
+                              TOKEN_82(9999): "c", line: 1, col: 219
                             LowercaseLetter(9999)
-                              TOKEN_79(9999): "o", line: 1, col: 220
+                              TOKEN_94(9999): "o", line: 1, col: 220
                             LowercaseLetter(9999)
-                              TOKEN_85(9999): "u", line: 1, col: 221
+                              TOKEN_100(9999): "u", line: 1, col: 221
                             LowercaseLetter(9999)
-                              TOKEN_78(9999): "n", line: 1, col: 222
+                              TOKEN_93(9999): "n", line: 1, col: 222
                             LowercaseLetter(9999)
-                              TOKEN_84(9999): "t", line: 1, col: 223
+                              TOKEN_99(9999): "t", line: 1, col: 223
                             LowercaseLetter(9999)
-                              TOKEN_83(9999): "s", line: 1, col: 224
+                              TOKEN_98(9999): "s", line: 1, col: 224
                             Spaces(9999)
                               Space(9999)
                                 TOKEN_1(9999): " ", line: 1, col: 225
                       HAS(9999)
-                        TOKEN_40(9999): "H", line: 1, col: 226
-                        TOKEN_33(9999): "A", line: 1, col: 227
-                        TOKEN_51(9999): "S", line: 1, col: 228
+                        TOKEN_46(9999): "HAS", line: 1, col: 226
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 229
                       ONLY(9999)
-                        TOKEN_47(9999): "O", line: 1, col: 230
-                        TOKEN_46(9999): "N", line: 1, col: 231
-                        TOKEN_44(9999): "L", line: 1, col: 232
-                        TOKEN_57(9999): "Y", line: 1, col: 233
+                        TOKEN_58(9999): "ONLY", line: 1, col: 230
                         Spaces(9999)
                           Space(9999)
                             TOKEN_1(9999): " ", line: 1, col: 234
@@ -588,7 +560,7 @@ Filter(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 236
+                                      TOKEN_45(9999): "H", line: 1, col: 236
                               TOKEN_3(9999): """, line: 1, col: 237
                               Spaces(9999)
                                 Space(9999)
@@ -610,12 +582,12 @@ Filter(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     UppercaseLetter(9999)
-                                      TOKEN_40(9999): "H", line: 1, col: 243
+                                      TOKEN_45(9999): "H", line: 1, col: 243
                               EscapedChar(9999)
                                 UnescapedChar(9999)
                                   Letter(9999)
                                     LowercaseLetter(9999)
-                                      TOKEN_69(9999): "e", line: 1, col: 244
+                                      TOKEN_84(9999): "e", line: 1, col: 244
                               TOKEN_3(9999): """, line: 1, col: 245
                           Colon(9999)
                             TOKEN_26(9999): ":", line: 1, col: 246

--- a/tests/outputs/Filter_069.out
+++ b/tests/outputs/Filter_069.out
@@ -17,15 +17,13 @@ Filter(9999)
     ExpressionClause(9999)
       ExpressionPhrase(9999)
         NOT(9999)
-          TOKEN_46(9999): "N", line: 1, col: 5
-          TOKEN_47(9999): "O", line: 1, col: 6
-          TOKEN_52(9999): "T", line: 1, col: 7
+          TOKEN_56(9999): "NOT", line: 1, col: 5
         Comparison(9999)
           PropertyFirstComparison(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 8
+                  TOKEN_80(9999): "a", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     nl(9999)
@@ -62,25 +60,25 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 4, col: 3
+                      TOKEN_78(9999): "_", line: 4, col: 3
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 4, col: 4
+                      TOKEN_78(9999): "_", line: 4, col: 4
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 4, col: 5
+                      TOKEN_78(9999): "_", line: 4, col: 5
                     LowercaseLetter(9999)
-                      TOKEN_66(9999): "b", line: 4, col: 6
+                      TOKEN_81(9999): "b", line: 4, col: 6
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 4, col: 7
+                      TOKEN_84(9999): "e", line: 4, col: 7
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 4, col: 8
+                      TOKEN_99(9999): "t", line: 4, col: 8
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 4, col: 9
+                      TOKEN_80(9999): "a", line: 4, col: 9
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 4, col: 10
+                      TOKEN_78(9999): "_", line: 4, col: 10
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 4, col: 11
+                      TOKEN_78(9999): "_", line: 4, col: 11
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 4, col: 12
+                      TOKEN_78(9999): "_", line: 4, col: 12
                     Spaces(9999)
                       Space(9999)
                         nl(9999)

--- a/tests/outputs/Filter_070.out
+++ b/tests/outputs/Filter_070.out
@@ -8,95 +8,88 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 1
+                  TOKEN_97(9999): "r", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 2
+                  TOKEN_84(9999): "e", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_76(9999): "l", line: 1, col: 3
+                  TOKEN_91(9999): "l", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 4
+                  TOKEN_80(9999): "a", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 5
+                  TOKEN_99(9999): "t", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 6
+                  TOKEN_88(9999): "i", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 7
+                  TOKEN_94(9999): "o", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 8
+                  TOKEN_93(9999): "n", line: 1, col: 8
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 9
+                  TOKEN_98(9999): "s", line: 1, col: 9
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 10
+                  TOKEN_87(9999): "h", line: 1, col: 10
                 LowercaseLetter(9999)
-                  TOKEN_73(9999): "i", line: 1, col: 11
+                  TOKEN_88(9999): "i", line: 1, col: 11
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 12
+                  TOKEN_95(9999): "p", line: 1, col: 12
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 13
+                  TOKEN_98(9999): "s", line: 1, col: 13
               Dot(9999)
                 TOKEN_14(9999): ".", line: 1, col: 14
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 15
+                  TOKEN_97(9999): "r", line: 1, col: 15
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 16
+                  TOKEN_84(9999): "e", line: 1, col: 16
                 LowercaseLetter(9999)
-                  TOKEN_70(9999): "f", line: 1, col: 17
+                  TOKEN_85(9999): "f", line: 1, col: 17
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 18
+                  TOKEN_84(9999): "e", line: 1, col: 18
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 19
+                  TOKEN_97(9999): "r", line: 1, col: 19
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 20
+                  TOKEN_84(9999): "e", line: 1, col: 20
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 21
+                  TOKEN_93(9999): "n", line: 1, col: 21
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 22
+                  TOKEN_82(9999): "c", line: 1, col: 22
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 23
+                  TOKEN_84(9999): "e", line: 1, col: 23
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 24
+                  TOKEN_98(9999): "s", line: 1, col: 24
               Dot(9999)
                 TOKEN_14(9999): ".", line: 1, col: 25
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 26
+                  TOKEN_80(9999): "a", line: 1, col: 26
                 LowercaseLetter(9999)
-                  TOKEN_85(9999): "u", line: 1, col: 27
+                  TOKEN_100(9999): "u", line: 1, col: 27
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 28
+                  TOKEN_99(9999): "t", line: 1, col: 28
                 LowercaseLetter(9999)
-                  TOKEN_72(9999): "h", line: 1, col: 29
+                  TOKEN_87(9999): "h", line: 1, col: 29
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 30
+                  TOKEN_94(9999): "o", line: 1, col: 30
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 31
+                  TOKEN_97(9999): "r", line: 1, col: 31
                 LowercaseLetter(9999)
-                  TOKEN_83(9999): "s", line: 1, col: 32
+                  TOKEN_98(9999): "s", line: 1, col: 32
               Dot(9999)
                 TOKEN_14(9999): ".", line: 1, col: 33
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_78(9999): "n", line: 1, col: 34
+                  TOKEN_93(9999): "n", line: 1, col: 34
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 35
+                  TOKEN_80(9999): "a", line: 1, col: 35
                 LowercaseLetter(9999)
-                  TOKEN_77(9999): "m", line: 1, col: 36
+                  TOKEN_92(9999): "m", line: 1, col: 36
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 37
+                  TOKEN_84(9999): "e", line: 1, col: 37
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 38
             FuzzyStringOpRhs(9999)
               CONTAINS(9999)
-                TOKEN_35(9999): "C", line: 1, col: 39
-                TOKEN_47(9999): "O", line: 1, col: 40
-                TOKEN_46(9999): "N", line: 1, col: 41
-                TOKEN_52(9999): "T", line: 1, col: 42
-                TOKEN_33(9999): "A", line: 1, col: 43
-                TOKEN_41(9999): "I", line: 1, col: 44
-                TOKEN_46(9999): "N", line: 1, col: 45
-                TOKEN_51(9999): "S", line: 1, col: 46
+                TOKEN_39(9999): "CONTAINS", line: 1, col: 39
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 47
@@ -107,42 +100,42 @@ Filter(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         UppercaseLetter(9999)
-                          TOKEN_36(9999): "D", line: 1, col: 49
+                          TOKEN_40(9999): "D", line: 1, col: 49
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_73(9999): "i", line: 1, col: 50
+                          TOKEN_88(9999): "i", line: 1, col: 50
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_74(9999): "j", line: 1, col: 51
+                          TOKEN_89(9999): "j", line: 1, col: 51
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_75(9999): "k", line: 1, col: 52
+                          TOKEN_90(9999): "k", line: 1, col: 52
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_83(9999): "s", line: 1, col: 53
+                          TOKEN_98(9999): "s", line: 1, col: 53
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_84(9999): "t", line: 1, col: 54
+                          TOKEN_99(9999): "t", line: 1, col: 54
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_82(9999): "r", line: 1, col: 55
+                          TOKEN_97(9999): "r", line: 1, col: 55
                   EscapedChar(9999)
                     UnescapedChar(9999)
                       Letter(9999)
                         LowercaseLetter(9999)
-                          TOKEN_65(9999): "a", line: 1, col: 56
+                          TOKEN_80(9999): "a", line: 1, col: 56
                   TOKEN_3(9999): """, line: 1, col: 57
                   Spaces(9999)
                     Space(9999)

--- a/tests/outputs/Filter_071.out
+++ b/tests/outputs/Filter_071.out
@@ -8,7 +8,7 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_65(9999): "a", line: 1, col: 1
+                  TOKEN_80(9999): "a", line: 1, col: 1
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 2
@@ -19,7 +19,7 @@ Filter(9999)
                     TOKEN_1(9999): " ", line: 1, col: 4
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_66(9999): "b", line: 1, col: 5
+                  TOKEN_81(9999): "b", line: 1, col: 5
               Dot(9999)
                 TOKEN_14(9999): ".", line: 1, col: 6
                 Spaces(9999)
@@ -27,7 +27,7 @@ Filter(9999)
                     TOKEN_1(9999): " ", line: 1, col: 7
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_67(9999): "c", line: 1, col: 8
+                  TOKEN_82(9999): "c", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
@@ -35,7 +35,7 @@ Filter(9999)
                 TOKEN_14(9999): ".", line: 1, col: 10
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_68(9999): "d", line: 1, col: 11
+                  TOKEN_83(9999): "d", line: 1, col: 11
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 12
@@ -46,7 +46,7 @@ Filter(9999)
                     TOKEN_1(9999): " ", line: 1, col: 14
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_63(9999): "_", line: 1, col: 15
+                  TOKEN_78(9999): "_", line: 1, col: 15
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 16

--- a/tests/outputs/Filter_072.out
+++ b/tests/outputs/Filter_072.out
@@ -8,40 +8,32 @@ Filter(9999)
             Property(9999)
               Identifier(9999)
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 1
+                  TOKEN_95(9999): "p", line: 1, col: 1
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 2
+                  TOKEN_97(9999): "r", line: 1, col: 2
                 LowercaseLetter(9999)
-                  TOKEN_79(9999): "o", line: 1, col: 3
+                  TOKEN_94(9999): "o", line: 1, col: 3
                 LowercaseLetter(9999)
-                  TOKEN_80(9999): "p", line: 1, col: 4
+                  TOKEN_95(9999): "p", line: 1, col: 4
                 LowercaseLetter(9999)
-                  TOKEN_69(9999): "e", line: 1, col: 5
+                  TOKEN_84(9999): "e", line: 1, col: 5
                 LowercaseLetter(9999)
-                  TOKEN_82(9999): "r", line: 1, col: 6
+                  TOKEN_97(9999): "r", line: 1, col: 6
                 LowercaseLetter(9999)
-                  TOKEN_84(9999): "t", line: 1, col: 7
+                  TOKEN_99(9999): "t", line: 1, col: 7
                 LowercaseLetter(9999)
-                  TOKEN_89(9999): "y", line: 1, col: 8
+                  TOKEN_104(9999): "y", line: 1, col: 8
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 9
             FuzzyStringOpRhs(9999)
               STARTS(9999)
-                TOKEN_51(9999): "S", line: 1, col: 10
-                TOKEN_52(9999): "T", line: 1, col: 11
-                TOKEN_33(9999): "A", line: 1, col: 12
-                TOKEN_50(9999): "R", line: 1, col: 13
-                TOKEN_52(9999): "T", line: 1, col: 14
-                TOKEN_51(9999): "S", line: 1, col: 15
+                TOKEN_64(9999): "STARTS", line: 1, col: 10
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 16
               WITH(9999)
-                TOKEN_55(9999): "W", line: 1, col: 17
-                TOKEN_41(9999): "I", line: 1, col: 18
-                TOKEN_52(9999): "T", line: 1, col: 19
-                TOKEN_40(9999): "H", line: 1, col: 20
+                TOKEN_70(9999): "WITH", line: 1, col: 17
                 Spaces(9999)
                   Space(9999)
                     TOKEN_1(9999): " ", line: 1, col: 21
@@ -49,37 +41,37 @@ Filter(9999)
                 Property(9999)
                   Identifier(9999)
                     LowercaseLetter(9999)
-                      TOKEN_65(9999): "a", line: 1, col: 22
+                      TOKEN_80(9999): "a", line: 1, col: 22
                     LowercaseLetter(9999)
-                      TOKEN_78(9999): "n", line: 1, col: 23
+                      TOKEN_93(9999): "n", line: 1, col: 23
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 24
+                      TOKEN_94(9999): "o", line: 1, col: 24
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 25
+                      TOKEN_99(9999): "t", line: 1, col: 25
                     LowercaseLetter(9999)
-                      TOKEN_72(9999): "h", line: 1, col: 26
+                      TOKEN_87(9999): "h", line: 1, col: 26
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 27
+                      TOKEN_84(9999): "e", line: 1, col: 27
                     LowercaseLetter(9999)
-                      TOKEN_82(9999): "r", line: 1, col: 28
+                      TOKEN_97(9999): "r", line: 1, col: 28
                     LowercaseLetter(9999)
-                      TOKEN_63(9999): "_", line: 1, col: 29
+                      TOKEN_78(9999): "_", line: 1, col: 29
                     LowercaseLetter(9999)
-                      TOKEN_80(9999): "p", line: 1, col: 30
+                      TOKEN_95(9999): "p", line: 1, col: 30
                     LowercaseLetter(9999)
-                      TOKEN_82(9999): "r", line: 1, col: 31
+                      TOKEN_97(9999): "r", line: 1, col: 31
                     LowercaseLetter(9999)
-                      TOKEN_79(9999): "o", line: 1, col: 32
+                      TOKEN_94(9999): "o", line: 1, col: 32
                     LowercaseLetter(9999)
-                      TOKEN_80(9999): "p", line: 1, col: 33
+                      TOKEN_95(9999): "p", line: 1, col: 33
                     LowercaseLetter(9999)
-                      TOKEN_69(9999): "e", line: 1, col: 34
+                      TOKEN_84(9999): "e", line: 1, col: 34
                     LowercaseLetter(9999)
-                      TOKEN_82(9999): "r", line: 1, col: 35
+                      TOKEN_97(9999): "r", line: 1, col: 35
                     LowercaseLetter(9999)
-                      TOKEN_84(9999): "t", line: 1, col: 36
+                      TOKEN_99(9999): "t", line: 1, col: 36
                     LowercaseLetter(9999)
-                      TOKEN_89(9999): "y", line: 1, col: 37
+                      TOKEN_104(9999): "y", line: 1, col: 37
                     Spaces(9999)
                       Space(9999)
                         nl(9999)


### PR DESCRIPTION
This PR contains a few small fixes related to filter's grammar which were partly discussed in an ongoing PR (https://github.com/Materials-Consortia/optimade-python-tools/pull/66). Thanks for the help of @sauliusg, these fixes have been pushed forward to merge into the main repository.
