### PR TITLE
clarify requirements on the base url

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -231,6 +231,7 @@ Every URL path segment that follows the base URL MUST behave as standardized in 
 All access to the API is provided under the **versioned base URLs**, which append a URL path segment to the base URL that SHOULD be of the form :query-url:`/vMAJOR`, :query-url:`/vMAJOR.MINOR` or :query-url:`/vMAJOR.MINOR.PATCH`. An implementation MUST provide the :query-url:`/vMAJOR` form, whereas the other forms are OPTIONAL.
 Here, :val:`MAJOR` is the major version number, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the standard implemented by the provider.
 For all major versions supported by the provider, the :val:`/vMAJOR` URL MUST serve the *latest* minor/patch version implemented by the provider.
+If the version has a suffix, e.g., `-rc<number>` for release candidate versions, this suffix SHOULD be omitted in the URL path segment.
 
     **For implementers**: Clients are recommended to discover the highest version supported by both the client and the API implementation by trying versioned base URLs in order of priority.
     E.g., if major version 2 and lower are supported by the client, it would try: :query-url:`/v2`, :query-url:`/v1`, and then :query-url:`/v0`.

--- a/optimade.rst
+++ b/optimade.rst
@@ -228,13 +228,13 @@ For any major version supported by the provider, the :val:`<URL>/vMAJOR` URL MUS
 
     **For implementers**: Clients are recommended to discover the highest commonly supported version by the client and the API implementation by trying versioned base URL in order of priority, e.g., if major version 2 and lower are supported by the client, it would try: :query-url:`/v2`, :query-url:`/v1`, and then :query-url:`/v0`.
 
-Examples of valid base URLs:
+Examples of valid versioned base URLs:
 
 - http://example.com/optimade/v0/
 - http://example.com/v0.9.1/
 - http://example.com/v1/
 
-Examples of invalid base URLs:
+Examples of invalid versioned base URLs:
 
 - http://example.com/optimade/0.9/
 - http://example.com/optimade/

--- a/optimade.rst
+++ b/optimade.rst
@@ -232,7 +232,8 @@ All access to the API is provided under the **versioned base URLs**, which appen
 Here, :val:`MAJOR` is the major version number, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the standard implemented by the provider.
 For all major versions supported by the provider, the :val:`/vMAJOR` URL MUST serve the *latest* minor/patch version implemented by the provider.
 
-    **For implementers**: Clients are recommended to discover the highest commonly supported version by the client and the API implementation by trying versioned base URLs in order of priority, e.g., if major version 2 and lower are supported by the client, it would try: :query-url:`/v2`, :query-url:`/v1`, and then :query-url:`/v0`.
+    **For implementers**: Clients are recommended to discover the highest version supported by both the client and the API implementation by trying versioned base URLs in order of priority.
+    E.g., if major version 2 and lower are supported by the client, it would try: :query-url:`/v2`, :query-url:`/v1`, and then :query-url:`/v0`.
 
 Examples of valid versioned base URLs:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -228,7 +228,7 @@ Base URL
 Each database provider will publish one or more **base URLs** that serve the API, for example: http://example.com/optimade/.
 Every URL path segment that follows the base URL MUST behave as standardized in this API specification.
 
-All access to the API is provided under the **versioned base URLs**, which append a URL path segment to the base URL that SHOULD be on the form :query-url:`/vMAJOR`, :query-url:`/vMAJOR.MINOR` or :query-url:`/vMAJOR.MINOR.PATCH`. An implementation MUST provide the :query-url:`/vMAJOR` form, whereas the other forms are OPTIONAL.
+All access to the API is provided under the **versioned base URLs**, which append a URL path segment to the base URL that SHOULD be of the form :query-url:`/vMAJOR`, :query-url:`/vMAJOR.MINOR` or :query-url:`/vMAJOR.MINOR.PATCH`. An implementation MUST provide the :query-url:`/vMAJOR` form, whereas the other forms are OPTIONAL.
 Here, :val:`MAJOR` is the major version number, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the standard implemented by the provider.
 For all major versions supported by the provider, the :val:`/vMAJOR` URL MUST serve the *latest* minor/patch version implemented by the provider.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -219,14 +219,14 @@ General API Requirements and Conventions
 Base URL
 --------
 
