### PR TITLE
Change homepage_url -> homepage in providers.json and add it to examples

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -1055,7 +1055,7 @@ The resource objects' response dictionaries MUST include the following fields:
     - **href**: a string containing the OPTiMaDe base URL.
     - **meta**: a meta object containing non-standard meta-information about the implementation.
 
-  - **homepage\_url**: `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__, pointing to a homepage URL for this implementation, either directly as a string, or as a links object, which can contain the following fields:
+  - **homepage**: `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__, pointing to a homepage URL for this implementation, either directly as a string, or as a links object, which can contain the following fields:
 
     - **href**: a string containing the implementation homepage URL.
     - **meta**: a meta object containing non-standard meta-information about the homepage.
@@ -1073,7 +1073,7 @@ Example:
 	     "name": "Index",
 	     "description": "Index for example's OPTiMaDe databases",
 	     "base_url": "http://example.com/optimade/index",
-	     "homepage_url": "http://example.com"
+	     "homepage": "http://example.com"
 	   }
 	 },
 	 {
@@ -1088,7 +1088,7 @@ Example:
 		 "_exmpl_catalyst_group": "denox"
 	       }
 	     },
-	     "homepage_url": "http://example.com"
+	     "homepage": "http://example.com"
 	   }
 	 },
 	 {
@@ -1098,7 +1098,7 @@ Example:
 	     "name": "Zeolitic Frameworks",
 	     "description": "",
 	     "base_url": "http://example.com/optimade/zeo_frameworks",
-	     "homepage_url": "http://example.com"
+	     "homepage": "http://example.com"
 	   }
 	 },
 	 {
@@ -1108,7 +1108,7 @@ Example:
 	     "name": "Example provider",
 	     "description": "Provider used for examples, not to be assigned to a real database",
 	     "base_url": "http://example.com/optimade/index",
-	     "homepage_url": "http://example.com"
+	     "homepage": "http://example.com"
 	   }
 	 }
 	 // ... <other objects>

--- a/optimade.rst
+++ b/optimade.rst
@@ -572,7 +572,7 @@ An example of a full response:
 	       "_exmpl_title": "This is an example site"
 	     }
 	   },
-	   "index_base_url": "http://example.com/optimade/index/"
+	   "index_base_url": "http://example.com/optimade"
 	 },
 	 "response_message": "OK"
 	 // <OPTIONAL implementation- or database-provider-specific metadata, global to the query>
@@ -1072,7 +1072,7 @@ Example:
 	   "attributes": {
 	     "name": "Index",
 	     "description": "Index for example's OPTiMaDe databases",
-	     "base_url": "http://example.com/optimade/index",
+	     "base_url": "http://example.com/optimade",
 	     "homepage": "http://example.com"
 	   }
 	 },
@@ -1097,7 +1097,7 @@ Example:
 	   "attributes": {
 	     "name": "Zeolitic Frameworks",
 	     "description": "",
-	     "base_url": "http://example.com/optimade/zeo_frameworks",
+	     "base_url": "http://example.com/zeo_frameworks/optimade",
 	     "homepage": "http://example.com"
 	   }
 	 },
@@ -1107,7 +1107,7 @@ Example:
 	   "attributes": {
 	     "name": "Example provider",
 	     "description": "Provider used for examples, not to be assigned to a real database",
-	     "base_url": "http://example.com/optimade/index",
+	     "base_url": "http://example.com/optimade",
 	     "homepage": "http://example.com"
 	   }
 	 }

--- a/optimade.rst
+++ b/optimade.rst
@@ -1072,7 +1072,8 @@ Example:
 	   "attributes": {
 	     "name": "Index",
 	     "description": "Index for example's OPTiMaDe databases",
-	     "base_url": "http://example.com/optimade/index"
+	     "base_url": "http://example.com/optimade/index",
+	     "homepage_url": "http://example.com"
 	   }
 	 },
 	 {
@@ -1086,7 +1087,8 @@ Example:
 	       "meta": {
 		 "_exmpl_catalyst_group": "denox"
 	       }
-	     }
+	     },
+	     "homepage_url": "http://example.com"
 	   }
 	 },
 	 {
@@ -1095,7 +1097,8 @@ Example:
 	   "attributes": {
 	     "name": "Zeolitic Frameworks",
 	     "description": "",
-	     "base_url": "http://example.com/optimade/zeo_frameworks"
+	     "base_url": "http://example.com/optimade/zeo_frameworks",
+	     "homepage_url": "http://example.com"
 	   }
 	 },
 	 {
@@ -1104,7 +1107,8 @@ Example:
 	   "attributes": {
 	     "name": "Example provider",
 	     "description": "Provider used for examples, not to be assigned to a real database",
-	     "base_url": "http://example.com/optimade/index"
+	     "base_url": "http://example.com/optimade/index",
+	     "homepage_url": "http://example.com"
 	   }
 	 }
 	 // ... <other objects>


### PR DESCRIPTION
When making PR #228 to implement issue #147 I missed updating the examples. This PR fixes that (sorry).

One thing, though. I implemented the suggestion from #147 to use the field name `homepage_url`, which probably was suggested because it matches `base_url`. However, in the `provider` field in the `info` endpoint we have already used the field name `homepage` for the same link. Should we live with this inconsistency, or should we change either one of them? I suppose when the field value is a "link object" which can be more that just an url, `homepage` makes more sense. (However `base_url` should still remain `base_url`, because that combination of words is for us a moniker for "the root of an API implementation")

Also, do you agree that listing a homepage in providers.json should be mandatory?

I've added an issue in the providers repository to add `homepage_url` to all entries, Materials-Consortia/providers#6.
