### PR TITLE
Update and clarify sort and sortable key

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -630,7 +630,7 @@ Example: http://example.com/optimade/v0.9/structures?page_limit=100
   If it does, it again MUST conform to the JSON API 1.0 specification.
 
   If an implementation supports sorting for an `entry listing endpoint <Entry Listing Endpoints_>`_, then the :endpoint:`/info/<entries>` endpoint MUST include, for each field name :field:`<fieldname>` in its :field:`data.properties.<fieldname>` response value, the key :field:`sortable` with value :field-val:`true` or :field-val:`false`.
-  The set of :field:`<fieldname>` s, with :field:`sortable` equal to :field-val:`true` make up the "sort fields" set according to its definition in the JSON API 1.0 specification.
+  The set of :field:`<fieldname>` s, with :field:`sortable` equal to :field-val:`true` are allowed to be used in the "sort fields" list according to its definition in the JSON API 1.0 specification.
   The field :field:`sortable` is in addition to each property description (and optional unit).
   An example is shown in section `Entry Listing Info Endpoints`_.
 
@@ -921,33 +921,33 @@ Example:
 
 .. code:: jsonc
 
-     {
-       "data": {
-	 "description": "a structures entry",
-	 "properties": {
-	   "nelements": {
-	     "description": "Number of elements",
-	     "sortable": true
-	   },
-	   "lattice_vectors": {
-	     "description": "Unit cell lattice vectors",
-	     "unit": "Å",
-       "sortable": false
-	   }
-	   // ... <other property descriptions>
-	 },
-	 "formats": ["json", "xml"],
-	 "output_fields_by_format": {
-	   "json": [
-	     "nelements",
-	     "lattice_vectors",
-	     // ...
-	   ],
-	   "xml": ["nelements"]
-	 }
-       }
-       // ...
-     }
+    {
+      "data": {
+        "description": "a structures entry",
+        "properties": {
+          "nelements": {
+            "description": "Number of elements",
+            "sortable": true
+          },
+          "lattice_vectors": {
+            "description": "Unit cell lattice vectors",
+            "unit": "Å",
+            "sortable": false
+          }
+          // ... <other property descriptions>
+        },
+        "formats": ["json", "xml"],
+        "output_fields_by_format": {
+          "json": [
+            "nelements",
+            "lattice_vectors",
+            // ...
+          ],
+          "xml": ["nelements"]
+        }
+      }
+      // ...
+    }
 
 Links Endpoint
 --------------

--- a/optimade.rst
+++ b/optimade.rst
@@ -629,7 +629,8 @@ Example: http://example.com/optimade/v0.9/structures?page_limit=100
   An implementation MAY support multiple sort fields for a single query.
   If it does, it again MUST conform to the JSON API 1.0 specification.
 
-  If an implementation supports sorting for an `entry listing endpoint <Entry Listing Endpoints_>`_, then the :endpoint:`/info/<entries>` endpoint MUST include, for each field name :field:`<fieldname>` in its :field:`data.properties.<fieldname>` response value, the key :field:`sortable` with value :field-val:`true` or :field-val:`false`.
+  If an implementation supports sorting for an `entry listing endpoint <Entry Listing Endpoints_>`_, then the :endpoint:`/info/<entries>` endpoint MUST include, for each field name :field:`<fieldname>` in its :field:`data.properties.<fieldname>` response value that can be used for sorting, the key :field:`sortable` with value :field-val:`true`.
+  If a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the :field:`sortable` key or set it equal to :field-val:`false` for the specific field name.
   The set of field names, with :field:`sortable` equal to :field-val:`true` are allowed to be used in the "sort fields" list according to its definition in the JSON API 1.0 specification.
   The field :field:`sortable` is in addition to each property description (and optional unit).
   An example is shown in section `Entry Listing Info Endpoints`_.

