### PR TITLE
Handle grammatiker build chain dependency as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/tools/grammatiker"]
+	path = tests/tools/grammatiker
+	url = https://github.com/Materials-Consortia/grammatiker

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -66,6 +66,29 @@
 # - test_authors: runs tests on the AUTHORS file (checks order)
 #
 #
+# Targets for build chain dependencies
+######################################
+#
+# - grammatiker_svn_update: connects the grammatiker submodule
+#   in tests/tools/grammatiker to the main svn repository
+#   and pulls the latest revisions via svn.
+#
+#   Upon running the above, one can update the git repository
+#   that hosts the submodule:
+#     cd tests/tools/grammatiker
+#     git remote add gitrepo git@github.com:Materials-Consortia/grammatiker.git
+#     git checkout -b new gitrepo/master
+#     git cherry-pick <ranges of hashes not yet in submodule repo>
+#     git push gitrepo master
+#
+#   The grammatiker commit used by OPTIMADE can be updated using:
+#     cd tests/tools/grammatiker
+#     git checkout <tag or hash>
+#     cd ../../..
+#     git add tests/tools/grammatiker
+#     git commit -m "Update grammatiker submodule to revision <specifier>"
+#     
+#
 # Furthermore, there are some more granular targets specifically for
 # testing the grammar.
 #

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -80,9 +80,7 @@
 #     git push gitrepo master
 #
 #   To alter the commit used by the OPTIMADE build chain:
-#     cd tests/tools/grammatiker
-#     git checkout <tag or hash>
-#     cd ../../..
+#     (cd tests/tools/grammatiker && git checkout <tag or hash>)
 #     git add tests/tools/grammatiker
 #     git commit -m "Update grammatiker submodule to revision <specifier>"
 #     

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -69,19 +69,17 @@
 # Targets for build chain dependencies
 ######################################
 #
-# - grammatiker_svn_update: connects the grammatiker submodule
-#   in tests/tools/grammatiker to the main svn repository
-#   and pulls the latest revisions via svn.
+# - grammatiker_svn_pull: connects the grammatiker submodule
+#   in tests/tools/grammatiker to the grammatiker svn repository
+#   and pulls new revisions, adding them as git commits
 #
-#   Upon running the above, one can update the git repository
-#   that hosts the submodule:
+#   Upon running the above, one can update a git repository
+#   with the grammatiker commits, e.g.:
 #     cd tests/tools/grammatiker
-#     git remote add gitrepo git@github.com:Materials-Consortia/grammatiker.git
-#     git checkout -b new gitrepo/master
-#     git cherry-pick <ranges of hashes not yet in submodule repo>
+#     git remote add gitrepo <repo>
 #     git push gitrepo master
 #
-#   The grammatiker commit used by OPTIMADE can be updated using:
+#   To alter the commit used by the OPTIMADE build chain:
 #     cd tests/tools/grammatiker
 #     git checkout <tag or hash>
 #     cd ../../..

--- a/tests/makefiles/Makelocal-tools
+++ b/tests/makefiles/Makelocal-tools
@@ -58,7 +58,7 @@ GRAMMATIKER_URL = svn://saulius-grazulis.lt/grammatiker
 GRAMMATIKER_LOG = ${TOOL_DIR}/grammatiker.log
 GRAMMATIKER_DIR = ${TOOL_DIR}/grammatiker
 
-.PHONY: grammatiker distclean-grammatiker grammatiker_submodule_init grammatiker_svn_init grammatiker_svn_pull
+.PHONY: grammatiker distclean-grammatiker grammatiker_submodule_init grammatiker_svn_pull
 
 grammatiker: ${GRAMMATIKER_LOG}
 

--- a/tests/makefiles/Makelocal-tools
+++ b/tests/makefiles/Makelocal-tools
@@ -54,12 +54,11 @@ DISTCLEAN_TARGETS += distclean-grammatica
 
 # Local installation of 'grammatiker':
 
-GRAMMATIKER_REV ?= 129
 GRAMMATIKER_URL = svn://saulius-grazulis.lt/grammatiker
-GRAMMATIKER_LOG = ${TOOL_DIR}/grammatiker-r${GRAMMATIKER_REV}.log
+GRAMMATIKER_LOG = ${TOOL_DIR}/grammatiker.log
 GRAMMATIKER_DIR = ${TOOL_DIR}/grammatiker
 
-.PHONY: grammatiker distclean-grammatiker grammatiker_submodule_init grammatiker_update_from_svn
+.PHONY: grammatiker distclean-grammatiker grammatiker_submodule_init grammatiker_svn_init grammatiker_svn_pull
 
 grammatiker: ${GRAMMATIKER_LOG}
 