-Each database provider will publish one or more **base URLs** that serve the API, for example: http://example.com/optimade/v1.
+Each database provider will publish one or more **base URLs** that serve the API, for example: http://example.com/optimade/
 Every URL component that follows the base URL MUST behave as standardized in this API specification.
 
-Base URLs SHOULD have the form :val:`<URL>/vMAJOR`, :val:`<URL>/vMAJOR.MINOR` or :val:`<URL>/vMAJOR.MINOR.PATCH`.
-Here, :val:`<URL>` represents a generic URL, :val:`MAJOR` is the major version number, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the standard implemented by the provider.
+All access to the API is provided under **versioned base URLs**, which append a URL component to the base URL that SHOULD be on the form :query-url:`vMAJOR`, :query-url:`/vMAJOR.MINOR` or :query-url:`/vMAJOR.MINOR.PATCH`. An implementation MUST provide the :query-url:`/vMAJOR` form, whereas the other forms are OPTIONAL.
+Here, :val:`MAJOR` is the major version number, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the standard implemented by the provider.
 For any major version supported by the provider, the :val:`<URL>/vMAJOR` URL MUST point to the **latest** minor/patch version implemented by the provider.
 
-    **For implementers**: Clients can discover the latest supported version of the standard by cycling through :val:`<URL>/v0`, :val:`<URL>/v1`, :val:`<URL>/v2` etc.
+    **For implementers**: Clients are recommended to discover the highest commonly supported version by the client and the API implementation by trying versioned base URL in order of priority, e.g., if major version 2 and lower are supported by the client, it would try: :query-url:`/v2`, :query-url:`/v1`, and then :query-url:`/v0`.
 
 Examples of valid base URLs:
 
@@ -241,8 +241,8 @@ Examples of invalid base URLs:
 
 Database providers SHOULD strive to implement the latest released version of this standard, as well as the latest patch version of any major and minor version they support.
 
-Note: The base URLs themselves are not considered part of the API, and the standard does not specify the response for a request to a base URL.
-However, it is RECOMMENDED that implementations serve a human-readable HTML document on a base URL, which explains that the URL is an OPTiMaDe base URL meant to be queried by an OPTiMaDe client.
+Note: The base URLs and versioned base URLs themselves are not considered part of the API, and the standard does not specify the response for a request to them.
+However, it is RECOMMENDED that implementations serve a human-readable HTML document on the base URLs and versioned base URLs, which explains that the URL is an OPTiMaDe URL meant to be queried by an OPTiMaDe client.
 
 Index Meta-Database
 -------------------

--- a/optimade.rst
+++ b/optimade.rst
@@ -232,7 +232,7 @@ All access to the API is provided under the **versioned base URLs**, which appen
 Here, :val:`MAJOR` is the major version number, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the standard implemented by the provider.
 For all major versions supported by the provider, the :val:`/vMAJOR` URL MUST serve the **latest** minor/patch version implemented by the provider.
 
-    **For implementers**: Clients are recommended to discover the highest commonly supported version by the client and the API implementation by trying versioned base URL in order of priority, e.g., if major version 2 and lower are supported by the client, it would try: :query-url:`/v2`, :query-url:`/v1`, and then :query-url:`/v0`.
+    **For implementers**: Clients are recommended to discover the highest commonly supported version by the client and the API implementation by trying versioned base URLs in order of priority, e.g., if major version 2 and lower are supported by the client, it would try: :query-url:`/v2`, :query-url:`/v1`, and then :query-url:`/v0`.
 
 Examples of valid versioned base URLs:
 
@@ -1026,7 +1026,7 @@ Links Endpoint
 --------------
 
 This endpoint exposes information on other OPTiMaDe API implementations that are linked to the current implementation.
-The links endpoint is accessed under the versioned base URL at :endpoint:`/links`.
+The links endpoint MUST be provided under the versioned base URL at :endpoint:`/links`.
 
 It can be considered an introspective endpoint, similar to the Info endpoint, but at a higher level: that is, Info endpoints provide information on the given implementation, while the Links endpoint provides information on the links between immediately related implementations (in particular, an array of none or a single :object:`parent` object and none or more child-type objects, see section `Parent and Child Objects`_).
 
