### PR TITLE
Relieve the requirement level of query support for 'nsites' from MUST to OPTIONAL

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -1696,7 +1696,7 @@ nsites
 - **Requirements/Conventions**:
     
   - **Response**: REQUIRED in the response unless explicitly excluded.
-  - **Query**: SHOULD be a queryable property with support for all mandatory filter operators.
+  - **Query**: Support for queries on this property is OPTIONAL.
     
 - **Examples**:
   

--- a/optimade.rst
+++ b/optimade.rst
@@ -1696,7 +1696,7 @@ nsites
 - **Requirements/Conventions**:
     
   - **Response**: REQUIRED in the response unless explicitly excluded.
-  - **Query**: MUST be a queryable property with support for all mandatory filter operators.
+  - **Query**: SHOULD be a queryable property with support for all mandatory filter operators.
     
 - **Examples**:
   


### PR DESCRIPTION
In the COD each structure is represented by an asymmetric unit + list of symmetry operators. One has to perform full symmetry reconstruction to arrive to the list of all atoms in cell, and this operation is quite intensive. Therefore both listing and querying on atoms and their positions is infeasible in the COD (more details in #184). Thus I would request relieving the requirement levels for querying on such structures. This PR addresses the `nsites`, the only coordinate-based property on which querying `MUST` be supported as of now.

**Edit**: This PR is also included in PR #210.