### PR TITLE
Relaxed requirements for index meta-databases to support static hosting

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -286,7 +286,7 @@ Database-Provider-Specific Namespace Prefixes
 
 This standard refers to database-provider-specific prefixes and database providers.
 
-A list of known providers and their assigned prefixes is published in the form of a statically hosted OPTiMaDe Index Meta-Database with base URL `https://www.optimade.org/providers/ <https://www.optimade.org/providers/>`__.
+A list of known providers and their assigned prefixes is published in the form of a statically hosted OPTiMaDe Index Meta-Database with base URL `https://providers.optimade.org <https://providers.optimade.org>`__.
 Visiting this URL in a web browser gives a human-readable description of how to retrieve the information in the form of a JSON file, and specifies the procedure for registration of new prefixes.
 
 API implementations SHOULD NOT make up and use new prefixes without first getting them registered in the official list.

--- a/optimade.rst
+++ b/optimade.rst
@@ -266,7 +266,7 @@ The value for :field:`is_index` MUST be :field-val:`true`.
 
 A few suggestions and mandatory requirements of the OPTIMaDe specification are specifically relaxed **only for index meta-databases** to make it possible to serve them in the form of static files on restricted third-party hosting platforms:
 
-- When serving an index meta-database in the form of static files, it is RECOMMENDED that the responses only contain the `data` field (as described in the section `JSON Response Schema: Common Fields`_.)
+- When serving an index meta-database in the form of static files, it is RECOMMENDED that the responses only contain the :field:`data` field (as described in the section `JSON Response Schema: Common Fields`_.)
   The motivation is that static files cannot keep dynamic fields such as :field:`time_stamp` updated.
 
 - The `JSON API specification <http://jsonapi.org/format/1.0>`__ requirements on content negotiation using the HTTP headers :http-header:`Content-type` and :http-header:`Accept` are NOT mandatory for index meta-databases.

--- a/optimade.rst
+++ b/optimade.rst
@@ -273,8 +273,7 @@ A few suggestions and mandatory requirements of the OPTIMaDe specification are s
   Hence, API Implementations MAY ignore the content of these headers and respond to all requests.
   The motivation is that static file hosting is typically not flexible enough to support these requirements on HTTP headers.
 
-- API implementations SHOULD serve JSON content with either the JSON API mandated HTTP header :http-header:`Content-Type: application/vnd.api+json` or :http-header:`Content-Type: application/json`. However, if the hosting platform does not allow this, JSON content MAY be served with other content types.
-  This relaxed requirement means that clients MUST ignore the value of the :http-header:`Content-Type` HTTP header in responses from index meta-databases and accept as valid any response with an HTTP body that can be parsed as UTF-8 encoded JSON if it matches the expected schema.
+- API implementations SHOULD serve JSON content with either the JSON API mandated HTTP header :http-header:`Content-Type: application/vnd.api+json` or :http-header:`Content-Type: application/json`. However, if the hosting platform does not allow this, JSON content MAY be served with :http-header:`Content-Type: text/plain`.
 
 ..
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -264,6 +264,20 @@ The :field:`index_base_url` field MUST be included in every response in the :fie
 The :field:`is_index` field under :field:`attributes` as well as the :field:`relationships` field, MUST be included in the :endpoint:`info` endpoint for the index meta-database (see section `Base URL Info Endpoint`_).
 The value for :field:`is_index` MUST be :field-val:`true`.
 
+A few suggestions and mandatory requirements of the OPTIMaDe specification are specifically relaxed **only for index meta-databases** to make it possible to serve them in the form of static files on restricted third-party hosting platforms:
+
+- When serving an index meta-database in the form of static files, it is RECOMMENDED that the responses only contain the `data` field (as described in the section `JSON Response Schema: Common Fields`_.)
+  The motivation is that static files cannot keep dynamic fields such as :field:`time_stamp` updated.
+
+- The `JSON API specification <http://jsonapi.org/format/1.0>`__ requirements on content negotiation using the HTTP headers :http-header:`Content-type` and :http-header:`Accept` are NOT mandatory for index meta-databases.
+  Hence, API Implementations MAY ignore the content of these headers and respond to all requests.
+  The motivation is that static file hosting is typically not flexible enough to support these requirements on HTTP headers.
+
+- API implementations SHOULD serve JSON content with either the JSON API mandated HTTP header :http-header:`Content-Type: application/vnd.api+json` or :http-header:`Content-Type: application/json`. However, if the hosting platform does not allow this, JSON content MAY be served with other content types.
+  This relaxed requirement means that clients MUST ignore the value of the :http-header:`Content-Type` HTTP header in responses from index meta-databases and accept as valid any response with an HTTP body that can be parsed as UTF-8 encoded JSON if it matches the expected schema.
+
+..
+
     **Note**: A list of database providers acknowledged by the **Open Databases Integration for Materials Design** consortium is maintained externally from this specification and can be retrieved as described in section `Database-Provider-Specific Namespace Prefixes`_.
     This list is also machine-readable, optimizing the automatic discoverability.
 


### PR DESCRIPTION
This is my concrete suggestion for #72. (Fixes #72.)

It was clear on the last telco that there were some differing opinions on this. My suggestion is to allow v1.0-rc1 to be released without this PR merged, and to sort this out between v1.0-rc1 and v1.0.

Issue #72 has become more severe since we (the Materials-Consortia) are now serving an index meta-database of OPTiMaDe providers on http://www.optimade.org/providers/ from github, and as far as I am aware, it is not possible to serve an index meta-database as static files from github without the relaxations in this PR.

I disagree with releasing v1.0 with our own index meta-database of providers in violation of our own specification. 

Hence, we either need this PR merged --- OR --- an alternative hosting solution set up for https://www.optimade.org/providers with comparable reliability/redundancy that auto-updates from the Materials Consortia providers github repo. 

Edit: a preview of these changes is visible at: https://deploy-preview-15--optimade-providers.netlify.com/