@@ -1494,7 +1494,7 @@ type
   - **Query**: MUST be a queryable property with support for all mandatory filter features.
   - **Response**: REQUIRED in the response.
   - MUST be an existing entry type.
-  - The entry of type `<type>` and ID `<id>` MUST be given as the response to a request for :endpoint:`/<type>/<id>` under the versioned base URL.
+  - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for :endpoint:`/<type>/<id>` under the versioned base URL.
     
 - **Example**: :val:`"structures"`
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -222,32 +222,34 @@ Base URL
 Each database provider will publish one or more base URLs that serve the API, for example: http://example.com/optimade/.
 Every URL component that follows the base URL MUST behave as standardized in this API specification.
 
-If database providers choose to implement multiple versions of the API standard, they MAY serve them under the same base URL, followed by the version number prefixed with the letter "v".
-Allowed formatting of the version are vMAJOR and vMAJOR.MINOR and vMAJOR.MINOR.PATCH, where MAJOR is the major version number, MINOR is the minor version number and PATCH is the patch version number of the corresponding standard.
+If database providers choose to implement multiple versions of the API standard, they MAY serve them using version-specific base URLs below the same generic base URL.
+In this case, the generic base URL MUST serve the **latest** version of the standard implemented by the provider.
+Version-specific base URLs consist of the generic base URL, followed by the version number prefixed with the letter "v".
+Allowed formatting of the version are vMAJOR and vMAJOR.MINOR, vMAJOR.MINOR.PATCH, where MAJOR is the major version number, MINOR is the minor version number and PATCH is the patch version number of the corresponding standard.
 If the major version number is 0, then the minor version number MUST also be included.
 
 Examples of valid base URLs:
 
-- http://example.com/optimade/, together with
-  http://example.com/optimade/v0.9/ and
-  http://example.com/optimade/v0.9.1/
+- http://example.com/optimade/
 - http://example.com/
 - http://example.com/some/path/
 
-Examples of invalid base URLs:
+Examples of valid version-specific base URLs:
 
-- http://example.com/v0, together with
-  http://example.com/
-- http://example.com/optimade/0.9/, together with 
-  http://example.com/optimade/
+- http://example.com/optimade/v0.9/
+- http://example.com/v0.9.1/
 
-The base URL MUST serve the latest version of the standard that the provider implements.
+Examples of invalid version-specific base URLs:
+
+- http://example.com/v0
+- http://example.com/optimade/0.9/
+
 The database provider SHOULD strive to implement the latest released version of this standard, as well as the latest patch version of any supported major and minor version.
 
 Clients can retrieve supported versions using the :field:`available_api_versions` field from a query to the base URL :endpoint:`info` endpoint (see section `Base URL Info Endpoint`_).
 
-Note: The base URLs themselves are not considered part of the API, and the standard does not specify the response for a request to the base URL.
-However, it is RECOMMENDED that the implementation serves a human-readable HTML document on each base URL, which explains that the URL is an OPTiMaDe base URL meant to be queried by an OPTiMaDe client.
+Note: The base URLs themselves are not considered part of the API, and the standard does not specify the response for a request to a base URL.
+However, it is RECOMMENDED that implementations serve a human-readable HTML document on a base URL, which explains that the URL is an OPTiMaDe base URL meant to be queried by an OPTiMaDe client.
 
 Index Meta-Database
 -------------------

--- a/optimade.rst
+++ b/optimade.rst
@@ -244,10 +244,10 @@ Examples of invalid base URLs:
 The base URL MUST serve the latest version of the standard that the provider implements.
 The database provider SHOULD strive to implement the latest released version of this standard, as well as the latest patch version of any supported major and minor version.
 
-Clients can query for supported versions using the :field:`available_api_versions` field of the :field:`attributes` field from a query to the base URL :endpoint:`info` endpoint (see section `Base URL Info Endpoint`_).
+Clients can retrieve supported versions using the :field:`available_api_versions` field from a query to the base URL :endpoint:`info` endpoint (see section `Base URL Info Endpoint`_).
 
 Note: The base URLs themselves are not considered part of the API, and the standard does not specify the response for a request to the base URL.
