### PR TITLE
Adjust query requirements on dimension_types

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -1874,8 +1874,7 @@ dimension\_types
 - **Requirements/Conventions**:
 
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
-  - **Query**: MUST be a queryable property.
-    Support for equality comparison is REQUIRED, support for other comparison operators are OPTIONAL.
+  - **Query**: Support for queries on this property is OPTIONAL.
   - MUST be a list of length 3.
   - Each integer element MUST assume only the value 0 or 1.
 


### PR DESCRIPTION
Fixes #276, I think. 

The only property I could find to reference queries on equality on a list is `dimension_types`. As per other discussions, this PR tunes it down so all queries on this field are OPTIONAL, since it is now mandatory to support queries instead on `nperiodic_dimensions` which should support all the relevant use cases for queries on this, but in a much simpler way.