### PR TITLE
Custom endpoints should be under `/extensions`

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -661,7 +661,7 @@ Examples of valid entry listing endpoint URLs:
 
 There MAY be multiple entry listing endpoints, depending on how many types of entries an implementation provides.
 Specific standard entry types are specified in section `Entry list`_.
-The API implementation MAY provide other entry types than the ones standardized in this specification, but such entry types MUST be prefixed by a database-provider-specific prefix.
+The API implementation MAY provide other entry types than the ones standardized in this specification, but such entry types MUST be situated under the :endpoint:`extensions` endpoint.
 
 Entry Listing URL Query Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/optimade.rst
+++ b/optimade.rst
@@ -662,7 +662,12 @@ Examples of valid entry listing endpoint URLs:
 There MAY be multiple entry listing endpoints, depending on how many types of entries an implementation provides.
 Specific standard entry types are specified in section `Entry list`_.
 
-The API implementation MAY provide other entry types than the ones standardized in this specification, but such entry types MUST be situated either under the :endpoint:`extensions` endpoint or be prefixed by a database-provider-specific prefix if situated at the root of the base URL.
+The API implementation MAY provide other entry types than the ones standardized in this specification.
+Such entry types MUST be prefixed by a database-provider-specific prefix (i.e., the resource objects' :property:`type` value should start with the database-provider-specific prefix, e.g., :property:`type` = :val:`_exmpl_workflows`).
+Each custom entry type SHOULD be served at a corresponding entry listing endpoint under the base URL with the same name (i.e., equal to the resource objects' :property:`type` value, e.g., :endpoint:`/_exmpl_workflows`).
+It is RECOMMENDED to align with the OPTIMADE API specification practice of using a plural for entry resource types and entry type endpoints.
+
+For more on custom endpoints, see `Custom Extension Endpoints`_.
 
 Entry Listing URL Query Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/optimade.rst
+++ b/optimade.rst
@@ -661,7 +661,8 @@ Examples of valid entry listing endpoint URLs:
 
 There MAY be multiple entry listing endpoints, depending on how many types of entries an implementation provides.
 Specific standard entry types are specified in section `Entry list`_.
-The API implementation MAY provide other entry types than the ones standardized in this specification, but such entry types MUST be situated under the :endpoint:`extensions` endpoint.
+
+The API implementation MAY provide other entry types than the ones standardized in this specification, but such entry types MUST be situated either under the :endpoint:`extensions` endpoint or be prefixed by a database-provider-specific prefix if situated at the root of the base URL.
 
 Entry Listing URL Query Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/optimade.rst
+++ b/optimade.rst
@@ -666,6 +666,7 @@ The API implementation MAY provide other entry types than the ones standardized 
 Such entry types MUST be prefixed by a database-provider-specific prefix (i.e., the resource objects' :property:`type` value should start with the database-provider-specific prefix, e.g., :property:`type` = :val:`_exmpl_workflows`).
 Each custom entry type SHOULD be served at a corresponding entry listing endpoint under the base URL with the same name (i.e., equal to the resource objects' :property:`type` value, e.g., :endpoint:`/_exmpl_workflows`).
 It is RECOMMENDED to align with the OPTIMADE API specification practice of using a plural for entry resource types and entry type endpoints.
+Any custom entry listing endpoint MUST also be added to the :property:`available\_endpoints` and :property:`entry\_types\_by\_format` attributes of the `Base Info Endpoint`_.
 
 For more on custom endpoints, see `Custom Extension Endpoints`_.
 


### PR DESCRIPTION
A minor clarification/change on how to implement custom endpoints to align with the sentiment under the `/extensions` endpoint section.

I didn't vacuum the spec to see if there are other places in the spec this should be updated/changed.