--- a/optimade.rst
+++ b/optimade.rst
@@ -630,7 +630,7 @@ Example: http://example.com/optimade/v0.9/structures?page_limit=100
   If it does, it again MUST conform to the JSON API 1.0 specification.
 
   If an implementation supports sorting for an `entry listing endpoint <Entry Listing Endpoints_>`_, then the :endpoint:`/info/<entries>` endpoint MUST include, for each field name :field:`<fieldname>` in its :field:`data.properties.<fieldname>` response value, the key :field:`sortable` with value :field-val:`true` or :field-val:`false`.
-  The set of :field:`<fieldname>` s, with :field:`sortable` equal to :field-val:`true` are allowed to be used in the "sort fields" list according to its definition in the JSON API 1.0 specification.
+  The set of field names, with :field:`sortable` equal to :field-val:`true` are allowed to be used in the "sort fields" list according to its definition in the JSON API 1.0 specification.
   The field :field:`sortable` is in addition to each property description (and optional unit).
   An example is shown in section `Entry Listing Info Endpoints`_.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -627,10 +627,11 @@ Example: http://example.com/optimade/v0.9/structures?page_limit=100
 - **sort**: If supporting sortable queries, an implementation MUST use the :query-param:`sort` query parameter with format as specified by `JSON API 1.0 <https://jsonapi.org/format/1.0/#fetching-sorting>`__.
 
   An implementation MAY support multiple sort fields for a single query.
-  If it does, it again MUST conform to the JSON API 1.0 spec.
+  If it does, it again MUST conform to the JSON API 1.0 specification.
 
-  If an implementation supports sorting for an `entry listing endpoint <Entry Listing Endpoints_>`_, then the :endpoint:`/info/<entries>` endpoint MUST include, for each field name :field:`<fieldname>` in its :field:`data.properties.<fieldname>` response value, the key :field:`sortable` with value :field-val:`true`.
-  This is in addition to each property description (and optional unit).
+  If an implementation supports sorting for an `entry listing endpoint <Entry Listing Endpoints_>`_, then the :endpoint:`/info/<entries>` endpoint MUST include, for each field name :field:`<fieldname>` in its :field:`data.properties.<fieldname>` response value, the key :field:`sortable` with value :field-val:`true` or :field-val:`false`.
+  The set of :field:`<fieldname>` s, with :field:`sortable` equal to :field-val:`true` make up the "sort fields" set according to its definition in the JSON API 1.0 specification.
+  The field :field:`sortable` is in addition to each property description (and optional unit).
   An example is shown in section `Entry Listing Info Endpoints`_.
 
 Standard OPTIONAL URL query parameters not in the JSON API specification:
@@ -912,7 +913,7 @@ The response for these endpoints MUST include the following information in the :
 
 - **description**: Description of the entry.
 - **properties**: A dictionary describing queryable properties for this entry type, where each key is a property name.
-  Each value is a dictionary, with the REQUIRED key :field:`description` and OPTIONAL key :field:`unit`.
+  Each value is a dictionary, with the REQUIRED key :field:`description` and OPTIONAL keys :field:`unit` and :field:`sortable` (see `Entry Listing URL Query Parameters`_ for more information on :field:`sortable`).
 - **formats**: List of output formats available for this type of entry.
 - **output\_fields\_by\_format**: Dictionary of available output fields for this entry type, where the keys are the values of the :field:`formats` list and the values are the keys of the :field:`properties` dictionary.
 
@@ -930,7 +931,8 @@ Example:
 	   },
 	   "lattice_vectors": {
 	     "description": "Unit cell lattice vectors",
-	     "unit": "Å"
+	     "unit": "Å",
+       "sortable": false
 	   }
 	   // ... <other property descriptions>
 	 },


### PR DESCRIPTION
Expand on the `sort` parameter definition and add the mentioning of the field `sortable` to the definition of what can be in `/info/<entries>` properties' dictionaries.

The most major thing here (in my opinion) is the clarification that if sorting is possible for an entry endpoint, the `sortable` key MUST be present for all fields under `data.properties.<field>` at `/info/<entries>` and _can_ be either `true` or `false`.
Mainly this is because I am unsure how to sort on lists/arrays, and would like to flag these as NOT sortable.

A minor, but important, addition is the mentioning of `sortable` under what can be in the `data.properties.<field>` dictionary.