@@ -81,15 +80,22 @@ grammatiker_svn_init: grammatiker_submodule_init
 	(cd "${GRAMMATIKER_DIR}"; git svn info >/dev/null 2>&1) || \
 	  (     cd "${GRAMMATIKER_DIR}"; \
 		git svn init ${GRAMMATIKER_URL} -s && \
-		git svn fetch && \
-		git rebase --onto remotes/origin/trunk --root master \
+		git svn fetch 
 	  )
 
-grammatiker_svn_update: grammatiker_svn_init
-	cd "${GRAMMATIKER_DIR}" && git svn rebase 
+grammatiker_svn_pull: grammatiker_svn_init
+	cd "${GRAMMATIKER_DIR}" && ${TOOL_DIR}/git_svn_pull "${GRAMMATIKER_URL}"
 
 distclean-grammatiker:
 	rm -rf ${GRAMMATIKER_DIR}
 	rm -f ${GRAMMATIKER_LOG}
 
 DISTCLEAN_TARGETS += distclean-grammatiker
+
+grammatiker_svn_old: grammatiker_submodule_init
+	(cd "${GRAMMATIKER_DIR}"; git svn info >/dev/null 2>&1) || \
+	  (     cd "${GRAMMATIKER_DIR}"; \
+		git svn init ${GRAMMATIKER_URL} -s && \
+		git svn fetch && \
+		git rebase --onto remotes/origin/trunk --root master \
+	  )

--- a/tests/makefiles/Makelocal-tools
+++ b/tests/makefiles/Makelocal-tools
@@ -76,15 +76,8 @@ ${GRAMMATIKER_LOG}: grammatiker_submodule_init ${GRAMMATICA_LOG}
 	test -d ${GRAMMATIKER_DIR} && ${GRAMMATIKER_MAKE} -C ${GRAMMATIKER_DIR} all tests \
 	2>&1 | tee -a $@
 
-grammatiker_svn_init: grammatiker_submodule_init
-	(cd "${GRAMMATIKER_DIR}"; git svn info >/dev/null 2>&1) || \
-	  (     cd "${GRAMMATIKER_DIR}"; \
-		git svn init ${GRAMMATIKER_URL} -s && \
-		git svn fetch 
-	  )
-
-grammatiker_svn_pull: grammatiker_svn_init
-	cd "${GRAMMATIKER_DIR}" && ${TOOL_DIR}/git_svn_pull "${GRAMMATIKER_URL}"
+grammatiker_svn_pull: 
+	${TOOL_DIR}/git_svn_pull "${GRAMMATIKER_URL}" "${GRAMMATIKER_DIR}"
 
 distclean-grammatiker:
 	rm -rf ${GRAMMATIKER_DIR}
@@ -92,10 +85,3 @@ distclean-grammatiker:
 
 DISTCLEAN_TARGETS += distclean-grammatiker
 
-grammatiker_svn_old: grammatiker_submodule_init
-	(cd "${GRAMMATIKER_DIR}"; git svn info >/dev/null 2>&1) || \
-	  (     cd "${GRAMMATIKER_DIR}"; \
-		git svn init ${GRAMMATIKER_URL} -s && \
-		git svn fetch && \
-		git rebase --onto remotes/origin/trunk --root master \
-	  )

--- a/tests/makefiles/Makelocal-tools
+++ b/tests/makefiles/Makelocal-tools
@@ -76,7 +76,7 @@ ${GRAMMATIKER_LOG}: grammatiker_submodule_init ${GRAMMATICA_LOG}
 	test -d ${GRAMMATIKER_DIR} && ${GRAMMATIKER_MAKE} -C ${GRAMMATIKER_DIR} all tests \
 	2>&1 | tee -a $@
 
-grammatiker_svn_pull: 
+grammatiker_svn_pull: grammatiker_submodule_init
 	${TOOL_DIR}/git_svn_pull "${GRAMMATIKER_URL}" "${GRAMMATIKER_DIR}"
 
 distclean-grammatiker:

--- a/tests/makefiles/Makelocal-tools
+++ b/tests/makefiles/Makelocal-tools
@@ -55,25 +55,38 @@ DISTCLEAN_TARGETS += distclean-grammatica
 # Local installation of 'grammatiker':
 
 GRAMMATIKER_REV ?= 129
-GRAMMATIKER_URL = svn://saulius-grazulis.lt/grammatiker/trunk
+GRAMMATIKER_URL = svn://saulius-grazulis.lt/grammatiker
 GRAMMATIKER_LOG = ${TOOL_DIR}/grammatiker-r${GRAMMATIKER_REV}.log
 GRAMMATIKER_DIR = ${TOOL_DIR}/grammatiker
 
