### PR TITLE
Formatting fixes

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -272,7 +272,7 @@ The :field:`index_base_url` field MUST be included in every response in the :fie
 The :field:`is_index` field under :field:`attributes` as well as the :field:`relationships` field, MUST be included in the :endpoint:`info` endpoint for the index meta-database (see section `Base Info Endpoint`_).
 The value for :field:`is_index` MUST be :field-val:`true`.
 
-A few suggestions and mandatory requirements of the OPTIMaDe specification are specifically relaxed **only for index meta-databases** to make it possible to serve them in the form of static files on restricted third-party hosting platforms:
+A few suggestions and mandatory requirements of the OPTIMADE specification are specifically relaxed **only for index meta-databases** to make it possible to serve them in the form of static files on restricted third-party hosting platforms:
 
 - When serving an index meta-database in the form of static files, it is RECOMMENDED that the responses only contain the :field:`data` field (as described in the section `JSON Response Schema: Common Fields`_.)
   The motivation is that static files cannot keep dynamic fields such as :field:`time_stamp` updated.
@@ -293,7 +293,7 @@ Database-Provider-Specific Namespace Prefixes
 
 This standard refers to database-provider-specific prefixes and database providers.
 
-A list of known providers and their assigned prefixes is published in the form of a statically hosted OPTiMaDe Index Meta-Database with base URL `https://providers.optimade.org <https://providers.optimade.org>`__.
+A list of known providers and their assigned prefixes is published in the form of a statically hosted OPTIMADE Index Meta-Database with base URL `https://providers.optimade.org <https://providers.optimade.org>`__.
 Visiting this URL in a web browser gives a human-readable description of how to retrieve the information in the form of a JSON file, and specifies the procedure for registration of new prefixes.
 
 API implementations SHOULD NOT make up and use new prefixes without first getting them registered in the official list.

--- a/optimade.rst
+++ b/optimade.rst
@@ -915,12 +915,12 @@ If this is an index meta-database base URL (see section `Index Meta-Database`_),
 
 - **relationships**: Dictionary that MAY contain a single `JSON API relationships object <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__:
 
-  - **default**: Reference to the child identifier object under the :endpoint:`links` endpoint that the provider has chosen as their "default" OPTIMADE API database.
+  - **default**: Reference to the links identifier object under the :endpoint:`links` endpoint that the provider has chosen as their "default" OPTIMADE API database.
     A client SHOULD present this database as the first choice when an end-user chooses this provider.
     This MUST include the field:
 
     - **data**: `JSON API resource linkage <http://jsonapi.org/format/1.0/#document-links>`__.
-      It MUST be either :field-val:`null` or contain a single child identifier object with the fields:
+      It MUST be either :field-val:`null` or contain a single links identifier object with the fields:
 
       - **type**: :field-val:`links`
       - **id**: ID of the provider's chosen default OPTIMADE API database.

--- a/optimade.rst
+++ b/optimade.rst
@@ -497,7 +497,7 @@ Every response SHOULD contain the following fields, and MUST contain at least on
 
 The response MAY also return resources related to the primary data in the field:
 
-- **links**: `JSON API links <http://jsonapi.org/format/1.0/#document-links>`__ is MANDATORY for implementing pagination.
+- **links**: `JSON API links <http://jsonapi.org/format/1.0/#document-links>`__ is REQUIRED for implementing pagination.
   (see section `Entry Listing URL Query Parameters`_.)
   Each field of a links object, i.e., a "link", MUST be one of:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1135,11 +1135,11 @@ The resource objects' response dictionaries MUST include the following fields:
     If specified, and the value is anything different than :val:`ok`, the client MUST assume that the server is suggesting not to follow the link during aggregation by default (also if the value is not among the known ones, in case a future specification adds new accepted values).
 
     Specific values indicate the reason why the server is providing the suggestion.
-    A client MAY follow the link anyway if it has reason to do so (e.g., if the client is looking for all test databases, it MAY follow the links marked with :property:`aggregate`=:val:`test`).
+    A client MAY follow the link anyway if it has reason to do so (e.g., if the client is looking for all test databases, it MAY follow the links where :property:`aggregate` has value :val:`test`).
 
     If specified, it MUST be one of the values listed in section `Link Aggregate Options`_.
 
