### PR TITLE
Update README.md recommendations for implementations beyond v1.0-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ A commit tagged with the suffix `-rc<number>` indicates a release candidate vers
 
 The [develop branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop) contains the present in-development version of the specification.
 
-API and client implementations are RECOMMENDED to implement the lastest named release.
+API and client implementations are RECOMMENDED to implement the latest named release.
 If the latest named release is a release candidate, it is also RECOMMENDED that they implement the latest stable release.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ This repository contains the specification of the OPTiMaDe API.
 
 ## For developers
 
-The [master branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) is at the latest named release of the specification.
+The [master branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) is at the latest named version of the specification.
 A commit tagged with a version number without a suffix (alpha, beta, release candidates and similar) indicates a stable release.
 
 The [develop branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop) contains the present in-development version of the specification.
 
-API and client implementations are encouraged to support the latest named release.
-If the latest named release is a release candidate, implementations are also encouraged to support the latest stable release.
+API and client implementations are encouraged to support the latest version of the release.
+If the latest version is a release candidate, implementations are also encouraged to support the latest stable release.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains the specification of the OPTiMaDe API.
 
 ## For developers
 
-The [master branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) is supposed to be at the latest named release of the specification.
+The [master branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) is at the latest named release of the specification.
 A commit tagged with a version number without a suffix indicates a stable release.
 A commit tagged with the suffix `-rc<number>` indicates a release candidate version. 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains the specification of the OPTiMaDe API.
 ## For developers
 
 The [master branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) is at the latest release or pre-release version of the specification.
-Versions without a version number suffix (alpha, beta, release candidates and similar) indicates a stable release.
+Versions without a version number suffix (alpha, beta, release candidates and similar) indicate a stable release.
 
 The [develop branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop) contains the present in-development version of the specification.
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ This repository contains the specification of the OPTiMaDe API.
 
 ## For developers
 
-The [master branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) is at the latest named version of the specification.
-A commit tagged with a version number without a suffix (alpha, beta, release candidates and similar) indicates a stable release.
+The [master branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) is at the latest release or pre-release version of the specification.
+Versions without a version number suffix (alpha, beta, release candidates and similar) indicates a stable release.
 
 The [develop branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop) contains the present in-development version of the specification.
 
-API and client implementations are encouraged to support the latest version of the release.
-If the latest version is a release candidate, implementations are also encouraged to support the latest stable release.
+API and client implementations are encouraged to support the latest release or pre-release of the specification.
+If this is a pre-release, implementations are also encouraged to support the latest stable release.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ A commit tagged with the suffix `-rc<number>` indicates a release candidate vers
 
 The [develop branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop) contains the present in-development version of the specification.
 
-API and client implementations are RECOMMENDED to implement the latest named release.
-If the latest named release is a release candidate, it is also RECOMMENDED that they implement the latest stable release.
+API and client implementations are encouraged to support the latest named release.
+If the latest named release is a release candidate, implementations are also encouraged to support the latest stable release.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ This repository contains the specification of the OPTiMaDe API.
 ## For developers
 
 The [master branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) is at the latest named release of the specification.
-A commit tagged with a version number without a suffix indicates a stable release.
-A commit tagged with the suffix `-rc<number>` indicates a release candidate version. 
+A commit tagged with a version number without a suffix (alpha, beta, release candidates and similar) indicates a stable release.
 
 The [develop branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop) contains the present in-development version of the specification.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # OPTiMaDe
 
-The Open Databases Integration for Materials Design (OPTiMaDe) consortium aims
-to make materials databases interoperational by developing a common REST API.
+The Open Databases Integration for Materials Design (OPTiMaDe) consortium aims to make materials databases interoperational by developing a common REST API.
 
 This repository contains the specification of the OPTiMaDe API.
 
@@ -12,11 +11,11 @@ This repository contains the specification of the OPTiMaDe API.
 
 ## For developers
 
-The latest "stable" version of the specification is found in the [master](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) branch.  
-The latest "in development" version is found in the [develop](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop) branch.
+The [master branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/master) is supposed to be at the latest named release of the specification.
+A commit tagged with a version number without a suffix indicates a stable release.
+A commit tagged with the suffix `-rc<number>` indicates a release candidate version. 
 
-If you are a **server** developer, it is _recommended_ to always implement the latest stable version. It is also _recommended_ to implement the latest version in development.
-You may want to use the same _master_ and _develop_ branch model employed here.
+The [develop branch of the repository](https://github.com/Materials-Consortia/OPTiMaDe/tree/develop) contains the present in-development version of the specification.
 
-If you are a **client** developer, you are _encouraged_ to support at least the latest stable version, while it is _recommended_ to support the latest version in development.
-You may want to use the same _master_ and _develop_ branch model employed here.
+API and client implementations are RECOMMENDED to implement the lastest named release.
+If the latest named release is a release candidate, it is also RECOMMENDED that they implement the latest stable release.


### PR DESCRIPTION
Beyond v1.0-rc1 we should not recommend external developers to implement a moving development version of the specification, or chaos will ensue.

\- "My server implements v1.1-develop"  
\- "My client too"  
\- "Then why are they incompatible?!"  
