### PR TITLE
Serving the API on the unversioned base URL

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -285,7 +285,7 @@ Implementations serving the API on the unversioned base URL have a few alternati
 Implementations MAY combine direct access to Single Entry Endpoints with redirects for other API queries.
 
 The client MAY provide a query parameter :query-param:`api_hint` to hint the server about a preferred API version.
-When this parameter is provided, the request is to be handled as described in section `Version Negotiation`_, which allows a "best sutiable" version of the API to be selected to serve the request (or forward the request to).
+When this parameter is provided, the request is to be handled as described in section `Version Negotiation`_, which allows a "best suitable" version of the API to be selected to serve the request (or forward the request to).
 However, if :query-param:`api_hint` is not provided, the implementation SHOULD serve (or redirect to) its preferred version of the API (i.e., the lastest, most mature, and stable version).
 In this case, that version MUST also be the first version in the response of the :endpoint:`versions` endpoint (see section `Versions Endpoint`_).
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -236,7 +236,7 @@ Versioned base URLs
 ~~~~~~~~~~~~~~~~~~~
 
 Access to the API is primarily provided under **versioned base URLs**.
-An implementation MUST provide the form where a URL path segment :query-url:`/vMAJOR` is appended to the base URL, where :val:`MAJOR` is one of the major version numbers of the API that the implementation supports.
+An implementation MUST provide access to the API under a URL where the first path segment appended to the base URL is :query-url:`/vMAJOR`, where :val:`MAJOR` is one of the major version numbers of the API that the implementation supports.
 This URL MUST serve the *latest* minor/patch version supported by the implementation.
 For example, the latest minor and patch version of major version 1 of the API is served under :query-url:`/v1`.
 
@@ -304,7 +304,7 @@ The OPTIMADE API provides three concurrent mechanisms for version negotiation be
    This parameter is described in more detail below.
 
 The :query-param:`api_hint` query parameter MUST be accepted by all API endpoints.
-However, for endpoints under a versioned base URL this parameter SHOULD be ignored, and the request served as usual according to the version specified in the URL path segment.
+However, for endpoints under a versioned base URL this parameter MUST be ignored, and the request served as usual according to the version specified in the URL path segment.
 If the client provides the parameter, the value SHOULD have the format :val:`vMAJOR` or :val:`vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API.
 For example, if a client appends :query-string:`api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -305,7 +305,7 @@ The OPTIMADE API provides three concurrent mechanisms for version negotiation be
 
 The :query-param:`api_hint` query parameter MUST be accepted by all API endpoints.
 However, for endpoints under a versioned base URL this parameter SHOULD be ignored, and the request served as usual according to the version specified in the URL path segment.
-If the client provides the parameter, the value SHOULD be on the format :val:`vMAJOR` where MAJOR is a major version of the API.
+If the client provides the parameter, the value SHOULD have the format :val:`vMAJOR` where MAJOR is a major version of the API.
 For example, if a client appends :query-string:`api_hint=v1` to the query string, the hint provided is for major version 1.
 
 If the server supports the version indicated by the :query-param:`api_hint` parameter, it SHOULD serve the request using this version.

--- a/optimade.rst
+++ b/optimade.rst
@@ -278,9 +278,9 @@ Clients that perform automated processing of responses SHOULD access the API via
 
 Implementations serving the API on the unversioned base URL have a few alternative options:
 
-1. Direct access may be provided to the full API.
-2. Requests to endpoints under the unversioned base URL may be redirected using an HTTP 307 temporary redirect to the corresponding endpoints under a versioned base URL.
-3. Direct access may be limited to only single entry endpoints (see section `Single Entry Endpoints`_), i.e., so that this form of access is only available for permanent links to resource objects.
+1. Direct access MAY be provided to the full API.
+2. Requests to endpoints under the unversioned base URL MAY be redirected using an HTTP 307 temporary redirect to the corresponding endpoints under a versioned base URL.
+3. Direct access MAY be limited to only single entry endpoints (see section `Single Entry Endpoints`_), i.e., so that this form of access is only available for permanent links to resource objects.
 
 Implementations MAY combine direct access to Single Entry Endpoints with redirects for other API queries.
 