-  - **no_aggregate_reason**: an OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link. It SHOULD NOT be present if :property:`aggregate`=:val:`ok`.
+  - **no_aggregate_reason**: an OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link. It SHOULD NOT be present if :property:`aggregate` has value :val:`ok`.
 
 Example:
 
@@ -1240,11 +1240,11 @@ Example:
 Internal Links: Root and Child Links
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Any number of resource objects with :property:`link_type`=:val:`child` MAY be present as part of the :field:`data` list.
+Any number of resource objects with :property:`link_type` equal to :val:`child` MAY be present as part of the :field:`data` list.
 A :val:`child` object represents a "link" to an OPTIMADE implementation within the same provider exactly one layer **below** the current implementation's layer.
 
-Exactly one resource object with :property:`link_type`=:val:`root` MUST be present as part of the :field:`data` list.
-Note: the same implementation may of course be linked by other implementations via a ' :endpoint:`/links` endpoint with :property:`link_type`=:val:`external`.
+Exactly one resource object with :property:`link_type` equal to :val:`root` MUST be present as part of the :field:`data` list.
+Note: the same implementation may of course be linked by other implementations via a :endpoint:`/links` endpoint with :property:`link_type` equal to :val:`external`.
 
 The :val:`root` resource object represents a link to the topmost OPTIMADE implementation of the current provider.
 By following :val:`child` links from the :val:`root` object recursively, it MUST be possible to reach the current OPTIMADE implementation.
@@ -1255,7 +1255,7 @@ In practice, this forms a tree structure for the OPTIMADE implementations of a p
 List of Providers Links
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Resource objects with :property:`link_type`=:val:`providers` links MUST point to an `Index Meta-Database`_ that supplies a list of OPTIMADE database providers.
+Resource objects with :property:`link_type` equal to :val:`providers` MUST point to an `Index Meta-Database`_ that supplies a list of OPTIMADE database providers.
 The intention is to be able to auto-discover all providers of OPTIMADE implementations.
 
 A list of known providers can be retrieved as described in section `Database-Provider-Specific Namespace Prefixes`_.

--- a/optimade.rst
+++ b/optimade.rst
@@ -1036,9 +1036,7 @@ The response for these endpoints MUST include the following information in the :
   - :field:`type`: String.
     The type of the property's value.
     This MUST be any of the types defined in `Data types`_.
-
-    For the purpose of compatibility with future versions of this specification, a client MUST accept values that are not :type:`string`s specifying any of the OPTIMADE `Data types`_, but MUST then also disregard the :field:`type` field.
-
+    For the purpose of compatibility with future versions of this specification, a client MUST accept values that are not :type:`string` values specifying any of the OPTIMADE `Data types`_, but MUST then also disregard the :field:`type` field.
     Note, if the value is a nested type, only the outermost type should be reported.
     E.g., for the entry resource :entry:`structures`, the :property:`species` property is defined as a list of dictionaries, hence its :field:`type` value would be :val:`list`.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -653,7 +653,7 @@ The section `Entry list`_ specifies properties as belonging to one of three cate
 
 2. Properties marked as REQUIRED only if the query parameter :query-param:`response_fields` is not part of the request, or if they are explicitly requested in :query-param:`response_fields`.
    Otherwise they MUST NOT be included.
-   One can think of these properties as consituting a default value for :query-param:`response_fields` when that parameter is omitted.
+   One can think of these properties as constituting a default value for :query-param:`response_fields` when that parameter is omitted.
 
 3. Properties not marked as REQUIRED in any case, MUST be included only if explicitly requested in the query parameter :query-param:`response_fields`.
    Otherwise they SHOULD NOT be included.