-It is RECOMMENDED that the implementation serves a human-readable HTML document on each base URL, which explains that the URL is an OPTiMaDe base URL meant to be queried by an OPTiMaDe client.
+However, it is RECOMMENDED that the implementation serves a human-readable HTML document on each base URL, which explains that the URL is an OPTiMaDe base URL meant to be queried by an OPTiMaDe client.
 
 Index Meta-Database
 -------------------

--- a/optimade.rst
+++ b/optimade.rst
@@ -219,34 +219,27 @@ General API Requirements and Conventions
 Base URL
 --------
 
-Each database provider will publish one or more base URLs that serve the API, for example: http://example.com/optimade/.
+Each database provider will publish one or more **base URLs** that serve the API, for example: http://example.com/optimade/v1.
 Every URL component that follows the base URL MUST behave as standardized in this API specification.
 
-If database providers choose to implement multiple versions of the API standard, they MAY serve them using version-specific base URLs below the same generic base URL.
-In this case, the generic base URL MUST serve the **latest** version of the standard implemented by the provider.
-Version-specific base URLs consist of the generic base URL, followed by the version number prefixed with the letter "v".
-Allowed formatting of the version are vMAJOR and vMAJOR.MINOR, vMAJOR.MINOR.PATCH, where MAJOR is the major version number, MINOR is the minor version number and PATCH is the patch version number of the corresponding standard.
-If the major version number is 0, then the minor version number MUST also be included.
+Base URLs SHOULD have the form :val:`<URL>/vMAJOR`, :val:`<URL>/vMAJOR.MINOR` or :val:`<URL>/vMAJOR.MINOR.PATCH`.
+Here, :val:`<URL>` represents a generic URL, :val:`MAJOR` is the major version number, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the standard implemented by the provider.
+For any major version supported by the provider, the :val:`<URL>/vMAJOR` URL MUST point to the **latest** minor/patch version implemented by the provider.
+
+    **For implementers**: Clients can discover the latest supported version of the standard by cycling through :val:`<URL>/v0`, :val:`<URL>/v1`, :val:`<URL>/v2` etc.
 
 Examples of valid base URLs:
 
-- http://example.com/optimade/
-- http://example.com/
-- http://example.com/some/path/
-
-Examples of valid version-specific base URLs:
-
-- http://example.com/optimade/v0.9/
+- http://example.com/optimade/v0/
 - http://example.com/v0.9.1/
+- http://example.com/v1/
 
-Examples of invalid version-specific base URLs:
+Examples of invalid base URLs:
 
-- http://example.com/v0
 - http://example.com/optimade/0.9/
+- http://example.com/optimade/
 
-The database provider SHOULD strive to implement the latest released version of this standard, as well as the latest patch version of any supported major and minor version.
-
-Clients can retrieve supported versions using the :field:`available_api_versions` field from a query to the base URL :endpoint:`info` endpoint (see section `Base URL Info Endpoint`_).
+Database providers SHOULD strive to implement the latest released version of this standard, as well as the latest patch version of any major and minor version they support.
 
 Note: The base URLs themselves are not considered part of the API, and the standard does not specify the response for a request to a base URL.
 However, it is RECOMMENDED that implementations serve a human-readable HTML document on a base URL, which explains that the URL is an OPTiMaDe base URL meant to be queried by an OPTiMaDe client.

--- a/optimade.rst
+++ b/optimade.rst
@@ -135,10 +135,10 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
     Names that MUST start with a lowercase letter ([a-z]) or an underscore ("\_") followed by any number of lowercase alphanumerics ([a-z0-9]) and underscores ("\_").
 
 **Base URL**
-    The topmost URL under which the API is served. See section `Base URL`.
+    The topmost URL under which the API is served. See section `Base URL`_.
 
 **Versioned base URL**
-   A URL formed by the base URL plus a path segment indicating a version of the API. See section `Base URL`.
+   A URL formed by the base URL plus a path segment indicating a version of the API. See section `Base URL`_.
     
 **Entry**
     A single instance of a specific type of resource served by the API implementation.

