### PR TITLE
Clarify when lattice_vectors MAY be null and how

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -1766,10 +1766,10 @@ lattice\_vectors
   - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.
     (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).
   - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.
-  - This property MUST be an array of dimensions 3 times 3 regardless of the elements of :property:`dimension_types`.
+  - MUST always contain three vectors of three coordinates each, independently of the elements of :property:`dimension_types`.
     The vectors SHOULD by convention be chosen so the determinant of the :property:`lattice_vectors` matrix is different from zero.
     The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.
-  - In the case of non-periodic dimensions, i.e., those dimensions for which :property:`dimension_types` is :val:`0`, implementers MAY choose to replace the values with a list of :val:`null` values.
+  - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which :property:`dimension_types` is :val:`0`) MAY be given as a list of :val:`null` values.
 
 - **Examples**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1757,7 +1757,7 @@ lattice\_vectors
 ~~~~~~~~~~~~~~~~
 
 - **Description**: The three lattice vectors in Cartesian coordinates, in ångström (Å).
-- **Type**: list of list of floats.
+- **Type**: list of list of floats and/or unknown values.
 - **Requirements/Conventions**:
 
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
@@ -1770,6 +1770,7 @@ lattice\_vectors
     The vectors SHOULD by convention be chosen so the determinant of the :property:`lattice_vectors` matrix is different from zero.
     The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.
   - All three elements of the inner lists of floats MAY be :val:`null` for non-periodic dimensions, i.e., those dimensions for which :property:`dimension\_types` is :val:`0`.
+    To clarify, this means a vector MUST he either all floats or all :val:`null` for non-periodic dimensions; a single :val:`null` value MUST never be found.
 
 - **Examples**:
 
@@ -1779,7 +1780,7 @@ cartesian\_site\_positions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **Description**: Cartesian positions of each site. A site is an atom, a site potentially occupied by an atom, or a placeholder for a virtual mixture of atoms (e.g., in a virtual crystal approximation).
-- **Type**: list of list of floats and/or unknown values
+- **Type**: list of list of floats and/or unknown values.
 - **Requirements/Conventions**:
 
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.

--- a/optimade.rst
+++ b/optimade.rst
@@ -1770,7 +1770,7 @@ lattice\_vectors
     The vectors SHOULD by convention be chosen so the determinant of the :property:`lattice_vectors` matrix is different from zero.
     The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.
   - All three elements of the inner lists of floats MAY be :val:`null` for non-periodic dimensions, i.e., those dimensions for which :property:`dimension\_types` is :val:`0`.
-    To clarify, this means a vector MUST he either all floats or all :val:`null` for non-periodic dimensions; a single :val:`null` value MUST never be found.
+    To clarify, this means a vector MUST be either all floats or all :val:`null` for non-periodic dimensions; a single :val:`null` value MUST never be found.
 
 - **Examples**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1769,7 +1769,8 @@ lattice\_vectors
   - MUST always contain three vectors of three coordinates each, independently of the elements of property `dimension\_types`_.
     The vectors SHOULD by convention be chosen so the determinant of the :property:`lattice_vectors` matrix is different from zero.
     The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.
-  - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which `dimension\_types`_ is :val:`0`) MAY be given as a list of :val:`null` values.
+  - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which `dimension\_types`_ is :val:`0`) MAY be given as a list of all :val:`null` values.
+    If a lattice vector contains the value :val:`null`, all coordinates of that lattice vector MUST be :val:`null`.
 
 - **Examples**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1735,14 +1735,14 @@ dimension\_types
 ~~~~~~~~~~~~~~~~
 
 - **Description**: List of three integers.
-  For each of the three directions indicated by the three lattice vectors (see property `lattice_vectors`_).
-  This list indicates if the direction is periodic (value :val:`1`) or non-periodic (value :val:`0`).
-  Note: the elements in this list each refer to the direction of the corresponding entry in property `lattice_vectors`_ and *not* the Cartesian x, y, z directions.
+  For each of the three directions indicated by the three lattice vectors (see property `lattice\_vectors`_), this list indicates if the direction is periodic (value :val:`1`) or non-periodic (value :val:`0`).
+  Note: the elements in this list each refer to the direction of the corresponding entry in `lattice\_vectors`_ and *not* the Cartesian x, y, z directions.
 - **Type**: list of integers.
 - **Requirements/Conventions**:
 
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
-  - **Query**: MUST be a queryable property. Support for equality comparison is REQUIRED, support for other comparison operators are OPTIONAL.
+  - **Query**: MUST be a queryable property.
+    Support for equality comparison is REQUIRED, support for other comparison operators are OPTIONAL.
   - MUST be a list of length 3.
   - Each integer element MUST assume only the value 0 or 1.
 
@@ -1766,10 +1766,10 @@ lattice\_vectors
   - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.
     (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).
   - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.
-  - MUST always contain three vectors of three coordinates each, independently of the elements of :property:`dimension_types`.
+  - MUST always contain three vectors of three coordinates each, independently of the elements of property `dimension\_types`_.
     The vectors SHOULD by convention be chosen so the determinant of the :property:`lattice_vectors` matrix is different from zero.
     The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.
-  - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which :property:`dimension_types` is :val:`0`) MAY be given as a list of :val:`null` values.
+  - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which `dimension\_types`_ is :val:`0`) MAY be given as a list of :val:`null` values.
 
 - **Examples**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1757,7 +1757,7 @@ lattice\_vectors
 ~~~~~~~~~~~~~~~~
 
 - **Description**: The three lattice vectors in Cartesian coordinates, in ångström (Å).
-- **Type**: list of list of floats and/or unknown values.
+- **Type**: list of list of floats or unknown values.
 - **Requirements/Conventions**:
 
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
@@ -1766,11 +1766,10 @@ lattice\_vectors
   - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.
     (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).
   - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.
-  - This property MUST be an array of dimensions 3 times 3 regardless of the elements of :property:`dimension\_types`.
+  - This property MUST be an array of dimensions 3 times 3 regardless of the elements of :property:`dimension_types`.
     The vectors SHOULD by convention be chosen so the determinant of the :property:`lattice_vectors` matrix is different from zero.
     The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.
-  - All three elements of the inner lists of floats MAY be :val:`null` for non-periodic dimensions, i.e., those dimensions for which :property:`dimension\_types` is :val:`0`.
-    To clarify, this means a vector MUST be either all floats or all :val:`null` for non-periodic dimensions; a single :val:`null` value MUST never be found.
+  - In the case of non-periodic dimensions, i.e., those dimensions for which :property:`dimension_types` is :val:`0`, implementers MAY choose to replace the values with a list of :val:`null` values.
 
 - **Examples**:
 


### PR DESCRIPTION
Fixes #253 

This may be a bit verbose, but should clarify what is truly meant by the requirements and conventions listed for `lattice_vectors` under the `structures` entry according to the discussion in #253.