--- a/optimade.rst
+++ b/optimade.rst
@@ -770,7 +770,7 @@ In the default JSON response format every dictionary (`resource object <http://j
 
 - **type**: field containing the Entry type as defined in section `Definition of Terms`_
 - **id**: field containing the ID of entry as defined in section `Definition of Terms`_. This can be the local database ID.
-- **attributes**: a dictionary, containing key-value pairs representing the entry's properties, except for type and id.
+- **attributes**: a dictionary, containing key-value pairs representing the entry's properties, except for `type` and `id`.
 
   Database-provider-specific properties need to include the database-provider-specific prefix (see section `Database-Provider-Specific Namespace Prefixes`_).
 
@@ -1020,12 +1020,12 @@ The response for these endpoints MUST include the following information in the :
 - **description**: Description of the entry.
 - **properties**: A dictionary describing queryable properties for this entry type, where each key is a property name.
   Each value is a dictionary, with the
-  
+
   *REQUIRED keys*:
 
   - :field:`description`: String.
     A human-readable description of the property.
-  
+
   *OPTIONAL keys*:
 
   - :field:`unit`: String.
@@ -1100,7 +1100,7 @@ The :property:`link_type` MUST be one of the following values:
   If the provider only supplies a single implementation, the :val:`root` link links to the implementation itself.
 - :field-val:`external`: a link to an external OPTIMADE implementation.
   This MAY be used to point to any other implementation, also in a different provider.
-- :field-val:`providers`: a link to a `List of Providers Links`_ implementation that includes the current implementation, e.g. `providers.optimade.org <https://providers.optimade.org/>`__. 
+- :field-val:`providers`: a link to a `List of Providers Links`_ implementation that includes the current implementation, e.g. `providers.optimade.org <https://providers.optimade.org/>`__.
 
 Limiting to the :val:`root` and :val:`child` link types, links can be used as an introspective endpoint, similar to the `Info Endpoints`_, but at a higher level, i.e., `Info Endpoints`_ provide information on the given implementation, while the :endpoint:`/links` endpoint provides information on the links between immediately related implementations (in particular, an array of none or a single object with link type :val:`root` and none or more objects with link type :val:`child`, see section `Internal Links: Root and Child Links`_).
 
@@ -1138,7 +1138,7 @@ The resource objects' response dictionaries MUST include the following fields:
 
     Specific values indicate the reason why the server is providing the suggestion.
     A client MAY follow the link anyway if it has reason to do so (e.g., if the client is looking for all test databases, it MAY follow the links marked with :property:`aggregate`=:val:`test`).
-  
+
     If specified, it MUST be one of the values listed in section `Link Aggregate Options`_.
 
   - **no_aggregate_reason**: an OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link. It SHOULD NOT be present if :property:`aggregate`=:val:`ok`.
@@ -1251,7 +1251,7 @@ Note: the same implementation may of course be linked by other implementations v
 The :val:`root` resource object represents a link to the topmost OPTIMADE implementation of the current provider.
 By following :val:`child` links from the :val:`root` object recursively, it MUST be possible to reach the current OPTIMADE implementation.
 
-In practice, this forms a tree structure for the OPTIMADE implementations of a provider. 
+In practice, this forms a tree structure for the OPTIMADE implementations of a provider.
 **Note**: The RECOMMENDED number of layers is two.
 
 List of Providers Links
@@ -1854,7 +1854,8 @@ chemical\_formula\_anonymous
 - **Requirements/Conventions**:
 
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
-  - **Query**: MUST be a queryable property. However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).
+  - **Query**: MUST be a queryable property.
+    However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).
 
 - **Examples**:
 
@@ -1888,13 +1889,13 @@ dimension\_types
 nperiodic\_dimensions
 ~~~~~~~~~~~~~~~~~~~~~
 
-- **Description**: An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in :property:`dimension\_types`.
+- **Description**: An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in `dimension\_types`_.
 - **Type**: integer
 - **Requirements/Conventions**:
 
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
   - **Query**: MUST be a queryable property with support for all mandatory filter features.
-  - The integer value MUST be between 0 and 3 inclusive and MUST be equal to the sum of the items in the `dimension_types`_ property.
+  - The integer value MUST be between 0 and 3 inclusive and MUST be equal to the sum of the items in the `dimension\_types`_ property.
   - This property only reflects the treatment of the lattice vectors provided for the structure, and not any physical interpretation of the dimensionality of its contents.
 
 - **Examples**:
@@ -1903,8 +1904,8 @@ nperiodic\_dimensions
 
 - **Query examples**:
 
-  - Match only structures with exactly 3 periodic dimensions: :filter:`nperiodic\_dimensions=3`
-  - Match all structures with 2 or fewer periodic dimensions: :filter:`nperiodic\_dimensions<=2`
+  - Match only structures with exactly 3 periodic dimensions: :filter:`nperiodic_dimensions=3`
+  - Match all structures with 2 or fewer periodic dimensions: :filter:`nperiodic_dimensions<=2`
 
 lattice\_vectors
 ~~~~~~~~~~~~~~~~