--- a/optimade.rst
+++ b/optimade.rst
@@ -230,7 +230,7 @@ Every URL path segment that follows the base URL MUST behave as standardized in 
 
 All access to the API is provided under the **versioned base URLs**, which append a URL path segment to the base URL that SHOULD be on the form :query-url:`/vMAJOR`, :query-url:`/vMAJOR.MINOR` or :query-url:`/vMAJOR.MINOR.PATCH`. An implementation MUST provide the :query-url:`/vMAJOR` form, whereas the other forms are OPTIONAL.
 Here, :val:`MAJOR` is the major version number, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the standard implemented by the provider.
-For all major versions supported by the provider, the :val:`/vMAJOR` URL MUST serve the **latest** minor/patch version implemented by the provider.
+For all major versions supported by the provider, the :val:`/vMAJOR` URL MUST serve the *latest* minor/patch version implemented by the provider.
 
     **For implementers**: Clients are recommended to discover the highest commonly supported version by the client and the API implementation by trying versioned base URLs in order of priority, e.g., if major version 2 and lower are supported by the client, it would try: :query-url:`/v2`, :query-url:`/v1`, and then :query-url:`/v0`.
 
@@ -374,7 +374,7 @@ Every response SHOULD contain the following fields, and MUST contain at least on
   - **query**: information on the query that was requested.
     It MUST be a dictionary with these fields:
 
-    - **representation**: a string with the part of the URL following the base URL.
+    - **representation**: a string with the part of the URL following the versioned base URL.
 
   - **api\_version**: a string containing the version of the API implementation.
   - **time\_stamp**: a timestamp containing the date and time at which the query was executed.

--- a/optimade.rst
+++ b/optimade.rst
@@ -219,39 +219,35 @@ General API Requirements and Conventions
 Base URL
 --------
 
-Each database provider will publish one or more base URL that serves the API.
-An example could be: http://example.com/optimade/.
+Each database provider will publish one or more base URLs that serve the API, for example: http://example.com/optimade/.
 Every URL component that follows the base URL MUST behave as standardized in this API specification.
 
-The client MAY include a version number in the base URL, prefixed with the letter "v", where the version number indicates the version of the API standard that the client requests.
-The format is either vMAJOR or vMAJOR.MINOR where MAJOR is the major version number, and MINOR is the minor version number of the standard being referenced.
-If the major version is 0, the minor version MUST also be included.
-The database provider MAY support further levels of versioning separated from the major and minor version by a decimal point, e.g., patch version on the format vMAJOR.MINOR.PATCH. However, the client MUST NOT assume levels beyond the minor version are supported.
-
-If the client does not include a version number in the base URL, the request is for the latest version of this standard that the database provider implements.
-A query that includes a major and/or minor version is for the latest subversion of that major and/or minor version that the database provider implements.
-
-A database provider MAY choose to only support a subset of possible versions.
-The client can find out which versions are supported using the :field:`available_api_versions` field of the :field:`attributes` field from a query to the base URL :endpoint:`info` endpoint (see section `Base URL Info Endpoint`_).
-The database provider SHOULD strive to implement the latest subversion of any major and minor version supported.
-Specifically, the latest version of this standard SHOULD be supported.
+If database providers choose to implement multiple versions of the API standard, they MAY serve them under the same base URL, followed by the version number prefixed with the letter "v".
+Allowed formatting of the version are vMAJOR and vMAJOR.MINOR and vMAJOR.MINOR.PATCH, where MAJOR is the major version number, MINOR is the minor version number and PATCH is the patch version number of the corresponding standard.
+If the major version number is 0, then the minor version number MUST also be included.
 
 Examples of valid base URLs:
 
-- http://example.com/optimade/
-- http://example.com/optimade/v0.9/
+- http://example.com/optimade/, together with
+  http://example.com/optimade/v0.9/ and
+  http://example.com/optimade/v0.9.1/
 - http://example.com/
 - http://example.com/some/path/
 
 Examples of invalid base URLs:
 
-- http://example.com/optimade/v0/
-- http://example.com/optimade/0.9/
+- http://example.com/v0, together with
+  http://example.com/
+- http://example.com/optimade/0.9/, together with 
+  http://example.com/optimade/
 
