### PR TITLE
Typo in author name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,7 +26,7 @@ Abhijith Gopakumar
 Marco Govoni
 Saulius Gražulis
 Geoffroy Hautier
-Vinay Hedge
+Vinay Hegde
 Georg Huhs
 Jens Hummelshoej
 Karsten W. Jacobsen


### PR DESCRIPTION
I noticed that this typo has been fixed in the paper, but not in the list here.