### PR TITLE
New representation of atoms at unknown positions

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -1828,20 +1828,15 @@ lattice\_vectors
 cartesian\_site\_positions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Description**: Cartesian positions of each site. A site is an atom, a site potentially occupied by an atom, or a placeholder for a virtual mixture of atoms (e.g., in a virtual crystal approximation).
-- **Type**: list of list of floats and/or unknown values.
+- **Description**: The cartesian positions of each site in the structure. A site is the position of a species (cf. the :property:`species` property.) as indicated by the :property:`species_at_sites` property.
+- **Type**: list of list of floats
 - **Requirements/Conventions**:
 
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
   - **Query**: Support for queries on this property is OPTIONAL.
     If supported, filters MAY support only a subset of comparison operators.
-  - It MUST be a list of length equal to the number of sites in the structure where every element is a list of the three Cartesian coordinates of a site.
-  - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`_).
-  - If a component of the position is unknown, the :val:`null` value SHOULD be provided instead (see section `Properties with an unknown value`_).
-    Otherwise, it SHOULD be a float value, expressed in angstrom (Å).
-    If at least one of the coordinates is unknown, the correct flag in the list property `structure_features`_ MUST be set.
-  - **Notes**: (for implementers) While this is unrelated to this OPTIMADE specification: If you decide to store internally the :property:`cartesian_site_positions` as a float array, you might want to represent :val:`null` values with :field-val:`NaN` values.
-    The latter being valid float numbers in the IEEE 754 standard in `IEEE 754-1985 <https://doi.org/10.1109/IEEESTD.1985.82928>`__ and in the updated version `IEEE 754-2008 <https://doi.org/10.1109/IEEESTD.2008.4610935>`__.
+  - It MUST be a list of length equal to the number of sites in the structure where every element is a list of the three Cartesian coordinates of a site expressed as float values, expressed in the unit angstrom (Å).
+  - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`_). 
 
 - **Examples**:
 
@@ -1869,7 +1864,7 @@ nsites
 species\_at\_sites
 ~~~~~~~~~~~~~~~~~~
 
-- **Description**: Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`_).
+- **Description**: Name of the species at each site specified by the property `cartesian_site_positions`_ (in the same order.)
   The properties of the species are found in the property `species`_.
 - **Type**: list of strings.
 - **Requirements/Conventions**:
@@ -1891,7 +1886,9 @@ species\_at\_sites
 species
 ~~~~~~~
 
-- **Description**: A list describing the species of the sites of this structure. Species can be pure chemical elements, or virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements.
+- **Description**: A list describing the species of the sites of this structure.
+  Species can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (more or less exclusively used to indicate hydrogen atoms attached to other elements.) 
+  
 - **Type**: list of dictionary with keys:
 
   - :property:`name`: string (REQUIRED)
@@ -1925,6 +1922,12 @@ species
 
       Note that concentrations are uncorrelated between different site (even of the same species).
 
+    - **attached**: OPTIONAL; if provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or "X" for a non-chemical element.
+    - **nattached**: OPTIONAL; if provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key.
+
+      The implementation MUST include either both or none of the :field:`attached` and :field:`nattached` keys, and if they are provided, they MUST be of the same length.
+      Furthermore, if they are provided, the `structure_features`_ property MUST include the string :val:`site_attachments`.
+      
     - **mass**: OPTIONAL. If present MUST be a float expressed in a.m.u.
     - **original\_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.
 
@@ -2070,11 +2073,12 @@ structure\_features
   - If a special feature listed below is not used, the list MUST NOT contain the corresponding string.
   - **List of strings used to indicate special structure features**:
 