-Note: The OPTiMaDe standard specifies the response from a number of endpoints under the base URLs.
-However, the base URLs themselves are not considered to be a part of the API.
-Hence, they are fully under the control of the API implementation.
-It is RECOMMENDED that the implementation serves a human-readable HTML document on each base URL, and this document is used to explain that the URL is an OPTiMaDe base URL meant to be queried by an OPTiMaDe client.
+The base URL MUST serve the latest version of the standard that the provider implements.
+The database provider SHOULD strive to implement the latest released version of this standard, as well as the latest patch version of any supported major and minor version.
+
+Clients can query for supported versions using the :field:`available_api_versions` field of the :field:`attributes` field from a query to the base URL :endpoint:`info` endpoint (see section `Base URL Info Endpoint`_).
+
+Note: The base URLs themselves are not considered part of the API, and the standard does not specify the response for a request to the base URL.
+It is RECOMMENDED that the implementation serves a human-readable HTML document on each base URL, which explains that the URL is an OPTiMaDe base URL meant to be queried by an OPTiMaDe client.
 
 Index Meta-Database
 -------------------

--- a/optimade.rst
+++ b/optimade.rst
@@ -134,6 +134,12 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 **Identifier**
     Names that MUST start with a lowercase letter ([a-z]) or an underscore ("\_") followed by any number of lowercase alphanumerics ([a-z0-9]) and underscores ("\_").
 
+**Base URL**
+    The topmost URL under which the API is served. See section `Base URL`.
+
+**Versioned base URL**
+   A URL formed by the base URL plus a path segment indicating a version of the API. See section `Base URL`.
+    
 **Entry**
     A single instance of a specific type of resource served by the API implementation.
     For example, a :entry:`structures` entry is comprised by data that pertain to a single structure.
@@ -219,12 +225,12 @@ General API Requirements and Conventions
 Base URL
 --------
 
-Each database provider will publish one or more **base URLs** that serve the API, for example: http://example.com/optimade/
-Every URL component that follows the base URL MUST behave as standardized in this API specification.
+Each database provider will publish one or more **base URLs** that serve the API, for example: http://example.com/optimade/.
+Every URL path segment that follows the base URL MUST behave as standardized in this API specification.
 
-All access to the API is provided under **versioned base URLs**, which append a URL component to the base URL that SHOULD be on the form :query-url:`vMAJOR`, :query-url:`/vMAJOR.MINOR` or :query-url:`/vMAJOR.MINOR.PATCH`. An implementation MUST provide the :query-url:`/vMAJOR` form, whereas the other forms are OPTIONAL.
+All access to the API is provided under the **versioned base URLs**, which append a URL path segment to the base URL that SHOULD be on the form :query-url:`/vMAJOR`, :query-url:`/vMAJOR.MINOR` or :query-url:`/vMAJOR.MINOR.PATCH`. An implementation MUST provide the :query-url:`/vMAJOR` form, whereas the other forms are OPTIONAL.
 Here, :val:`MAJOR` is the major version number, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the standard implemented by the provider.
-For any major version supported by the provider, the :val:`<URL>/vMAJOR` URL MUST point to the **latest** minor/patch version implemented by the provider.
+For all major versions supported by the provider, the :val:`/vMAJOR` URL MUST serve the **latest** minor/patch version implemented by the provider.
 
     **For implementers**: Clients are recommended to discover the highest commonly supported version by the client and the API implementation by trying versioned base URL in order of priority, e.g., if major version 2 and lower are supported by the client, it would try: :query-url:`/v2`, :query-url:`/v1`, and then :query-url:`/v0`.
 
@@ -242,7 +248,7 @@ Examples of invalid versioned base URLs:
 Database providers SHOULD strive to implement the latest released version of this standard, as well as the latest patch version of any major and minor version they support.
 
 Note: The base URLs and versioned base URLs themselves are not considered part of the API, and the standard does not specify the response for a request to them.