@@ -1941,7 +1942,7 @@ cartesian\_site\_positions
   - **Query**: Support for queries on this property is OPTIONAL.
     If supported, filters MAY support only a subset of comparison operators.
   - It MUST be a list of length equal to the number of sites in the structure, where every element is a list of the three Cartesian coordinates of a site expressed as float values in the unit angstrom (Å).
-  - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`_). 
+  - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`_).
 
 - **Examples**:
 
@@ -1993,7 +1994,7 @@ species
 
 - **Description**: A list describing the species of the sites of this structure.
   Species can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to another element, e.g., a carbon with three attached hydrogens might represent a methyl group, -CH3).
-  
+
 - **Type**: list of dictionary with keys:
 
   - :property:`name`: string (REQUIRED)
@@ -2025,14 +2026,14 @@ species
       - Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations :val:`1/3` and :val:`2/3`, the concentration might look something like :val:`[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.
       - Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.
 
-      Note that concentrations are uncorrelated between different site (even of the same species).
+      Note that concentrations are uncorrelated between different sites (even of the same species).
 
     - **attached**: OPTIONAL; if provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or "X" for a non-chemical element.
     - **nattached**: OPTIONAL; if provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key.
 
       The implementation MUST include either both or none of the :field:`attached` and :field:`nattached` keys, and if they are provided, they MUST be of the same length.
       Furthermore, if they are provided, the `structure_features`_ property MUST include the string :val:`site_attachments`.
-      
+
     - **mass**: OPTIONAL. If present MUST be a float expressed in a.m.u.
     - **original\_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.
 
@@ -2051,7 +2052,7 @@ species
   - :val:`[ {"name": "BaCa", "chemical_symbols": ["vacancy", "Ba", "Ca"], "concentration": [0.05, 0.45, 0.5], "mass": 88.5} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.
   - :val:`[ {"name": "C12", "chemical_symbols": ["C"], "concentration": [1.0], "mass": 12.0} ]`: any site with this species is occupied by a carbon isotope with mass 12.
   - :val:`[ {"name": "C13", "chemical_symbols": ["C"], "concentration": [1.0], "mass": 13.0} ]`: any site with this species is occupied by a carbon isotope with mass 13.
-  - :val:`[ {"name": "CH3", "chemical_symbols": ["C"], "concentration": [1.0], "attached": ["H"], "nattached": [3]} ]` : any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.
+  - :val:`[ {"name": "CH3", "chemical_symbols": ["C"], "concentration": [1.0], "attached": ["H"], "nattached": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.
 
 assemblies
 ~~~~~~~~~~
@@ -2172,7 +2173,9 @@ structure\_features
 - **Requirements/Conventions**:
 
   - **Support**: MUST be supported by all implementations, MUST NOT be :val:`null`.
-  - **Query**: MUST be a queryable property. Filters on the list MUST support all mandatory HAS-type queries. Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.
+  - **Query**: MUST be a queryable property.
+    Filters on the list MUST support all mandatory HAS-type queries.
+    Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.
   - MUST be an empty list if no special features are used.
   - MUST be sorted alphabetically.
   - If a special feature listed below is used, the list MUST contain the corresponding string.
@@ -2181,7 +2184,7 @@ structure\_features
 
     - :val:`disorder`: this flag MUST be present if any one entry in the `species`_ list has a :field:`chemical_symbols` list that is longer than 1 element.
     - :val:`implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites`_ (e.g., because their positions are unknown).
-      When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`_, `species`_, and `assemblies`_ properties. 
+      When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`_, `species`_, and `assemblies`_ properties.
     - :val:`site_attachments`: this flag MUST be present if any one entry in the `species`_ list includes :field:`attached` and :field:`nattached`.
     - :val:`assemblies`: this flag MUST be present if the property `assemblies`_ is present.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -690,8 +690,7 @@ Standard OPTIONAL URL query parameters standardized by the JSON API specificatio
   It MAY return fewer.
   The database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).
   The default limit value is up to the API implementation to decide.
-
-Example: http://example.com/optimade/v1/structures?page_limit=100
+  Example: http://example.com/optimade/v1/structures?page_limit=100
 
 - **page\_{offset, number, cursor, above, below}**: A server MUST implement pagination in the case of no user-specified :query-param:`sort` parameter (via the :field:`links` response field, see section `JSON Response Schema: Common Fields`_).
   A server MAY implement pagination in concert with :query-param:`sort`.

--- a/optimade.rst
+++ b/optimade.rst
@@ -690,7 +690,7 @@ Standard OPTIONAL URL query parameters standardized by the JSON API specificatio
   It MAY return fewer.
   The database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).
   The default limit value is up to the API implementation to decide.
-  Example: http://example.com/optimade/v1/structures?page_limit=100
+  Example: :query-url:`http://example.com/optimade/v1/structures?page_limit=100`
 
 - **page\_{offset, number, cursor, above, below}**: A server MUST implement pagination in the case of no user-specified :query-param:`sort` parameter (via the :field:`links` response field, see section `JSON Response Schema: Common Fields`_).
   A server MAY implement pagination in concert with :query-param:`sort`.
@@ -736,14 +736,14 @@ Standard OPTIONAL URL query parameters not in the JSON API specification:
 
 - **response\_format**: the output format requested (see section `Response Format`_).
   Defaults to the format string 'json', which specifies the standard output format described in this specification.
-  Example: http://example.com/optimade/v1/structures?response_format=xml
+  Example: :query-url:`http://example.com/optimade/v1/structures?response_format=xml`
 - **email\_address**: an email address of the user making the request.
   The email SHOULD be that of a person and not an automatic system.
-  Example: http://example.com/optimade/v1/structures?email_address=user@example.com
+  Example: :query-url:`http://example.com/optimade/v1/structures?email_address=user@example.com`
 - **response\_fields**: a comma-delimited set of fields to be provided in the output.
   If provided, these fields MUST be returned along with the REQUIRED fields.
   Other OPTIONAL fields MUST NOT be returned when this parameter is present.
-  Example: http://example.com/optimade/v1/structures?response_fields=last_modified,nsites
+  Example: :query-url:`http://example.com/optimade/v1/structures?response_fields=last_modified,nsites`
 
 Additional OPTIONAL URL query parameters not described above are not considered to be part of this standard, and are instead considered to be "custom URL query parameters".
 These custom URL query parameters MUST be of the format "<database-provider-specific prefix><url\_query\_parameter\_name>".

--- a/optimade.rst
+++ b/optimade.rst
@@ -1633,7 +1633,9 @@ type
   - MUST be an existing entry type.
   - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for :endpoint:`/<type>/<id>` under the versioned base URL.
 
-- **Example**: :val:`"structures"`
+- **Examples**:
+
+  - :val:`"structures"`
 
 immutable\_id
 ~~~~~~~~~~~~~
@@ -1661,7 +1663,7 @@ last\_modified
   - **Query**: MUST be a queryable property with support for all mandatory filter features.
   - **Response**: REQUIRED in the response unless the query parameter :query-param:`response_fields` is present and does not include this property.
 
-- **Example**:
+- **Examples**:
 
   - As part of JSON response format: :VAL:`"2007-04-05T14:30:20Z"` (i.e., encoded as an `RFC 3339 Internet Date/Time Format <https://tools.ietf.org/html/rfc3339#section-5.6>`__ string.)
 
@@ -1727,7 +1729,10 @@ nelements
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
   - **Query**: MUST be a queryable property with support for all mandatory filter features.
 
-- **Example**: :val:`3`
+- **Examples**:
+
+  - :val:`3`
+
 - **Querying**:
 
   -  Note: queries on this property can equivalently be formulated using :filter-fragment:`elements LENGTH`.
@@ -1838,6 +1843,7 @@ chemical\_formula\_hill
   - No spaces or separators are allowed.
 
 - **Examples**:
+
   - :val:`"H2O2"`
 
 - **Query examples**:


### PR DESCRIPTION
Some minor, and one not so minor, changes to formatting in the specification.

I'm leaving this as a draft for now until I've finished going through all the models for the python-tools, which is why I spotted these.

Most of these arise in the rendering of the rst only: often things like ```":property:`aggregate`=:val:`value`"``` were attempted, which do not render nicely at all. These sections were reworded slightly to avoid this construct.