@@ -289,7 +289,7 @@ If this parameter is provided, the server MAY serve the request using (or redire
 However, if :query-param:`api_hint` is not provided, the implementation SHOULD serve (or redirect to) its preferred version of the API (i.e., the lastest, most mature, and stable version).
 In this case, that version MUST also be the first version in the response of the :endpoint:`versions` endpoint (see section `Versions Endpoint`_).
 
-    **For implementers**: Before enabling access to the API on unversioned base URLs, implementers are advised to consider that an upgrade of the major version of the API served this way may change the behaviors of associated endpoints in ways that are not backward compatible.
+    **For implementers**: Before enabling access to the API on unversioned base URLs, implementers are advised to consider that an upgrade of the major version of the API served this way can change the behaviors of associated endpoints in ways that are not backward compatible.
 
 Version Negotiation
 -------------------

--- a/optimade.rst
+++ b/optimade.rst
@@ -285,7 +285,7 @@ Implementations serving the API on the unversioned base URL have a few alternati
 Implementations MAY combine direct access to Single Entry Endpoints with redirects for other API queries.
 
 The client MAY provide a query parameter :query-param:`api_hint` to hint the server about a preferred API version.
-If this parameter is provided, the server MAY serve the request using (or redirect the request to) any version of the API that it finds appropriate, see section `Version Negotiation`_ for more details.
+When this parameter is provided, the request is to be handled as described in section `Version Negotiation`_, which allows a "best sutiable" version of the API to be selected to serve the request (or forward the request to).
 However, if :query-param:`api_hint` is not provided, the implementation SHOULD serve (or redirect to) its preferred version of the API (i.e., the lastest, most mature, and stable version).
 In this case, that version MUST also be the first version in the response of the :endpoint:`versions` endpoint (see section `Versions Endpoint`_).
 
@@ -305,7 +305,7 @@ The OPTIMADE API provides three concurrent mechanisms for version negotiation be
 
 The :query-param:`api_hint` query parameter MUST be accepted by all API endpoints.
 However, for endpoints under a versioned base URL this parameter SHOULD be ignored, and the request served as usual according to the version specified in the URL path segment.
-The client SHOULD set the value on the format :val:`vMAJOR` where MAJOR is a major version of the API.
+When a client provides the parameter, the value SHOULD be on the format :val:`vMAJOR` where MAJOR is a major version of the API.
 For example, if a client appends to the query string :query-string:`api_hint=v1` the hint provided is for major version 1.
 
 The intent of the :query-param:`api_hint` parameter is that if a client hints a version that is not supported by the server, the server can use the value to make a best-effort attempt at still serving the request, e.g., by invoking the closest supported version of the API.

--- a/optimade.rst
+++ b/optimade.rst
@@ -713,7 +713,7 @@ Versions Endpoint
 The :endpoint:`versions` endpoint aims at providing a stable and future-proof way for a client to discover the major versions of the API that the implementation provides. 
 This endpoint is special in that it MUST be provided directly on the unversioned base URL at :query-url:`/versions` and MUST NOT be provided under the versioned base URLs.
 
-The response to a query to this endpoint is in the :RFC:`4180` CSV (`text/csv; header=present`) format (and does therefore not comply with the JSON:API data format of the `JSON API v1.0 <http://jsonapi.org/format/1.0>`__ specification).
+The response to a query to this endpoint is in the :RFC:`4180` CSV (`text/csv; header=present`) format.
 In the present version of the API, the response contains only a single field that is used to list the major versions of the API that the implementation supports.
 However, clients MUST accept responses that include other fields that follow the version.
 The CSV format header line MUST be provided, and the header for the first field MUST be :val:`version`.

--- a/optimade.rst
+++ b/optimade.rst
@@ -684,10 +684,10 @@ Versions Endpoint
 The :endpoint:`versions` endpoint aims at providing a stable and future-proof way for a client to discover the major versions of the API that the implementation provides. 
 This endpoint is special in that it MUST be provided directly on the unversioned base URL at :query-url:`/versions` and MUST NOT be provided under the versioned base URLs.
 
-The response to a query to this endpoint is in the :RFC:`4180` CSV format (and does therefore not comply with JSON:API data format of the `JSON API v1.0 <http://jsonapi.org/format/1.0>`__ specification).
-In the present version of the API the response contains only a single field, which is used to list the major versions of the API that the implementation supports.
+The response to a query to this endpoint is in the :RFC:`4180` `text/csv; header=present` format (and does therefore not comply with JSON:API data format of the `JSON API v1.0 <http://jsonapi.org/format/1.0>`__ specification).
+In the present version of the API, the response contains only a single field that is used to list the major versions of the API that the implementation supports.
 However, clients MUST accept responses that include other fields that follow the version.
-If the CSV response includes a header line, the name of the first field MUST be "#version", and the client can therefore safely disregard the first line if it starts with the '#' character.
+The csv format header line MUST be provided, and the header for the first field MUST be `#version`.
 
 The major API versions in the response are to be ordered according to the preference of the API implementation.
 If a version of the API is served on the unversioned base URL as described in the section `Base URL`_, that version MUST be the top line of the response (after the optional CSV header).

--- a/optimade.rst
+++ b/optimade.rst
@@ -282,7 +282,7 @@ Implementations serving the API on the unversioned base URL have a few alternati
 2. Requests to endpoints under the unversioned base URL MAY be redirected using an HTTP 307 temporary redirect to the corresponding endpoints under a versioned base URL.
 3. Direct access MAY be limited to only single entry endpoints (see section `Single Entry Endpoints`_), i.e., so that this form of access is only available for permanent links to resource objects.
 
-Implementations MAY combine direct access to Single Entry Endpoints with redirects for other API queries.
+Implementations MAY combine direct access to single entry endpoints with redirects for other API queries.
 
 The client MAY provide a query parameter :query-param:`api_hint` to hint the server about a preferred API version.
 When this parameter is provided, the request is to be handled as described in section `Version Negotiation`_, which allows a "best suitable" version of the API to be selected to serve the request (or forward the request to).
@@ -304,8 +304,8 @@ The OPTIMADE API provides three concurrent mechanisms for version negotiation be
    This parameter is described in more detail below.
 
 The :query-param:`api_hint` query parameter MUST be accepted by all API endpoints.
-However, for endpoints under a versioned base URL the request MUST be served as usual according to the version specified in the URL path segment regardless of the value of `api_hint`.
-In this case, the server MAY issue a warning if the value of `api_hint` suggests that the query may not be properly supported.
+However, for endpoints under a versioned base URL the request MUST be served as usual according to the version specified in the URL path segment regardless of the value of :query-param:`api_hint`.
+In this case, the server MAY issue a warning if the value of :query-param:`api_hint` suggests that the query may not be properly supported.
 If the client provides the parameter, the value SHOULD have the format :val:`vMAJOR` or :val:`vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API.
 For example, if a client appends :query-string:`api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -249,11 +249,11 @@ A URL on the form  :query-url:`/vMAJOR.MINOR` MUST serve the *latest* patch vers
 
 API versions that are published with a suffix, e.g., `-rc<number>` to indicate a release candidate version, SHOULD be served on versioned base URLs without this suffix.
 
-If a request is made to a versioned base URL that begins with `/v` and an integer followed by any other characters, indicating a version that the implementation does not recognize or support, it SHOULD respond with the custom HTTP server error status code :http-error:`553 API Version Not Supported`, perferably along with a user-friendly error message that directs the client to adapt the request to a version it provides.
+If a request is made to a versioned base URL that begins with `/v` and an integer followed by any other characters, indicating a version that the implementation does not recognize or support, the implementation SHOULD respond with the custom HTTP server error status code :http-error:`553 API Version Not Supported`, perferably along with a user-friendly error message that directs the client to adapt the request to a version it provides.
 
 It is the intent that future versions of this standard will not assign different meanings to URLs that begin with :query-url:`/v` and an integer followed by other characters.
 Hence, a client can safely attempt to access a specific version of the API via the corresponding versioned base URL. 
-Other forms of version negotiation is provided by the :endpoint:`versions` endpoint (see section `Versions Endpoint`_).
+Other forms of version negotiation are provided by the :endpoint:`versions` endpoint (see section `Versions Endpoint`_).
 
 Examples of valid versioned base URLs:
 
@@ -276,23 +276,23 @@ Unversioned base URLs
 
 Implementations MAY also provide access to the API on the **unversioned base URL** as described in this subsection.
 
-Access via the unversioned URL is primarily intended for (i) convinience when manually interacting with the API, and (ii) to provide version agnostic permanent links to resource objects.
+Access via the unversioned URL is primarily intended for (i) convenience when manually interacting with the API, and (ii) to provide version agnostic permanent links to resource objects.
 Clients that perform automated processing of responses SHOULD access the API via versioned base URLs.
 
 Implementations MAY provide direct access to the full API under the unversioned base URL. 
 In this case, the implementation SHOULD serve its preferred version of the API (i.e., the lastest, most mature, and stable version.) 
 
-Implementations MAY instead issue a HTTP 307 temporary redirect for queries issued to endpoints under the unversioned base URL.  
-In that case, the redirect SHOULD be to the corresponding versioned URL for the implementations preferred version of the API.
+Implementations MAY instead issue an HTTP 307 temporary redirect for queries issued to endpoints under the unversioned base URL.  
+In that case, the redirect SHOULD be to the corresponding versioned URL for the preferred version of the API supported by the implementation.
 
 As a third alternative, implementations MAY choose to provide direct access only to Single Entry Endpoints (see section `Single Entry Endpoints`_) under the unversioned base URL, i.e., so that this form of access is only available for permanent links to resource objects.
-In that case, the response format SHOULD be that of the implementations preferred version of the API.
+In that case, the response format SHOULD be that of the preferred version of the API supported by the implementation.
 Implementations MAY combine direct access to Single Entry Endpoints with redirects for other API queries.
 
 When an implementation serves (or redirects to) a preferred major version of the API on the unversioned base URL, that version MUST also be the version at the first line in the response of the :endpoint:`versions` endpoint (see `Versions Endpoint`_).
 
-    **For implementers**: Before enabling access to the API on unversioned base URLs, implementations are advised to consider that this feature may encourage careless automated access from clients that, without verification, assumes a specific version of the API to be served on the unversioned base URL.
-    The implementation needs to be prepared to break such clients on major version upgrades, or will otherwise get stuck at serving the *oldest* API version on the unversioned URL.
+    **For implementers**: Before enabling access to the API on unversioned base URLs, implementers are advised to consider that this feature may encourage careless automated access from clients that, without verification, assumes a specific version of the API to be served on the unversioned base URL.
+    The implementer needs to be prepared to break such clients on major version upgrades, or will otherwise get stuck at serving the *oldest* API version on the unversioned URL.
 
 Index Meta-Database
 -------------------
@@ -666,7 +666,7 @@ For implementation-specific warnings, they MUST start with ``_`` and the databas
 API Endpoints
 =============
 
-Access to API endpoints as desribed in the subsections below are to be provided under the versioned and/or the unversioned base URL as desribed in the section `Base URL`_.
+Access to API endpoints as described in the subsections below are to be provided under the versioned and/or the unversioned base URL as explained in the section `Base URL`_.
 
 The endpoints are:
 
@@ -686,7 +686,7 @@ Versions Endpoint
 The :endpoint:`versions` endpoint aims at providing a stable and future-proof way for a client to discover the major versions of the API that the implementation provides. 
 This endpoint is special in that it MUST be provided directly on the unversioned base URL at :query-url:`/versions` and MUST NOT be provided under the versioned base URLs.
 
-The response to a query to this endpoint is in the :RFC:`4180` `text/csv; header=present` format (and does therefore not comply with JSON:API data format of the `JSON API v1.0 <http://jsonapi.org/format/1.0>`__ specification).
+The response to a query to this endpoint is in the :RFC:`4180` `text/csv; header=present` format (and does therefore not comply with the JSON:API data format of the `JSON API v1.0 <http://jsonapi.org/format/1.0>`__ specification).
 In the present version of the API, the response contains only a single field that is used to list the major versions of the API that the implementation supports.
 However, clients MUST accept responses that include other fields that follow the version.
 The csv format header line MUST be provided, and the header for the first field MUST be `#version`.
@@ -704,8 +704,8 @@ Example response:
   1
   0
 
-The above response means that the API versions 1 and 0 are served under the versioned base URLs `/v1` and `/v0` respectively.
-The order of the versions indicate that the API implementation regards version 1 as preferred over version 0.
+The above response means that the API versions 1 and 0 are served under the versioned base URLs `/v1` and `/v0`, respectively.
+The order of the versions indicates that the API implementation regards version 1 as preferred over version 0.
 If the API implementation allows access to the API on the unversioned base URL, this access has to be to version 1, since the number 1 appears in the first (non-header) line.
 
 Entry Listing Endpoints

--- a/optimade.rst
+++ b/optimade.rst
@@ -242,7 +242,7 @@ Versioned base URLs
 Access to the API is primarily provided under **versioned base URLs**.
 An implementation MUST provide the form where a URL path segment :query-url:`/vMAJOR` is appended to the base URL, where :val:`MAJOR` is one of the major version numbers of the API that the implementation supports.
 This URL MUST serve the *latest* minor/patch version supported by the implementation.
-For example, the lastest minor and patch version of major version 1 of the API is served under :query-url:`/v1`.
+For example, the latest minor and patch version of major version 1 of the API is served under :query-url:`/v1`.
 
 An implementation MAY also provide versioned base URLs on the forms :query-url:`/vMAJOR.MINOR` and :query-url:`/vMAJOR.MINOR.PATCH`.
 Here, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the API.
@@ -692,7 +692,7 @@ However, clients MUST accept responses that include other fields that follow the
 The CSV format header line MUST be provided, and the header for the first field MUST be `version`.
 
 The major API versions in the response are to be ordered according to the preference of the API implementation.
-If a version of the API is served on the unversioned base URL as described in the section `Base URL`_, that version MUST be the top line of the response (after the optional CSV header).
+If a version of the API is served on the unversioned base URL as described in the section `Base URL`_, that version MUST be the top line of the response (after the CSV header).
 
 It is the intent that all future versions of this specification retain this endpoint and the meaning of the first field of the response.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -249,7 +249,9 @@ A URL on the form  :query-url:`/vMAJOR.MINOR` MUST serve the *latest* patch vers
 
 API versions that are published with a suffix, e.g., `-rc<number>` to indicate a release candidate version, SHOULD be served on versioned base URLs without this suffix.
 
-It is the intent that future versions of this standard will not assign different meanings to URLs that begin with :query-url:`/v` and an integer.
+If a request is made to a versioned base URL that begins with `/v` and an integer followed by any other characters, indicating a version that the implementation does not recognize or support, it SHOULD respond with the custom HTTP server error status code :http-error:`553 API Version Not Supported`, perferably along with a user-friendly error message that directs the client to adapt the request to a version it provides.
+
+It is the intent that future versions of this standard will not assign different meanings to URLs that begin with :query-url:`/v` and an integer followed by other characters.
 Hence, a client can safely attempt to access a specific version of the API via the corresponding versioned base URL. 
 Other forms of version negotiation is provided by the :endpoint:`versions` endpoint (see section `Versions Endpoint`_).
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -692,7 +692,7 @@ However, clients MUST accept responses that include other fields that follow the
 The CSV format header line MUST be provided, and the header for the first field MUST be `version`.
 
 The major API versions in the response are to be ordered according to the preference of the API implementation.
-If a version of the API is served on the unversioned base URL as described in the section `Base URL`_, that version MUST be the top line of the response (after the CSV header).
+If a version of the API is served on the unversioned base URL as described in the section `Base URL`_, that version MUST be the first value in the response (i.e., it MUST be on the second line of the response directly following the required CSV header).
 
 It is the intent that all future versions of this specification retain this endpoint and the meaning of the first field of the response.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -713,15 +713,18 @@ Versions Endpoint
 The :endpoint:`versions` endpoint aims at providing a stable and future-proof way for a client to discover the major versions of the API that the implementation provides. 
 This endpoint is special in that it MUST be provided directly on the unversioned base URL at :query-url:`/versions` and MUST NOT be provided under the versioned base URLs.
 
-The response to a query to this endpoint is in the :RFC:`4180` CSV (`text/csv; header=present`) format.
+The response to a query to this endpoint is in a restricted subset of the :RFC:`4180` CSV (`text/csv; header=present`) format.
+The restrictions are: (i) field values and header names MUST NOT contain commas, newlines, or double quote characters; (ii) Field values and header names MUST NOT be enclosed by double quotes; (iii) The first line MUST be a header line.
+These restrictions allow clients to parse the file line-by-line, where each line can be split on all occurences of the comma ',' character to obtain the head names and field values.
+
 In the present version of the API, the response contains only a single field that is used to list the major versions of the API that the implementation supports.
+The CSV format header line MUST specify :val:`version` as the name for this field.
 However, clients MUST accept responses that include other fields that follow the version.
-The CSV format header line MUST be provided, and the header for the first field MUST be :val:`version`.
 
 The major API versions in the response are to be ordered according to the preference of the API implementation.
 If a version of the API is served on the unversioned base URL as described in the section `Base URL`_, that version MUST be the first value in the response (i.e., it MUST be on the second line of the response directly following the required CSV header).
 
-It is the intent that all future versions of this specification retain this endpoint and the meaning of the first field of the response.
+It is the intent that all future versions of this specification retain this endpoint, its restricted CSV response format, and the meaning of the first field of the response.
 
 Example response:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -292,8 +292,7 @@ Implementations MAY combine direct access to Single Entry Endpoints with redirec
 
 When an implementation serves (or redirects to) a preferred major version of the API on the unversioned base URL, that version MUST also be the version at the first line in the response of the :endpoint:`versions` endpoint (see `Versions Endpoint`_).
 
-    **For implementers**: Before enabling access to the API on unversioned base URLs, implementers are advised to consider that this feature may encourage careless automated access from clients that, without verification, assumes a specific version of the API to be served on the unversioned base URL.
-    The implementer needs to be prepared to break such clients on major version upgrades, or will otherwise get stuck at serving the *oldest* API version on the unversioned URL.
+    **For implementers**: Before enabling access to the API on unversioned base URLs, implementers are advised to consider that an upgrade of the major version of the API served this way may change the behaviors of associated endpoints in ways that are not backwards compatible.
 
 Index Meta-Database
 -------------------

--- a/optimade.rst
+++ b/optimade.rst
@@ -300,17 +300,22 @@ The OPTIMADE API provides three concurrent mechanisms for version negotiation be
 2. A client can access the API under versioned base URLs.
    In this case, the server MUST respond according to the specified version or return an error if the version is not supported (see section `Versioned Base URLs`_).
   
-3. When accessing the API under the unversioned base URL, a client MAY append the query parameter :query-param:`api_hint` to hint the server about a preferred API version.
+3. When accessing the API under the unversioned base URL, clients are encouraged to append the OPTIONAL query parameter :query-param:`api_hint` to hint the server about a preferred API version for the request.
    This parameter is described in more detail below.
 
 The :query-param:`api_hint` query parameter MUST be accepted by all API endpoints.
 However, for endpoints under a versioned base URL this parameter SHOULD be ignored, and the request served as usual according to the version specified in the URL path segment.
-When a client provides the parameter, the value SHOULD be on the format :val:`vMAJOR` where MAJOR is a major version of the API.
-For example, if a client appends to the query string :query-string:`api_hint=v1` the hint provided is for major version 1.
+If the client provides the parameter, the value SHOULD be on the format :val:`vMAJOR` where MAJOR is a major version of the API.
+For example, if a client appends :query-string:`api_hint=v1` to the query string, the hint provided is for major version 1.
 
-The intent of the :query-param:`api_hint` parameter is that if a client hints a version that is not supported by the server, the server can use the value to make a best-effort attempt at still serving the request, e.g., by invoking the closest supported version of the API.
-However, the use of this parameter, if any, is entirely at the discretion of the implementation, and clients MUST NOT expect the response to be served according to the version that is hinted.
+If the server supports the version indicated by the :query-param:`api_hint` parameter, it SHOULD serve the request using this version.
+If the server does not support the version hinted, it MAY use the provided value to make a best-effort attempt at still serving the request, e.g., by invoking the closest supported version of the API.
+If the hinted version is not supported by the server and the request is not served using an alternative version, the server SHOULD respond with the custom HTTP server error status code :http-error:`553 Version Not Supported`.
+Note that the above protocol means that clients MUST NOT expect a returned response is served according to the version that is hinted.
 
+    **For end users**: Users are strongly encouraged to include the :query-param:`api_hint` query parameter for URLs in, e.g., journal publications for queries on endpoints under the unversioned base URL.
+    The version hint will make it possible to serve such queries in a reasonable way even after the server changes the major API version used for requests without version hints.
+    
 Index Meta-Database
 -------------------
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -305,13 +305,13 @@ The OPTIMADE API provides three concurrent mechanisms for version negotiation be
 
 The :query-param:`api_hint` query parameter MUST be accepted by all API endpoints.
 However, for endpoints under a versioned base URL this parameter SHOULD be ignored, and the request served as usual according to the version specified in the URL path segment.
-If the client provides the parameter, the value SHOULD have the format :val:`vMAJOR` where MAJOR is a major version of the API.
-For example, if a client appends :query-string:`api_hint=v1` to the query string, the hint provided is for major version 1.
+If the client provides the parameter, the value SHOULD have the format :val:`vMAJOR` or :val:`vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API.
+For example, if a client appends :query-string:`api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.
 
-If the server supports the version indicated by the :query-param:`api_hint` parameter, it SHOULD serve the request using this version.
-If the server does not support the version hinted, it MAY use the provided value to make a best-effort attempt at still serving the request, e.g., by invoking the closest supported version of the API.
+If the server supports the major version indicated by the :query-param:`api_hint` parameter at the same or a higher minor version (if provided), it SHOULD serve the request using this version.
+If the server does not support the major version hinted, or if it supports the major version but only at a minor version below the one hinted, it MAY use the provided values to make a best-effort attempt at still serving the request, e.g., by invoking the closest supported version of the API.
 If the hinted version is not supported by the server and the request is not served using an alternative version, the server SHOULD respond with the custom HTTP server error status code :http-error:`553 Version Not Supported`.
-Note that the above protocol means that clients MUST NOT expect a returned response is served according to the version that is hinted.
+Note that the above protocol means that clients MUST NOT expect that a returned response is served according to the version that is hinted.
 
     **For end users**: Users are strongly encouraged to include the :query-param:`api_hint` query parameter for URLs in, e.g., journal publications for queries on endpoints under the unversioned base URL.
     The version hint will make it possible to serve such queries in a reasonable way even after the server changes the major API version used for requests without version hints.

--- a/optimade.rst
+++ b/optimade.rst
@@ -242,6 +242,7 @@ Versioned base URLs
 Access to the API is primarily provided under **versioned base URLs**.
 An implementation MUST provide the form where a URL path segment :query-url:`/vMAJOR` is appended to the base URL, where :val:`MAJOR` is one of the major version numbers of the API that the implementation supports.
 This URL MUST serve the *latest* minor/patch version supported by the implementation.
+For example, the lastest minor and patch version of major version 1 of the API is served under :query-url:`/v1`.
 
 An implementation MAY also provide versioned base URLs on the forms :query-url:`/vMAJOR.MINOR` and :query-url:`/vMAJOR.MINOR.PATCH`.
 Here, :val:`MINOR` is the minor version number and :val:`PATCH` is the patch version number of the API.
@@ -686,10 +687,10 @@ Versions Endpoint
 The :endpoint:`versions` endpoint aims at providing a stable and future-proof way for a client to discover the major versions of the API that the implementation provides. 
 This endpoint is special in that it MUST be provided directly on the unversioned base URL at :query-url:`/versions` and MUST NOT be provided under the versioned base URLs.
 
-The response to a query to this endpoint is in the :RFC:`4180` `text/csv; header=present` format (and does therefore not comply with the JSON:API data format of the `JSON API v1.0 <http://jsonapi.org/format/1.0>`__ specification).
+The response to a query to this endpoint is in the :RFC:`4180` CSV (`text/csv; header=present`) format (and does therefore not comply with the JSON:API data format of the `JSON API v1.0 <http://jsonapi.org/format/1.0>`__ specification).
 In the present version of the API, the response contains only a single field that is used to list the major versions of the API that the implementation supports.
 However, clients MUST accept responses that include other fields that follow the version.
-The csv format header line MUST be provided, and the header for the first field MUST be `#version`.
+The CSV format header line MUST be provided, and the header for the first field MUST be `version`.
 
 The major API versions in the response are to be ordered according to the preference of the API implementation.
 If a version of the API is served on the unversioned base URL as described in the section `Base URL`_, that version MUST be the top line of the response (after the optional CSV header).
@@ -700,7 +701,7 @@ Example response:
 
 .. code:: CSV
 
-  #version
+  version
   1
   0
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -304,7 +304,8 @@ The OPTIMADE API provides three concurrent mechanisms for version negotiation be
    This parameter is described in more detail below.
 
 The :query-param:`api_hint` query parameter MUST be accepted by all API endpoints.
-However, for endpoints under a versioned base URL this parameter MUST be ignored, and the request served as usual according to the version specified in the URL path segment.
+However, for endpoints under a versioned base URL the request MUST be served as usual according to the version specified in the URL path segment regardless of the value of `api_hint`.
+In this case, the server MAY issue a warning if the value of `api_hint` suggests that the query may not be properly supported.
 If the client provides the parameter, the value SHOULD have the format :val:`vMAJOR` or :val:`vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API.
 For example, if a client appends :query-string:`api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.
 


### PR DESCRIPTION
This PR is an attempt at accommodating the various views in #277 for how version negotiation between server and client should be done, and what should be allowed and not with regards to serving the API on the unversioned base URL.

Closes #277 