-    - :val:`disorder`: This flag MUST be present if any one entry in the :property:`species` list has a :property:`chemical_symbols` list that is longer than 1 element.
-    - :val:`unknown_positions`: This flag MUST be present if at least one component of the :property:`cartesian_site_positions` list of lists has value :val:`null`.
-    - :val:`assemblies`: This flag MUST be present if the property `assemblies`_ is present.
+    - :val:`disorder`: this flag MUST be present if any one entry in the `species`_ list has a :field:`chemical_symbols` list that is longer than 1 element.
+    - :val:`implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites`_ (e.g., because their positions are unknown). When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`_, `species`_, and `assemblies`_ properties. 
+    - :val:`site_attachments`: this flag MUST be present if any one entry in the `species`_ list includes :field:`attached` and :field:`nattached`.
+    - :val:`assemblies`: this flag MUST be present if the property `assemblies`_ is present.
 
--  **Examples**: A structure having unknown positions and using assemblies: :val:`["assemblies", "unknown_positions"]`
+-  **Examples**: A structure having implcit atoms and using assemblies: :val:`["assemblies", "implicit_atoms"]`
 
 Calculations Entries
 --------------------

--- a/optimade.rst
+++ b/optimade.rst
@@ -1829,7 +1829,7 @@ cartesian\_site\_positions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **Description**: Cartesian positions of each site in the structure.
-   A site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the :property:`species_at_sites` property, and the species themselves are described in the :property:`species` property.
+  A site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the :property:`species_at_sites` property, and the species themselves are described in the :property:`species` property.
 - **Type**: list of list of floats
 - **Requirements/Conventions**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1828,7 +1828,8 @@ lattice\_vectors
 cartesian\_site\_positions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Description**: The cartesian positions of each site in the structure. A site is the position of a species (cf. the :property:`species` property.) as indicated by the :property:`species_at_sites` property.
+- **Description**: Cartesian positions of each site in the structure. 
+  A site is the location of a species (cf. the `species`_ property) as assigned by the `species_at_sites`_ property.
 - **Type**: list of list of floats
 - **Requirements/Conventions**:
 
@@ -1864,7 +1865,7 @@ nsites
 species\_at\_sites
 ~~~~~~~~~~~~~~~~~~
 
-- **Description**: Name of the species at each site specified by the property `cartesian_site_positions`_ (in the same order.)
+- **Description**: Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`_).
   The properties of the species are found in the property `species`_.
 - **Type**: list of strings.
 - **Requirements/Conventions**:
@@ -1887,7 +1888,7 @@ species
 ~~~~~~~
 
 - **Description**: A list describing the species of the sites of this structure.
-  Species can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (more or less exclusively used to indicate hydrogen atoms attached to other elements.) 
+  Species can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to other elements). 
   
 - **Type**: list of dictionary with keys:
 
@@ -2078,7 +2079,7 @@ structure\_features
     - :val:`site_attachments`: this flag MUST be present if any one entry in the `species`_ list includes :field:`attached` and :field:`nattached`.
     - :val:`assemblies`: this flag MUST be present if the property `assemblies`_ is present.
 
--  **Examples**: A structure having implcit atoms and using assemblies: :val:`["assemblies", "implicit_atoms"]`
+-  **Examples**: A structure having implicit atoms and using assemblies: :val:`["assemblies", "implicit_atoms"]`
 
 Calculations Entries
 --------------------