-.PHONY: grammatiker distclean-grammatiker
+.PHONY: grammatiker distclean-grammatiker grammatiker_submodule_init grammatiker_update_from_svn
 
 grammatiker: ${GRAMMATIKER_LOG}
 
 GRAMMATIKER_MAKE ?= make
 
-${GRAMMATIKER_LOG}: ${GRAMMATICA_LOG}
-	svn co -r ${GRAMMATIKER_REV} ${GRAMMATIKER_URL} ${GRAMMATIKER_DIR} \
-	2>&1 | tee $@
+grammatiker_submodule_init:
+	git submodule status | grep " ${GRAMMATIKER_DIR}" | egrep -q "^-" && git submodule init "${GRAMMATIKER_DIR}" || true
+	test -e "${GRAMMATIKER_DIR}/.git" || git submodule update "${GRAMMATIKER_DIR}"
+
+${GRAMMATIKER_LOG}: grammatiker_submodule_init ${GRAMMATICA_LOG}
 	rm -rf ${GRAMMATIKER_DIR}/EBNF/lib
 	ln -s ${GRAMMATICA_DIR} ${GRAMMATIKER_DIR}/EBNF/lib
 	rm -rf ${GRAMMATIKER_DIR}/BNF/lib
 	ln -s ${GRAMMATICA_DIR} ${GRAMMATIKER_DIR}/BNF/lib
 	test -d ${GRAMMATIKER_DIR} && ${GRAMMATIKER_MAKE} -C ${GRAMMATIKER_DIR} all tests \
 	2>&1 | tee -a $@
+
+grammatiker_svn_init: grammatiker_submodule_init
+	(cd "${GRAMMATIKER_DIR}"; git svn info >/dev/null 2>&1) || \
+	  (     cd "${GRAMMATIKER_DIR}"; \
+		git svn init ${GRAMMATIKER_URL} -s && \
+		git svn fetch && \
+		git rebase --onto remotes/origin/trunk --root master \
+	  )
+
+grammatiker_svn_update: grammatiker_svn_init
+	cd "${GRAMMATIKER_DIR}" && git svn rebase 
 
 distclean-grammatiker:
 	rm -rf ${GRAMMATIKER_DIR}

--- a/tests/tools/.gitignore
+++ b/tests/tools/.gitignore
@@ -1,3 +1,2 @@
 *.log
 grammatica*
-grammatiker

--- a/tests/tools/Dockerfile
+++ b/tests/tools/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
         make \
         default-jdk \
         subversion \
-	git \
+        git \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/tests/tools/Dockerfile
+++ b/tests/tools/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
         make \
         default-jdk \
         subversion \
+	git \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/tests/tools/git_svn_pull
+++ b/tests/tools/git_svn_pull
@@ -1,11 +1,26 @@
 #!/bin/bash
 
+set -e
+
 URL="$1"
+DIR="$2"
 
-git checkout master
+if [ -z "$1" ]; then
+    echo "Usage: $0 <svn url>"
+    exit 0
+fi
 
-# Make sure the SVN repository is initialized
-git show-ref --verify --quiet refs/remotes/origin/master || git svn init "${URL}" -s
+if [ -n "$2" ]; then
+    cd "$2"
+fi
+
+git checkout --quiet master
+
+# Make sure the SVN repository is initialized to the right URL
+CONFIG_URL=$(git config --get svn-remote.svn.url)
+if [ "$CONFIG_URL" != "$URL" ]; then
+    git svn init "${URL}" -s
+fi
 
 # Fetch svn commits
 git svn fetch 
@@ -14,13 +29,15 @@ git svn fetch
 OLDREV=$(git svn find-rev "$(git log --max-count 1 --pretty=format:%H)")
 
 # Find last svn revision in the commits fetched from svn
-git checkout remotes/origin/master
-NEWREV=$(git svn find-rev "$(git log --max-count 1 --pretty=format:%H)")
-OLDCOMMIT=$(git svn find-rev r$OLDREV)
+git checkout --quiet remotes/origin/trunk
+LAST_NEW_COMMIT="$(git log --max-count 1 --pretty=format:%H)"
+LAST_OLD_COMMIT=$(git svn find-rev "r$OLDREV")
 
-git checkout master
+if [ "$LAST_NEW_COMMIT" == "$LAST_OLD_COMMIT" ]; then
+    echo "No new svn revisions to pull."
+    exit 0
+fi
 
-# Grab all commits that are not already in master
-git rebase --onto remotes/origin/trunk master 
-
-
+git checkout --quiet master
+# Rebase commits that are not already in master onto master
+git rebase --onto master "$LAST_OLD_COMMIT" "$LAST_NEW_COMMIT"