-However, it is RECOMMENDED that implementations serve a human-readable HTML document on the base URLs and versioned base URLs, which explains that the URL is an OPTiMaDe URL meant to be queried by an OPTiMaDe client.
+However, it is RECOMMENDED that implementations serve a human-readable HTML document on base URLs and versioned base URLs, which explains that the URL is an OPTiMaDe URL meant to be queried by an OPTiMaDe client.
 
 Index Meta-Database
 -------------------
@@ -257,7 +263,7 @@ However, they MUST return the correct and updated information on all currently p
 
 The :field:`index_base_url` field MUST be included in every response in the :field:`provider` field under the top-level :field:`meta` field (see section `JSON Response Schema: Common Fields`_).
 
-The :field:`is_index` field under :field:`attributes` as well as the :field:`relationships` field, MUST be included in the :endpoint:`info` endpoint for the index meta-database (see section `Base URL Info Endpoint`_).
+The :field:`is_index` field under :field:`attributes` as well as the :field:`relationships` field, MUST be included in the :endpoint:`info` endpoint for the index meta-database (see section `Base Info Endpoint`_).
 The value for :field:`is_index` MUST be :field-val:`true`.
 
     **Note**: A list of database providers acknowledged by the **Open Databases Integration for Materials Design** consortium is maintained externally from this specification and can be retrieved as described in section `Database-Provider-Specific Namespace Prefixes`_.