--- a/optimade.rst
+++ b/optimade.rst
@@ -1947,6 +1947,7 @@ species
   - :val:`[ {"name": "BaCa", "chemical_symbols": ["vacancy", "Ba", "Ca"], "concentration": [0.05, 0.45, 0.5], "mass": 88.5} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.
   - :val:`[ {"name": "C12", "chemical_symbols": ["C"], "concentration": [1.0], "mass": 12.0} ]`: any site with this species is occupied by a carbon isotope with mass 12.
   - :val:`[ {"name": "C13", "chemical_symbols": ["C"], "concentration": [1.0], "mass": 13.0} ]`: any site with this species is occupied by a carbon isotope with mass 13.
+  - :val:`[ {"name": "-CH3", "chemical_symbols": ["C"], "concentration": [1.0], "attached":"H", "nattached":3} ]` : any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.
 
 assemblies
 ~~~~~~~~~~

--- a/optimade.rst
+++ b/optimade.rst
@@ -1828,8 +1828,8 @@ lattice\_vectors
 cartesian\_site\_positions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Description**: Cartesian positions of each site in the structure. 
-  A site is the location of a species (cf. the `species`_ property) as assigned by the `species_at_sites`_ property.
+- **Description**: Cartesian positions of each site in the structure.
+   A site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the :property:`species_at_sites` property, and the species themselves are described in the :property:`species` property.
 - **Type**: list of list of floats
 - **Requirements/Conventions**:
 
@@ -1888,7 +1888,7 @@ species
 ~~~~~~~
 
 - **Description**: A list describing the species of the sites of this structure.
-  Species can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to other elements). 
+  Species can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to another element, e.g., a carbon with three attached hydrogens might represent a methyl group, -CH3).
   
 - **Type**: list of dictionary with keys:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1947,7 +1947,7 @@ species
   - :val:`[ {"name": "BaCa", "chemical_symbols": ["vacancy", "Ba", "Ca"], "concentration": [0.05, 0.45, 0.5], "mass": 88.5} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.
   - :val:`[ {"name": "C12", "chemical_symbols": ["C"], "concentration": [1.0], "mass": 12.0} ]`: any site with this species is occupied by a carbon isotope with mass 12.
   - :val:`[ {"name": "C13", "chemical_symbols": ["C"], "concentration": [1.0], "mass": 13.0} ]`: any site with this species is occupied by a carbon isotope with mass 13.
-  - :val:`[ {"name": "-CH3", "chemical_symbols": ["C"], "concentration": [1.0], "attached":"H", "nattached":3} ]` : any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.
+  - :val:`[ {"name": "CH3", "chemical_symbols": ["C"], "concentration": [1.0], "attached":"H", "nattached":3} ]` : any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.
 
 assemblies
 ~~~~~~~~~~

--- a/optimade.rst
+++ b/optimade.rst
@@ -1836,7 +1836,7 @@ cartesian\_site\_positions
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
   - **Query**: Support for queries on this property is OPTIONAL.
     If supported, filters MAY support only a subset of comparison operators.
-  - It MUST be a list of length equal to the number of sites in the structure where every element is a list of the three Cartesian coordinates of a site expressed as float values, expressed in the unit angstrom (Å).
+  - It MUST be a list of length equal to the number of sites in the structure, where every element is a list of the three Cartesian coordinates of a site expressed as float values in the unit angstrom (Å).
   - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`_). 
 
 - **Examples**:
@@ -1947,7 +1947,7 @@ species
   - :val:`[ {"name": "BaCa", "chemical_symbols": ["vacancy", "Ba", "Ca"], "concentration": [0.05, 0.45, 0.5], "mass": 88.5} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.
   - :val:`[ {"name": "C12", "chemical_symbols": ["C"], "concentration": [1.0], "mass": 12.0} ]`: any site with this species is occupied by a carbon isotope with mass 12.
   - :val:`[ {"name": "C13", "chemical_symbols": ["C"], "concentration": [1.0], "mass": 13.0} ]`: any site with this species is occupied by a carbon isotope with mass 13.
-  - :val:`[ {"name": "CH3", "chemical_symbols": ["C"], "concentration": [1.0], "attached":"H", "nattached":3} ]` : any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.
+  - :val:`[ {"name": "CH3", "chemical_symbols": ["C"], "concentration": [1.0], "attached": ["H"], "nattached": [3]} ]` : any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.
 
 assemblies
 ~~~~~~~~~~
@@ -2076,7 +2076,8 @@ structure\_features
   - **List of strings used to indicate special structure features**:
 
     - :val:`disorder`: this flag MUST be present if any one entry in the `species`_ list has a :field:`chemical_symbols` list that is longer than 1 element.
-    - :val:`implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites`_ (e.g., because their positions are unknown). When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`_, `species`_, and `assemblies`_ properties. 
+    - :val:`implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites`_ (e.g., because their positions are unknown).
+      When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`_, `species`_, and `assemblies`_ properties. 
     - :val:`site_attachments`: this flag MUST be present if any one entry in the `species`_ list includes :field:`attached` and :field:`nattached`.
     - :val:`assemblies`: this flag MUST be present if the property `assemblies`_ is present.
 


### PR DESCRIPTION
This PR follows discussions at the OPTIMADE 2020 workshop.

As per issues #260 and #258 (and also see #50, #93) there has been quite some discussion about how to handle unknown positions. It was previously decided that we would allow `null` in the `cartesian_site_positions` property in the `structure` entry for this. However, since then it has come up that: (i) it is not desirable for databases to on-the-fly have to insert these null entries, (ii) it can be difficult for databases to provide reasonably efficient queries on whether such `null`s will be present or not.

Hence, after some discussion, this PR implements:

- The old notion of `unknown_atoms` is completely removed. `nulls` are no longer allowed in the `cartesian_site_position` property.
- A species definition may now include attached atoms, e.g., one can define 'CH4' to be a Carbon with four attached Hydrogens. This feature is provided by keys `attached` and `nattached` in the `sites` list. There is a flag `site_attachments` in `structure_features` to indicate when this feature is used so queries easily can exclude/include these structures.
- An implementation may serve structures with `implicit atoms`. This means that not all atoms are actually included in the structure definition provided in `cartisian_site_positions` and `species_at_sites`. This usually means there is a mismatch between the properties indicating the chemical formula and what is found in this structural definition. There is a flag `implicit_atoms` in `structure_features` to indicate when this feature is used so queries can exclude/include these structures.

(Other people prominently being part of the discussions shaping this PR: @sauliusg, @giovannipizzi, and @merkys).

Closes #260 
Closes #258