--- a/tests/tools/git_svn_pull
+++ b/tests/tools/git_svn_pull
@@ -14,6 +14,12 @@ if [ -n "$2" ]; then
     cd "$2"
 fi
 
+# Saftey to avoid accidentally running git commands in wrong repo
+if [ ! -e .git ]; then
+    echo "Expected .git to exist in directory."
+    exit 1
+fi
+ 
 git checkout --quiet master
 
 # Make sure the SVN repository is initialized to the right URL

--- a/tests/tools/git_svn_pull
+++ b/tests/tools/git_svn_pull
@@ -19,16 +19,16 @@ if [ ! -e .git ]; then
     echo "Expected .git to exist in directory."
     exit 1
 fi
- 
+
 git checkout --quiet master
 
 # Make sure the SVN repository is initialized to the right URL
-CONFIG_URL=$(git config --get svn-remote.svn.url)
+CONFIG_URL=$(git config --get svn-remote.svn.url || true)
 if [ "$CONFIG_URL" != "$URL" ]; then
     git svn init "${URL}" -s
 fi
 
-# Fetch svn commits
+# Fetch all unseen svn commits
 git svn fetch 
 
 # Find last svn revision in master
@@ -38,12 +38,14 @@ OLDREV=$(git svn find-rev "$(git log --max-count 1 --pretty=format:%H)")
 git checkout --quiet remotes/origin/trunk
 LAST_NEW_COMMIT="$(git log --max-count 1 --pretty=format:%H)"
 LAST_OLD_COMMIT=$(git svn find-rev "r$OLDREV")
+git checkout --quiet master
 
 if [ "$LAST_NEW_COMMIT" == "$LAST_OLD_COMMIT" ]; then
     echo "No new svn revisions to pull."
     exit 0
 fi
 
-git checkout --quiet master
 # Rebase commits that are not already in master onto master
 git rebase --onto master "$LAST_OLD_COMMIT" "$LAST_NEW_COMMIT"
+git branch -f master
+git checkout --quiet master

--- a/tests/tools/git_svn_pull
+++ b/tests/tools/git_svn_pull
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+URL="$1"
+
+git checkout master
+
+# Make sure the SVN repository is initialized
+git show-ref --verify --quiet refs/remotes/origin/master || git svn init "${URL}" -s
+
+# Fetch svn commits
+git svn fetch 
+
+# Find last svn revision in master
+OLDREV=$(git svn find-rev "$(git log --max-count 1 --pretty=format:%H)")
+
+# Find last svn revision in the commits fetched from svn
+git checkout remotes/origin/master
+NEWREV=$(git svn find-rev "$(git log --max-count 1 --pretty=format:%H)")
+OLDCOMMIT=$(git svn find-rev r$OLDREV)
+
+git checkout master
+
+# Grab all commits that are not already in master
+git rebase --onto remotes/origin/trunk master 
+
+


### PR DESCRIPTION
This PR attempts to demonstrate one suggestion of how we could improve the present handling of the dependency our build chain has on the grammatiker software. This addresses a problem brought up in #195 (where this solution was also discussed). **Note: there is yet not a consensus on the best way to do this.** I prepared this PR to demonstrate how (un)complicated this solution is in practice and it is meant to be rejected if we decide for another way.

*The present way the dependency on grammatiker is handled:*

The makefile, during build-time, uses svn to download a specific revision (129) of grammatiker from an svn server via a URL specified in the makefile using the svn:// protocol (host: saulius-grazulis.lt). The download is presently not checked for integrity (but this could of course be added in some way).

*With this PR:*

Our github Materials-Consortia/grammatiker repo becomes a git submodule under tests/tools/grammatiker. The binding is to a specific commit in that git repo (presently the one corresponding to SVN revision 129). 

The handling of the submodule with git is mostly transparent for end-users as it is automatically initialized and updated by the makefile when the dependency is needed.

There is also a makefile target: `make grammatiker_svn_pull` that fetches new revisions from the upstream svn server and places them as git commits in the local master branch of the submodule repo. The local repo can then be used to update the Materials-Consortia/grammatiker github repo.

Some properties I like with this solution:

- The way git ties the submodule to a hash guarantees that what is downloaded is the same thing as can be browsed in the github Materials-Consortia/grammatiker repo, where one can look at the changes as individual commits.
 
- When we want to upgrade the revision of grammatiker to use, this will be done via a PR against OPTIMADE for the submodule to point at a new commit. It is then easy to review the changes between revisions in the Materials-Consortia/grammatiker github repo using the same UI we use to reivew the usual OPTIMADE PRs. 