@@ -492,7 +498,7 @@ The response MAY also return resources related to the primary data in the field:
       {
         "links": {
           "base_url": {
-            "href": "http://example.com/optimade/v0.9/",
+            "href": "http://example.com/optimade",
             "meta": {
               "_exmpl_db_version": "3.2.1"
             }
@@ -536,7 +542,7 @@ An example of a full response:
        "links": {
 	 "next": null,
 	 "base_url": {
-	   "href": "http://example.com/optimade/v0.9/",
+	   "href": "http://example.com/optimade",
 	   "meta": {
 	      "_exmpl_db_version": "3.2.1"
 	   }
@@ -603,7 +609,7 @@ For implementation-specific warnings, they MUST start with ``_`` and the databas
 API Endpoints
 =============
 
-The URL component that follows the base URL MUST represent one of the following endpoints:
+The URL path segment that follows the versioned base URL MUST represent one of the following endpoints:
 
 - an "entry listing" endpoint
 - a "single entry" endpoint
@@ -787,7 +793,7 @@ Example:
 Single Entry Endpoints
 ----------------------
 
-A client can request a specific entry by appending an URL-encoded ID component to the URL of an entry listing endpoint. This will return properties for the entry with that ID.
+A client can request a specific entry by appending an URL-encoded ID path segment to the URL of an entry listing endpoint. This will return properties for the entry with that ID.
 
 In the default JSON response format, the ID component MUST be the content of the :field:`id` field.
 
@@ -843,18 +849,17 @@ Info endpoints provide introspective information, either about the API implement
 
 There are two types of info endpoints:
 
-1. the base URL (e.g., http://example.com/optimade/v0.9/info)
-2. type-specific entry listing endpoints (e.g.,
-   http://example.com/optimade/v0.9/info/structures)
+1. Base info endpoints: placed directly under the versioned base URL (e.g., http://example.com/optimade/v0.9/info)
+2. Entry listing info endpoints: placed under the endpoints pertaining to specific entry types (e.g., http://example.com/optimade/v0.9/info/structures)
 
 The types and output content of these info endpoints are described in more detail in the subsections below.
 Common for them all are that the :field:`data` field SHOULD return only a single resource object.
 If no resource object is provided, the value of the :field:`data` field MUST be :field-val:`null`.
 
-Base URL Info Endpoint
-~~~~~~~~~~~~~~~~~~~~~~
+Base Info Endpoint
+~~~~~~~~~~~~~~~~~~
 
-The Info endpoint on the base URL or directly after the version number (e.g. http://example.com/optimade/v0.9/info) returns information relating to the API implementation.
+The Info endpoint under a versioned base URL (e.g. http://example.com/optimade/v0.9/info) returns information relating to the API implementation.
 
 The single resource object's response dictionary MUST include the following fields:
 
@@ -865,12 +870,12 @@ The single resource object's response dictionary MUST include the following fiel
   - **api\_version**: Presently used version of the OPTiMaDe API.
   - **available\_api\_versions**: MUST be a list of dictionaries, each containing the fields:
 
-    - **url**: a string specifying a base URL that MUST adhere to the rules in section `Base URL`_
-    - **version**: a string containing the full version number of the API served at that base URL. The version number string MUST NOT be prefixed by, e.g., "v".
+    - **url**: a string specifying a versioned base URL that MUST adhere to the rules in section `Base URL`_
+    - **version**: a string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., "v".
 
   - **formats**: List of available output formats.
   - **entry\_types\_by\_format**: Available entry endpoints as a function of output formats.
-  - **available\_endpoints**: List of available endpoints (i.e., the string to be appended to the base URL).
+  - **available\_endpoints**: List of available endpoints (i.e., the string to be appended to the versioned base URL).
 
   :field:`attributes` MAY also include the following OPTIONAL fields:
 
@@ -976,7 +981,7 @@ Example for an index meta-database:
 Entry Listing Info Endpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Entry listing info endpoints are of the form :endpoint:`<base_url>/info/<entry_type>` (e.g., http://example.com/optimade/v0.9/info/structures).
+Entry listing info endpoints are accessed under the versioned base URL as :endpoint:`/info/<entry_type>` (e.g., http://example.com/optimade/v0.9/info/structures).
 The response for these endpoints MUST include the following information in the :field:`data` field:
 
 - **description**: Description of the entry.
@@ -1021,7 +1026,7 @@ Links Endpoint
 --------------
 
 This endpoint exposes information on other OPTiMaDe API implementations that are linked to the current implementation.
-The endpoint MUST be provided at the path :endpoint:`<base_url>/links`.
+The links endpoint is accessed under the versioned base URL at :endpoint:`/links`.
 
 It can be considered an introspective endpoint, similar to the Info endpoint, but at a higher level: that is, Info endpoints provide information on the given implementation, while the Links endpoint provides information on the links between immediately related implementations (in particular, an array of none or a single :object:`parent` object and none or more child-type objects, see section `Parent and Child Objects`_).
 
@@ -1139,7 +1144,8 @@ Custom Extension Endpoints
 --------------------------
 
 API implementations MAY provide custom endpoints under the Extensions endpoint.
-These endpoints MUST be on the form "<base\_url>/extensions/<custom paths>".
+Custom extension endpoints MUST be placed under the versioned base URL at :endpoint:`/extensions`.
+The API implementation is free to define roles of further URL path segments under this URL.
 
 API Filtering Format Specification
 ==================================
@@ -1480,7 +1486,7 @@ id
 type
 ~~~~
 
-- **Description**: The name of the type of an entry. Any entry MUST be able to be fetched using the `base URL <Base URL_>`_ type and ID at the URL :endpoint:`<base URL>/<type>/<id>`.
+- **Description**: The name of the type of an entry.
 - **Type**: string.
 - **Requirements/Conventions**:
 
@@ -1488,7 +1494,8 @@ type
   - **Query**: MUST be a queryable property with support for all mandatory filter features.
   - **Response**: REQUIRED in the response.
   - MUST be an existing entry type.
-
+  - The entry of type `<type>` and ID `<id>` MUST be given as the response to a request for :endpoint:`/<type>/<id>` under the versioned base URL.
+    
 - **Example**: :val:`"structures"`
 
 immutable\_id


### PR DESCRIPTION
This PR tries to clarify a couple of issues in the requirements for the base url.

 - The spec seemed to define a way for clients to construct new base
   urls themselves. This bit is removed, since clients can easily discover
   the base urls of supported versions via the info/ endpoint.

 - It was unclear whether the spec *mandated* serving the API both under
   a baseurl *and* under a baseurl + version suffix. This PR makes clear
   that the second part is optional.

 - The spec differentiated between treatment of vMAJOR, vMAJOR.MINOR and
   vMAJOR.MINOR.PATCH version numbers. Since clients use /info to access
   supported versions, this special treatment is not needed.

 - The spec gave examples of invalid base urls. Strictly speaking, all
   base urls are valid - it is just certain combinations of base URLs that
   are invalid.