### PR TITLE
Updated OpenAPI spec to ready for 1.0.0-rc.2

### DIFF
--- a/schemas/index_openapi_schema.json
+++ b/schemas/index_openapi_schema.json
@@ -257,6 +257,7 @@
           },
           "version": {
             "title": "Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "A string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
           }
@@ -664,6 +665,7 @@
         "properties": {
           "api_version": {
             "title": "Api Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "Presently used version of the OPTIMADE API"
           },
@@ -1475,6 +1477,7 @@
           },
           "api_version": {
             "title": "Api Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "A string containing the version of the API implementation."
           },

--- a/schemas/index_openapi_schema.json
+++ b/schemas/index_openapi_schema.json
@@ -2,24 +2,24 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API - Index meta-database",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.3.3) v0.3.3.",
-    "version": "1.0.0"
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.9.1) v0.9.1.",
+    "version": "1.0.0-rc.2"
   },
   "paths": {
-    "/index/optimade/v1/info": {
+    "/v1/info": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Info",
-        "operationId": "get_info_index_optimade_v1_info_get",
+        "operationId": "get_info_v1_info_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Info Index Optimade V1 Info Get",
+                  "title": "Response Get Info V1 Info Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/IndexInfoResponse"
@@ -35,41 +35,45 @@
         }
       }
     },
-    "/index/optimade/v1/links": {
+    "/v1/links": {
       "get": {
         "tags": [
           "Links"
         ],
         "summary": "Get Links",
-        "operationId": "get_links_index_optimade_v1_links_get",
+        "operationId": "get_links_v1_links_get",
         "parameters": [
           {
-            "description": "See [the full and latest OPTIMADE spec](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
             "required": false,
             "schema": {
               "title": "Filter",
               "type": "string",
-              "description": "See [the full and latest OPTIMADE spec](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
               "default": ""
             },
             "name": "filter",
             "in": "query"
           },
           {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
               "format": "email",
               "default": ""
             },
@@ -77,89 +81,119 @@
             "in": "query"
           },
           {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
             "required": false,
             "schema": {
               "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
               "default": ""
             },
             "name": "response_fields",
             "in": "query"
           },
           {
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
             "required": false,
             "schema": {
               "title": "Sort",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
               "default": ""
             },
             "name": "sort",
             "in": "query"
           },
           {
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
             "required": false,
             "schema": {
               "title": "Page Limit",
               "minimum": 0.0,
               "type": "integer",
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
               "default": 20
             },
             "name": "page_limit",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
             "required": false,
             "schema": {
               "title": "Page Offset",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
               "default": 0
             },
             "name": "page_offset",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
             "required": false,
             "schema": {
-              "title": "Page Page",
+              "title": "Page Number",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
               "default": 0
             },
-            "name": "page_page",
+            "name": "page_number",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
             "required": false,
             "schema": {
               "title": "Page Cursor",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
               "default": 0
             },
             "name": "page_cursor",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
             "required": false,
             "schema": {
               "title": "Page Above",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
               "default": 0
             },
             "name": "page_above",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
             "required": false,
             "schema": {
               "title": "Page Below",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
               "default": 0
             },
             "name": "page_below",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
             "in": "query"
           }
         ],
@@ -169,7 +203,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Links Index Optimade V1 Links Get",
+                  "title": "Response Get Links V1 Links Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/LinksResponse"
@@ -216,20 +250,21 @@
             "title": "Url",
             "maxLength": 65536,
             "minLength": 1,
+            "pattern": ".+/v[0-1](\\.[0-9]+)*/?$",
             "type": "string",
-            "description": "a string specifying a base URL that MUST adhere to the rules in section Base URL",
+            "description": "A string specifying a versioned base URL that MUST adhere to the rules in section Base URL",
             "format": "uri"
           },
           "version": {
             "title": "Version",
             "type": "string",
-            "description": "a string containing the full version number of the API served at that base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
+            "description": "A string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
           }
         },
         "description": "A JSON object containing information about an available API version"
       },
-      "BaseRealationshipMeta": {
-        "title": "BaseRealationshipMeta",
+      "BaseRelationshipMeta": {
+        "title": "BaseRelationshipMeta",
         "required": [
           "description"
         ],
@@ -265,7 +300,7 @@
             "title": "Meta",
             "allOf": [
               {
-                "$ref": "#/components/schemas/BaseRealationshipMeta"
+                "$ref": "#/components/schemas/BaseRelationshipMeta"
               }
             ],
             "description": "Relationship meta field. MUST contain 'description' if supplied."
@@ -310,12 +345,12 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section `Definition of Terms`_.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - See section `Definition of Terms`_.\n\n- **Examples**:\n\n  - :val:`\"db/1234567\"`\n  - :val:`\"cod/2000000\"`\n  - :val:`\"cod/2000000@1234567\"`\n  - :val:`\"nomad/L1234567890\"`\n  - :val:`\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
           },
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "The name of the type of an entry.\nAny entry MUST be able to be fetched using the `base URL <Base URL_>`_ type and ID at the url :endpoint:`<base URL>/<type>/<id>`.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: Support for queries on this property is OPTIONAL.\n    If supported, only a subset of string comparison operators MAY be supported.\n\n- **Requirements/Conventions**: MUST be an existing entry type.\n- **Example**: :val:`\"structures\"`"
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`"
           },
           "links": {
             "title": "Links",
@@ -342,7 +377,7 @@
                 "$ref": "#/components/schemas/EntryResourceAttributes"
               }
             ],
-            "description": "a dictionary, containing key-value pairs representing the entry's properties, except for type and id.\n\nDatabase-provider-specific properties need to include the database-provider-specific prefix\n(see appendix `Database-Provider-Specific Namespace Prefixes`_)."
+            "description": "A dictionary, containing key-value pairs representing the entry's properties, except for `type` and `id`.\nDatabase-provider-specific properties need to include the database-provider-specific prefix (see section on Database-Provider-Specific Namespace Prefixes)."
           },
           "relationships": {
             "title": "Relationships",
@@ -351,10 +386,10 @@
                 "$ref": "#/components/schemas/EntryRelationships"
               }
             ],
-            "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
-        "description": "Resource objects appear in a JSON:API document to represent resources."
+        "description": "Resource objects appear in a JSON API document to represent resources."
       },
       "EntryResourceAttributes": {
         "title": "EntryResourceAttributes",
@@ -366,16 +401,75 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID).\nThis is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants.\nThis ID maps to the version-specific record, in case it changes in the future.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: OPTIONAL in the response.\n  - **Query**: If present, MUST be a queryable property with support for all mandatory filter operators.\n\n- **Examples**:\n\n  - :val:`\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n  - :val:`\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
-            "description": "Date and time representing when the entry was last modified.\n- **Type**: timestamp.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n\n- **Example**:\n\n  - As part of JSON response format: :VAL:`\"2007-04-05T14:30Z\"`\n    (i.e., encoded as an `RFC 3339 Internet Date/Time Format <https://tools.ietf.org/html/rfc3339#section-5.6>`__ string.)",
+            "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
             "format": "date-time"
           }
         },
         "description": "Contains key-value pairs representing the entry's properties."
+      },
+      "Error": {
+        "title": "Error",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          }
+        },
+        "description": "An error response"
       },
       "ErrorLinks": {
         "title": "ErrorLinks",
@@ -412,6 +506,7 @@
         "properties": {
           "data": {
             "title": "Data",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "allOf": [
@@ -424,21 +519,28 @@
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/Resource"
-                },
-                "uniqueItems": true
+                }
               }
             ],
             "description": "Outputted Data"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
+            "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__optimade_json__Error"
-            }
+              "$ref": "#/components/schemas/OptimadeError"
+            },
+            "description": "A list of OPTIMADE-specific JSON API error objects, where the field detail MUST be present."
           },
           "included": {
             "title": "Included",
@@ -447,7 +549,7 @@
             "items": {
               "$ref": "#/components/schemas/Resource"
             },
-            "description": "A list of resources that are included"
+            "description": "A list of unique included resources"
           },
           "links": {
             "title": "Links",
@@ -456,7 +558,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -590,7 +692,7 @@
             "items": {
               "type": "string"
             },
-            "description": "List of available endpoints (i.e., the string to be appended to the base URL)."
+            "description": "List of available endpoints (i.e., the string to be appended to the versioned base URL)."
           },
           "entry_types_by_format": {
             "title": "Entry Types By Format",
@@ -606,7 +708,7 @@
           "is_index": {
             "title": "Is Index",
             "type": "boolean",
-            "description": "If true, this is an index meta-database base URL (see section Index Meta-Database). If this member is not provided, the client MUST assume this is not an index meta-database base URL (i.e., the default is for is_index to be false)."
+            "description": "This must be `true` since this is an index meta-database (see section Index Meta-Database)."
           }
         },
         "description": "Attributes for Base URL Info endpoint for an Index Meta-Database"
@@ -654,10 +756,10 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/IndexRelationship"
             },
-            "description": "Reference to the child identifier object under the links endpoint that the provider has chosen as their 'default' OPTIMADE API database. A client SHOULD present this database as the first choice when an end-user chooses this provider."
+            "description": "Reference to the Links identifier object under the `links` endpoint that the provider has chosen as their 'default' OPTIMADE API database.\nA client SHOULD present this database as the first choice when an end-user chooses this provider."
           }
         },
-        "description": "Index Meta-Database Base URL Info enpoint resource"
+        "description": "Index Meta-Database Base URL Info endpoint resource"
       },
       "IndexInfoResponse": {
         "title": "IndexInfoResponse",
@@ -667,19 +769,31 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/IndexInfoResource"
+            "title": "Data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IndexInfoResource"
+              }
+            ],
+            "description": "Index meta-database /info data"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+              "$ref": "#/components/schemas/Error"
             },
-            "description": "A list of errors"
+            "description": "A list of unique errors"
           },
           "included": {
             "title": "Included",
@@ -688,7 +802,7 @@
             "items": {
               "$ref": "#/components/schemas/Resource"
             },
-            "description": "A list of resources that are included"
+            "description": "A list of unique included resources"
           },
           "links": {
             "title": "Links",
@@ -697,7 +811,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -722,10 +836,10 @@
             "title": "Data",
             "allOf": [
               {
-                "$ref": "#/components/schemas/RelatedChildResource"
+                "$ref": "#/components/schemas/RelatedLinksResource"
               }
             ],
-            "description": "JSON API resource linkage. It MUST be either null or contain a single child identifier object with the fields 'id' and 'type'"
+            "description": "[JSON API resource linkage](http://jsonapi.org/format/1.0/#document-links).\nIt MUST be either `null` or contain a single Links identifier object with the fields `id` and `type`"
           }
         },
         "description": "Index Meta-Database relationship"
@@ -783,7 +897,6 @@
         "title": "LinksResource",
         "required": [
           "id",
-          "type",
           "attributes"
         ],
         "type": "object",
@@ -791,12 +904,12 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section `Definition of Terms`_.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - See section `Definition of Terms`_.\n\n- **Examples**:\n\n  - :val:`\"db/1234567\"`\n  - :val:`\"cod/2000000\"`\n  - :val:`\"cod/2000000@1234567\"`\n  - :val:`\"nomad/L1234567890\"`\n  - :val:`\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
           },
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "MUST be either \"parent\", \"child\", or \"provider\". These objects are described in detail in sections Parent and Child Objects and Provider Objects."
+            "description": "These objects are described in detail in the section Links Endpoint"
           },
           "links": {
             "title": "Links",
@@ -823,7 +936,7 @@
                 "$ref": "#/components/schemas/LinksResourceAttributes"
               }
             ],
-            "description": "a dictionary containing key-value pairs representing the entry's properties."
+            "description": "A dictionary containing key-value pairs representing the Links resource's properties."
           },
           "relationships": {
             "title": "Relationships",
@@ -832,7 +945,7 @@
                 "$ref": "#/components/schemas/EntryRelationships"
               }
             ],
-            "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
         "description": "A Links endpoint resource object"
@@ -843,19 +956,20 @@
           "name",
           "description",
           "base_url",
-          "homepage"
+          "homepage",
+          "link_type"
         ],
         "type": "object",
         "properties": {
           "name": {
             "title": "Name",
             "type": "string",
-            "description": "Human-readable name for the OPTIMADE API implementation a client may provide in a list to an end-user."
+            "description": "Human-readable name for the OPTIMADE API implementation, e.g., for use in clients to show the name to the end-user."
           },
           "description": {
             "title": "Description",
             "type": "string",
-            "description": "Human-readable description for the OPTIMADE API implementation a client may provide in a list to an end-user."
+            "description": "Human-readable description for the OPTIMADE API implementation, e.g., for use in clients to show a description to the end-user."
           },
           "base_url": {
             "title": "Base Url",
@@ -894,6 +1008,32 @@
               }
             ],
             "description": "JSON API links object, pointing to a homepage URL for this implementation"
+          },
+          "link_type": {
+            "title": "Link Type",
+            "enum": [
+              "child",
+              "root",
+              "external",
+              "providers"
+            ],
+            "description": "The type of the linked relation.\nMUST be one of these values: 'child', 'root', 'external', 'providers'."
+          },
+          "aggregate": {
+            "title": "Aggregate",
+            "enum": [
+              "ok",
+              "test",
+              "staging",
+              "no"
+            ],
+            "description": "A string indicating whether a client that is following links to aggregate results from different OPTIMADE implementations should follow this link or not.\nThis flag SHOULD NOT be indicated for links where `link_type` is not `child`.\n\nIf not specified, clients MAY assume that the value is `ok`.\nIf specified, and the value is anything different than `ok`, the client MUST assume that the server is suggesting not to follow the link during aggregation by default (also if the value is not among the known ones, in case a future specification adds new accepted values).\n\nSpecific values indicate the reason why the server is providing the suggestion.\nA client MAY follow the link anyway if it has reason to do so (e.g., if the client is looking for all test databases, it MAY follow the links marked with `aggregate`=`test`).\n\nIf specified, it MUST be one of the values listed in section Link Aggregate Options.",
+            "default": "ok"
+          },
+          "no_aggregate_reason": {
+            "title": "No Aggregate Reason",
+            "type": "string",
+            "description": "An OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link.\nIt SHOULD NOT be present if `aggregate`=`ok`."
           }
         },
         "description": "Links endpoint resource object attributes"
@@ -907,6 +1047,7 @@
         "properties": {
           "data": {
             "title": "Data",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "type": "array",
@@ -920,22 +1061,30 @@
                   "type": "object"
                 }
               }
-            ]
+            ],
+            "description": "List of unique OPTIMADE links resource objects"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+              "$ref": "#/components/schemas/Error"
             },
-            "description": "A list of errors"
+            "description": "A list of unique errors"
           },
           "included": {
             "title": "Included",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "type": "array",
@@ -958,7 +1107,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -977,6 +1126,68 @@
         "type": "object",
         "properties": {},
         "description": "Non-standard meta-information that can not be represented as an attribute or relationship."
+      },
+      "OptimadeError": {
+        "title": "OptimadeError",
+        "required": [
+          "detail"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          }
+        },
+        "description": "detail MUST be present"
       },
       "Provider": {
         "title": "Provider",
@@ -1058,6 +1269,7 @@
           },
           "data": {
             "title": "Data",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "allOf": [
@@ -1087,8 +1299,8 @@
         },
         "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource"
       },
-      "RelatedChildResource": {
-        "title": "RelatedChildResource",
+      "RelatedLinksResource": {
+        "title": "RelatedLinksResource",
         "required": [
           "id"
         ],
@@ -1104,7 +1316,7 @@
             "type": "string"
           }
         },
-        "description": "Keep only type and id of a ChildResource"
+        "description": "A related Links resource object"
       },
       "RelationshipLinks": {
         "title": "RelationshipLinks",
@@ -1127,7 +1339,7 @@
                 ]
               }
             ],
-            "description": "A link to itself"
+            "description": "A link for the relationship itself (a 'relationship link').\nThis link allows the client to directly manipulate the relationship.\nWhen fetched successfully, this link returns the [linkage](https://jsonapi.org/format/1.0/#document-resource-object-linkage) for the related resources as its primary data.\n(See [Fetching Relationships](https://jsonapi.org/format/1.0/#fetching-relationships).)"
           },
           "related": {
             "title": "Related",
@@ -1146,10 +1358,10 @@
                 ]
               }
             ],
-            "description": "A related resource link"
+            "description": "A [related resource link](https://jsonapi.org/format/1.0/#document-resource-object-related-resource-links)."
           }
         },
-        "description": "A resource object **MAY** contain references to other resource objects (\"relationships\").\nRelationships may be to-one or to-many. Relationships can be specified by including a member in a resource's links object."
+        "description": "A resource object **MAY** contain references to other resource objects (\"relationships\").\nRelationships may be to-one or to-many.\nRelationships can be specified by including a member in a resource's links object."
       },
       "Relationships": {
         "title": "Relationships",
@@ -1209,10 +1421,10 @@
                 "$ref": "#/components/schemas/Relationships"
               }
             ],
-            "description": "a relationships object describing relationships between the resource and other JSON:API resources."
+            "description": "[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)\ndescribing relationships between the resource and other JSON API resources."
           }
         },
-        "description": "Resource objects appear in a JSON:API document to represent resources."
+        "description": "Resource objects appear in a JSON API document to represent resources."
       },
       "ResourceLinks": {
         "title": "ResourceLinks",
@@ -1259,29 +1471,29 @@
                 "$ref": "#/components/schemas/ResponseMetaQuery"
               }
             ],
-            "description": "information on the query that was requested"
+            "description": "Information on the Query that was requested"
           },
           "api_version": {
             "title": "Api Version",
             "type": "string",
-            "description": "a string containing the version of the API implementation, e.g. v0.9.5"
+            "description": "A string containing the version of the API implementation."
           },
           "time_stamp": {
             "title": "Time Stamp",
             "type": "string",
-            "description": "a string containing the date and time at which the query was exexcuted",
+            "description": "A timestamp containing the date and time at which the query was executed.",
             "format": "date-time"
           },
           "data_returned": {
             "title": "Data Returned",
             "minimum": 0.0,
             "type": "integer",
-            "description": "an integer containing the number of data objects returned for the query."
+            "description": "An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination."
           },
           "more_data_available": {
             "title": "More Data Available",
             "type": "boolean",
-            "description": "`false` if all data has been returned, and `true` if not."
+            "description": "`false` if all data resource objects for this `filter` query have been returned in the response or if it is the last page of a paginated response, and `true` otherwise."
           },
           "provider": {
             "title": "Provider",
@@ -1295,7 +1507,7 @@
           "data_available": {
             "title": "Data Available",
             "type": "integer",
-            "description": "an integer containing the total number of data objects available in the database"
+            "description": "An integer containing the total number of data resource objects available in the database for the endpoint."
           },
           "last_id": {
             "title": "Last Id",
@@ -1318,11 +1530,12 @@
           },
           "warnings": {
             "title": "Warnings",
+            "uniqueItems": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Warnings"
             },
-            "description": "List of warning resource objects representing non-critical errors or warnings. A warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\". The field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features. The field status, representing a HTTP response status code, MUST NOT be present for a warning resource object. This is an exclusive field for error resource objects."
+            "description": "A list of warning resource objects representing non-critical errors or warnings.\nA warning resource object is defined similarly to a [JSON API error object](http://jsonapi.org/format/1.0/#error-objects), but MUST also include the field `type`, which MUST have the value `\"warning\"`.\nThe field `detail` MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\nThe field `status`, representing a HTTP response status code, MUST NOT be present for a warning resource object.\nThis is an exclusive field for error resource objects."
           }
         },
         "description": "A [JSON API meta member](https://jsonapi.org/format/1.0#document-meta)\nthat contains JSON API meta objects of non-standard\nmeta-information.\n\nOPTIONAL additional information global to the query that is not\nspecified in this document, MUST start with a\ndatabase-provider-specific prefix."
@@ -1357,6 +1570,7 @@
           },
           "data": {
             "title": "Data",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "allOf": [
@@ -1554,128 +1768,7 @@
             "description": "Warnings must be of type \"warning\""
           }
         },
-        "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\nFrom the specification:\n\n    A warning resource object is defined similarly to a JSON API\n    error object, but MUST also include the field type, which MUST\n    have the value \"warning\". The field detail MUST be present and\n    SHOULD contain a non-critical message, e.g., reporting\n    unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."
-      },
-      "optimade__models__jsonapi__Error": {
-        "title": "Error",
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "string",
-            "description": "A unique identifier for this particular occurrence of the problem."
-          },
-          "links": {
-            "title": "Links",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorLinks"
-              }
-            ],
-            "description": "A links object storing about"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "description": "the HTTP status code applicable to this problem, expressed as a string value."
-          },
-          "code": {
-            "title": "Code",
-            "type": "string",
-            "description": "an application-specific error code, expressed as a string value."
-          },
-          "title": {
-            "title": "Title",
-            "type": "string",
-            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
-          },
-          "detail": {
-            "title": "Detail",
-            "type": "string",
-            "description": "A human-readable explanation specific to this occurrence of the problem."
-          },
-          "source": {
-            "title": "Source",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorSource"
-              }
-            ],
-            "description": "An object containing references to the source of the error"
-          },
-          "meta": {
-            "title": "Meta",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Meta"
-              }
-            ],
-            "description": "a meta object containing non-standard meta-information about the error."
-          }
-        },
-        "description": "An error response"
-      },
-      "optimade__models__optimade_json__Error": {
-        "title": "Error",
-        "required": [
-          "detail"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "string",
-            "description": "A unique identifier for this particular occurrence of the problem."
-          },
-          "links": {
-            "title": "Links",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorLinks"
-              }
-            ],
-            "description": "A links object storing about"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "description": "the HTTP status code applicable to this problem, expressed as a string value."
-          },
-          "code": {
-            "title": "Code",
-            "type": "string",
-            "description": "an application-specific error code, expressed as a string value."
-          },
-          "title": {
-            "title": "Title",
-            "type": "string",
-            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
-          },
-          "detail": {
-            "title": "Detail",
-            "type": "string",
-            "description": "A human-readable explanation specific to this occurrence of the problem."
-          },
-          "source": {
-            "title": "Source",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorSource"
-              }
-            ],
-            "description": "An object containing references to the source of the error"
-          },
-          "meta": {
-            "title": "Meta",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Meta"
-              }
-            ],
-            "description": "a meta object containing non-standard meta-information about the error."
-          }
-        },
-        "description": "detail MUST be present"
+        "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\n\nFrom the specification:\n\nA warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\".\nThe field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."
       }
     }
   }

--- a/schemas/openapi_schema.json
+++ b/schemas/openapi_schema.json
@@ -2,24 +2,24 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.3.3) v0.3.3.",
-    "version": "1.0.0"
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.9.1) v0.9.1.",
+    "version": "1.0.0-rc.2"
   },
   "paths": {
-    "/optimade/v1/info": {
+    "/v1/info": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Info",
-        "operationId": "get_info_optimade_v1_info_get",
+        "operationId": "get_info_v1_info_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Info Optimade V1 Info Get",
+                  "title": "Response Get Info V1 Info Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/InfoResponse"
@@ -35,13 +35,13 @@
         }
       }
     },
-    "/optimade/v1/info/{entry}": {
+    "/v1/info/{entry}": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Entry Info",
-        "operationId": "get_entry_info_optimade_v1_info__entry__get",
+        "operationId": "get_entry_info_v1_info__entry__get",
         "parameters": [
           {
             "required": true,
@@ -59,7 +59,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Entry Info Optimade V1 Info  Entry  Get",
+                  "title": "Response Get Entry Info V1 Info  Entry  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/EntryInfoResponse"
@@ -85,41 +85,45 @@
         }
       }
     },
-    "/optimade/v1/links": {
+    "/v1/links": {
       "get": {
         "tags": [
           "Links"
         ],
         "summary": "Get Links",
-        "operationId": "get_links_optimade_v1_links_get",
+        "operationId": "get_links_v1_links_get",
         "parameters": [
           {
-            "description": "See [the full and latest OPTIMADE spec](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
             "required": false,
             "schema": {
               "title": "Filter",
               "type": "string",
-              "description": "See [the full and latest OPTIMADE spec](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
               "default": ""
             },
             "name": "filter",
             "in": "query"
           },
           {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
               "format": "email",
               "default": ""
             },
@@ -127,89 +131,119 @@
             "in": "query"
           },
           {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
             "required": false,
             "schema": {
               "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
               "default": ""
             },
             "name": "response_fields",
             "in": "query"
           },
           {
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
             "required": false,
             "schema": {
               "title": "Sort",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
               "default": ""
             },
             "name": "sort",
             "in": "query"
           },
           {
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
             "required": false,
             "schema": {
               "title": "Page Limit",
               "minimum": 0.0,
               "type": "integer",
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
               "default": 20
             },
             "name": "page_limit",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
             "required": false,
             "schema": {
               "title": "Page Offset",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
               "default": 0
             },
             "name": "page_offset",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
             "required": false,
             "schema": {
-              "title": "Page Page",
+              "title": "Page Number",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
               "default": 0
             },
-            "name": "page_page",
+            "name": "page_number",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
             "required": false,
             "schema": {
               "title": "Page Cursor",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
               "default": 0
             },
             "name": "page_cursor",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
             "required": false,
             "schema": {
               "title": "Page Above",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
               "default": 0
             },
             "name": "page_above",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
             "required": false,
             "schema": {
               "title": "Page Below",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
               "default": 0
             },
             "name": "page_below",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
             "in": "query"
           }
         ],
@@ -219,7 +253,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Links Optimade V1 Links Get",
+                  "title": "Response Get Links V1 Links Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/LinksResponse"
@@ -245,41 +279,45 @@
         }
       }
     },
-    "/optimade/v1/references": {
+    "/v1/references": {
       "get": {
         "tags": [
           "References"
         ],
         "summary": "Get References",
-        "operationId": "get_references_optimade_v1_references_get",
+        "operationId": "get_references_v1_references_get",
         "parameters": [
           {
-            "description": "See [the full and latest OPTIMADE spec](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
             "required": false,
             "schema": {
               "title": "Filter",
               "type": "string",
-              "description": "See [the full and latest OPTIMADE spec](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
               "default": ""
             },
             "name": "filter",
             "in": "query"
           },
           {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
               "format": "email",
               "default": ""
             },
@@ -287,89 +325,119 @@
             "in": "query"
           },
           {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
             "required": false,
             "schema": {
               "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
               "default": ""
             },
             "name": "response_fields",
             "in": "query"
           },
           {
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
             "required": false,
             "schema": {
               "title": "Sort",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
               "default": ""
             },
             "name": "sort",
             "in": "query"
           },
           {
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
             "required": false,
             "schema": {
               "title": "Page Limit",
               "minimum": 0.0,
               "type": "integer",
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
               "default": 20
             },
             "name": "page_limit",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
             "required": false,
             "schema": {
               "title": "Page Offset",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
               "default": 0
             },
             "name": "page_offset",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
             "required": false,
             "schema": {
-              "title": "Page Page",
+              "title": "Page Number",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
               "default": 0
             },
-            "name": "page_page",
+            "name": "page_number",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
             "required": false,
             "schema": {
               "title": "Page Cursor",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
               "default": 0
             },
             "name": "page_cursor",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
             "required": false,
             "schema": {
               "title": "Page Above",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
               "default": 0
             },
             "name": "page_above",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
             "required": false,
             "schema": {
               "title": "Page Below",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
               "default": 0
             },
             "name": "page_below",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
             "in": "query"
           }
         ],
@@ -379,7 +447,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get References Optimade V1 References Get",
+                  "title": "Response Get References V1 References Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/ReferenceResponseMany"
@@ -405,13 +473,13 @@
         }
       }
     },
-    "/optimade/v1/references/{entry_id}": {
+    "/v1/references/{entry_id}": {
       "get": {
         "tags": [
           "References"
         ],
         "summary": "Get Single Reference",
-        "operationId": "get_single_reference_optimade_v1_references__entry_id__get",
+        "operationId": "get_single_reference_v1_references__entry_id__get",
         "parameters": [
           {
             "required": true,
@@ -423,20 +491,24 @@
             "in": "path"
           },
           {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
               "format": "email",
               "default": ""
             },
@@ -444,13 +516,28 @@
             "in": "query"
           },
           {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
             "required": false,
             "schema": {
               "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
               "default": ""
             },
             "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
             "in": "query"
           }
         ],
@@ -460,7 +547,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Single Reference Optimade V1 References  Entry Id  Get",
+                  "title": "Response Get Single Reference V1 References  Entry Id  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/ReferenceResponseOne"
@@ -486,41 +573,45 @@
         }
       }
     },
-    "/optimade/v1/structures": {
+    "/v1/structures": {
       "get": {
         "tags": [
           "Structures"
         ],
         "summary": "Get Structures",
-        "operationId": "get_structures_optimade_v1_structures_get",
+        "operationId": "get_structures_v1_structures_get",
         "parameters": [
           {
-            "description": "See [the full and latest OPTIMADE spec](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
             "required": false,
             "schema": {
               "title": "Filter",
               "type": "string",
-              "description": "See [the full and latest OPTIMADE spec](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst) for filter query syntax.\n\nExample: `chemical_formula = \"Al\" OR (prototype_formula = \"AB\" AND elements HAS Si, Al, O)`.\n",
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
               "default": ""
             },
             "name": "filter",
             "in": "query"
           },
           {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
               "format": "email",
               "default": ""
             },
@@ -528,89 +619,119 @@
             "in": "query"
           },
           {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
             "required": false,
             "schema": {
               "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
               "default": ""
             },
             "name": "response_fields",
             "in": "query"
           },
           {
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
             "required": false,
             "schema": {
               "title": "Sort",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
               "default": ""
             },
             "name": "sort",
             "in": "query"
           },
           {
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
             "required": false,
             "schema": {
               "title": "Page Limit",
               "minimum": 0.0,
               "type": "integer",
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
               "default": 20
             },
             "name": "page_limit",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
             "required": false,
             "schema": {
               "title": "Page Offset",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
               "default": 0
             },
             "name": "page_offset",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
             "required": false,
             "schema": {
-              "title": "Page Page",
+              "title": "Page Number",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
               "default": 0
             },
-            "name": "page_page",
+            "name": "page_number",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
             "required": false,
             "schema": {
               "title": "Page Cursor",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
               "default": 0
             },
             "name": "page_cursor",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
             "required": false,
             "schema": {
               "title": "Page Above",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
               "default": 0
             },
             "name": "page_above",
             "in": "query"
           },
           {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
             "required": false,
             "schema": {
               "title": "Page Below",
               "minimum": 0.0,
               "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
               "default": 0
             },
             "name": "page_below",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
             "in": "query"
           }
         ],
@@ -620,7 +741,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Structures Optimade V1 Structures Get",
+                  "title": "Response Get Structures V1 Structures Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/StructureResponseMany"
@@ -646,13 +767,13 @@
         }
       }
     },
-    "/optimade/v1/structures/{entry_id}": {
+    "/v1/structures/{entry_id}": {
       "get": {
         "tags": [
           "Structures"
         ],
         "summary": "Get Single Structure",
-        "operationId": "get_single_structure_optimade_v1_structures__entry_id__get",
+        "operationId": "get_single_structure_v1_structures__entry_id__get",
         "parameters": [
           {
             "required": true,
@@ -664,20 +785,24 @@
             "in": "path"
           },
           {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
             "required": false,
             "schema": {
               "title": "Response Format",
               "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
               "default": "json"
             },
             "name": "response_format",
             "in": "query"
           },
           {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
             "required": false,
             "schema": {
               "title": "Email Address",
               "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
               "format": "email",
               "default": ""
             },
@@ -685,13 +810,28 @@
             "in": "query"
           },
           {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
             "required": false,
             "schema": {
               "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
               "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
               "default": ""
             },
             "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
             "in": "query"
           }
         ],
@@ -701,7 +841,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Single Structure Optimade V1 Structures  Entry Id  Get",
+                  "title": "Response Get Single Structure V1 Structures  Entry Id  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/StructureResponseOne"
@@ -747,7 +887,7 @@
                 "type": "integer"
               }
             },
-            "description": "Index of the sites (0-based) that belong to each group for each assembly.\n\nExample: :val:`[[1], [2]]`: two groups, one with the second site, one with the third.\nExample: :val:`[[1,2], [3]]`: one group with the second and third site, one with the fourth."
+            "description": "Index of the sites (0-based) that belong to each group for each assembly.\n\n- **Examples**:\n    - `[[1], [2]]`: two groups, one with the second site, one with the third.\n    - `[[1,2], [3]]`: one group with the second and third site, one with the fourth."
           },
           "group_probabilities": {
             "title": "Group Probabilities",
@@ -755,10 +895,10 @@
             "items": {
               "type": "number"
             },
-            "description": "Statistical probability of each group. It MUST have the same length as :property:`sites_in_groups`.\nIt SHOULD sum to one.\nSee below for examples of how to specify the probability of the occurrence of a vacancy.\nThe possible reasons for the values not to sum to one are the same as already specified above for the :property:`concentration` of each :property:`species`, see property `species`_."
+            "description": "Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\nIt SHOULD sum to one.\nSee below for examples of how to specify the probability of the occurrence of a vacancy.\nThe possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`."
           }
         },
-        "description": "A description of groups of sites that are statistically correlated.\n\n- **Examples** (for each entry of the assemblies list):\n\n    - :val:`{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - :val:`{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent)."
+        "description": "A description of groups of sites that are statistically correlated.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n      Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n      The second group is formed by the fourth site. Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n      30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n    "
       },
       "Attributes": {
         "title": "Attributes",
@@ -778,14 +918,15 @@
             "title": "Url",
             "maxLength": 65536,
             "minLength": 1,
+            "pattern": ".+/v[0-1](\\.[0-9]+)*/?$",
             "type": "string",
-            "description": "a string specifying a base URL that MUST adhere to the rules in section Base URL",
+            "description": "A string specifying a versioned base URL that MUST adhere to the rules in section Base URL",
             "format": "uri"
           },
           "version": {
             "title": "Version",
             "type": "string",
-            "description": "a string containing the full version number of the API served at that base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
+            "description": "A string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
           }
         },
         "description": "A JSON object containing information about an available API version"
@@ -830,7 +971,7 @@
             "items": {
               "type": "string"
             },
-            "description": "List of available endpoints (i.e., the string to be appended to the base URL)."
+            "description": "List of available endpoints (i.e., the string to be appended to the versioned base URL)."
           },
           "entry_types_by_format": {
             "title": "Entry Types By Format",
@@ -846,7 +987,7 @@
           "is_index": {
             "title": "Is Index",
             "type": "boolean",
-            "description": "If true, this is an index meta-database base URL (see section Index Meta-Database). If this member is not provided, the client MUST assume this is not an index meta-database base URL (i.e., the default is for is_index to be false).",
+            "description": "If true, this is an index meta-database base URL (see section Index Meta-Database). If this member is not provided, the client MUST assume this is not an index meta-database base URL (i.e., the default is for `is_index` to be `false`).",
             "default": false
           }
         },
@@ -895,13 +1036,13 @@
                 "$ref": "#/components/schemas/Relationships"
               }
             ],
-            "description": "a relationships object describing relationships between the resource and other JSON:API resources."
+            "description": "[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)\ndescribing relationships between the resource and other JSON API resources."
           }
         },
-        "description": "Resource objects appear in a JSON:API document to represent resources."
+        "description": "Resource objects appear in a JSON API document to represent resources."
       },
-      "BaseRealationshipMeta": {
-        "title": "BaseRealationshipMeta",
+      "BaseRelationshipMeta": {
+        "title": "BaseRelationshipMeta",
         "required": [
           "description"
         ],
@@ -937,7 +1078,7 @@
             "title": "Meta",
             "allOf": [
               {
-                "$ref": "#/components/schemas/BaseRealationshipMeta"
+                "$ref": "#/components/schemas/BaseRelationshipMeta"
               }
             ],
             "description": "Relationship meta field. MUST contain 'description' if supplied."
@@ -955,17 +1096,31 @@
           "description": {
             "title": "Description",
             "type": "string",
-            "description": "description of the entry property"
+            "description": "A human-readable description of the entry property"
           },
           "unit": {
             "title": "Unit",
             "type": "string",
-            "description": "the physical unit of the entry property"
+            "description": "The physical unit of the entry property.\nIt is RECOMMENDED that non-standard (non-SI) units are described in the description for the property."
           },
           "sortable": {
             "title": "Sortable",
             "type": "boolean",
-            "description": "defines whether the entry property can be used for sorting with the \"sort\" parameter. If the entry listing endpoint supports sorting, this key MUST be present for all properties."
+            "description": "Defines whether the entry property can be used for sorting with the \"sort\" parameter.\nIf the entry listing endpoint supports sorting, this key MUST be present for sortable properties with value `true`."
+          },
+          "type": {
+            "title": "Type",
+            "enum": [
+              "string",
+              "integer",
+              "float",
+              "boolean",
+              "timestamp",
+              "list",
+              "dictionary",
+              "unknown"
+            ],
+            "description": "The type of the property's value.\nThis MUST be any of the types defined in the Data types section.\nFor the purpose of compatibility with future versions of this specification, a client MUST accept values that are not `string` values specifying any of the OPTIMADE Data types, but MUST then also disregard the `type` field.\nNote, if the value is a nested type, only the outermost type should be reported.\nE.g., for the entry resource `structures`, the `species` property is defined as a list of dictionaries, hence its `type` value would be `list`."
           }
         }
       },
@@ -985,12 +1140,12 @@
             "items": {
               "type": "string"
             },
-            "description": "list of available output formats."
+            "description": "List of output formats available for this type of entry."
           },
           "description": {
             "title": "Description",
             "type": "string",
-            "description": "description of the entry"
+            "description": "Description of the entry."
           },
           "properties": {
             "title": "Properties",
@@ -998,7 +1153,7 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/EntryInfoProperty"
             },
-            "description": "a dictionary describing queryable properties for this entry type, where each key is a property ID."
+            "description": "A dictionary describing queryable properties for this entry type, where each key is a property name."
           },
           "output_fields_by_format": {
             "title": "Output Fields By Format",
@@ -1009,7 +1164,7 @@
                 "type": "string"
               }
             },
-            "description": "a dictionary of available output fields for this entry type, where the keys are the values of the `formats` list and the values are the keys of the `properties` dictionary."
+            "description": "Dictionary of available output fields for this entry type, where the keys are the values of the `formats` list and the values are the keys of the `properties` dictionary."
           }
         }
       },
@@ -1021,19 +1176,31 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/EntryInfoResource"
+            "title": "Data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryInfoResource"
+              }
+            ],
+            "description": "OPTIMADE information for an entry endpoint"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+              "$ref": "#/components/schemas/Error"
             },
-            "description": "A list of errors"
+            "description": "A list of unique errors"
           },
           "included": {
             "title": "Included",
@@ -1042,7 +1209,7 @@
             "items": {
               "$ref": "#/components/schemas/Resource"
             },
-            "description": "A list of resources that are included"
+            "description": "A list of unique included resources"
           },
           "links": {
             "title": "Links",
@@ -1051,7 +1218,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -1102,12 +1269,12 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section `Definition of Terms`_.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - See section `Definition of Terms`_.\n\n- **Examples**:\n\n  - :val:`\"db/1234567\"`\n  - :val:`\"cod/2000000\"`\n  - :val:`\"cod/2000000@1234567\"`\n  - :val:`\"nomad/L1234567890\"`\n  - :val:`\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
           },
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "The name of the type of an entry.\nAny entry MUST be able to be fetched using the `base URL <Base URL_>`_ type and ID at the url :endpoint:`<base URL>/<type>/<id>`.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: Support for queries on this property is OPTIONAL.\n    If supported, only a subset of string comparison operators MAY be supported.\n\n- **Requirements/Conventions**: MUST be an existing entry type.\n- **Example**: :val:`\"structures\"`"
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`"
           },
           "links": {
             "title": "Links",
@@ -1134,7 +1301,7 @@
                 "$ref": "#/components/schemas/EntryResourceAttributes"
               }
             ],
-            "description": "a dictionary, containing key-value pairs representing the entry's properties, except for type and id.\n\nDatabase-provider-specific properties need to include the database-provider-specific prefix\n(see appendix `Database-Provider-Specific Namespace Prefixes`_)."
+            "description": "A dictionary, containing key-value pairs representing the entry's properties, except for `type` and `id`.\nDatabase-provider-specific properties need to include the database-provider-specific prefix (see section on Database-Provider-Specific Namespace Prefixes)."
           },
           "relationships": {
             "title": "Relationships",
@@ -1143,10 +1310,10 @@
                 "$ref": "#/components/schemas/EntryRelationships"
               }
             ],
-            "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
-        "description": "Resource objects appear in a JSON:API document to represent resources."
+        "description": "Resource objects appear in a JSON API document to represent resources."
       },
       "EntryResourceAttributes": {
         "title": "EntryResourceAttributes",
@@ -1158,16 +1325,75 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID).\nThis is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants.\nThis ID maps to the version-specific record, in case it changes in the future.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: OPTIONAL in the response.\n  - **Query**: If present, MUST be a queryable property with support for all mandatory filter operators.\n\n- **Examples**:\n\n  - :val:`\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n  - :val:`\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
-            "description": "Date and time representing when the entry was last modified.\n- **Type**: timestamp.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n\n- **Example**:\n\n  - As part of JSON response format: :VAL:`\"2007-04-05T14:30Z\"`\n    (i.e., encoded as an `RFC 3339 Internet Date/Time Format <https://tools.ietf.org/html/rfc3339#section-5.6>`__ string.)",
+            "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
             "format": "date-time"
           }
         },
         "description": "Contains key-value pairs representing the entry's properties."
+      },
+      "Error": {
+        "title": "Error",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          }
+        },
+        "description": "An error response"
       },
       "ErrorLinks": {
         "title": "ErrorLinks",
@@ -1204,6 +1430,7 @@
         "properties": {
           "data": {
             "title": "Data",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "allOf": [
@@ -1216,21 +1443,28 @@
                 "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/Resource"
-                },
-                "uniqueItems": true
+                }
               }
             ],
             "description": "Outputted Data"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
+            "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__optimade_json__Error"
-            }
+              "$ref": "#/components/schemas/OptimadeError"
+            },
+            "description": "A list of OPTIMADE-specific JSON API error objects, where the field detail MUST be present."
           },
           "included": {
             "title": "Included",
@@ -1239,7 +1473,7 @@
             "items": {
               "$ref": "#/components/schemas/Resource"
             },
-            "description": "A list of resources that are included"
+            "description": "A list of unique included resources"
           },
           "links": {
             "title": "Links",
@@ -1248,7 +1482,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -1350,19 +1584,31 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/BaseInfoResource"
+            "title": "Data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseInfoResource"
+              }
+            ],
+            "description": "The implementations /info data"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+              "$ref": "#/components/schemas/Error"
             },
-            "description": "A list of errors"
+            "description": "A list of unique errors"
           },
           "included": {
             "title": "Included",
@@ -1371,7 +1617,7 @@
             "items": {
               "$ref": "#/components/schemas/Resource"
             },
-            "description": "A list of resources that are included"
+            "description": "A list of unique included resources"
           },
           "links": {
             "title": "Links",
@@ -1380,7 +1626,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -1447,7 +1693,6 @@
         "title": "LinksResource",
         "required": [
           "id",
-          "type",
           "attributes"
         ],
         "type": "object",
@@ -1455,12 +1700,12 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section `Definition of Terms`_.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - See section `Definition of Terms`_.\n\n- **Examples**:\n\n  - :val:`\"db/1234567\"`\n  - :val:`\"cod/2000000\"`\n  - :val:`\"cod/2000000@1234567\"`\n  - :val:`\"nomad/L1234567890\"`\n  - :val:`\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
           },
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "MUST be either \"parent\", \"child\", or \"provider\". These objects are described in detail in sections Parent and Child Objects and Provider Objects."
+            "description": "These objects are described in detail in the section Links Endpoint"
           },
           "links": {
             "title": "Links",
@@ -1487,7 +1732,7 @@
                 "$ref": "#/components/schemas/LinksResourceAttributes"
               }
             ],
-            "description": "a dictionary containing key-value pairs representing the entry's properties."
+            "description": "A dictionary containing key-value pairs representing the Links resource's properties."
           },
           "relationships": {
             "title": "Relationships",
@@ -1496,7 +1741,7 @@
                 "$ref": "#/components/schemas/EntryRelationships"
               }
             ],
-            "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
         "description": "A Links endpoint resource object"
@@ -1507,19 +1752,20 @@
           "name",
           "description",
           "base_url",
-          "homepage"
+          "homepage",
+          "link_type"
         ],
         "type": "object",
         "properties": {
           "name": {
             "title": "Name",
             "type": "string",
-            "description": "Human-readable name for the OPTIMADE API implementation a client may provide in a list to an end-user."
+            "description": "Human-readable name for the OPTIMADE API implementation, e.g., for use in clients to show the name to the end-user."
           },
           "description": {
             "title": "Description",
             "type": "string",
-            "description": "Human-readable description for the OPTIMADE API implementation a client may provide in a list to an end-user."
+            "description": "Human-readable description for the OPTIMADE API implementation, e.g., for use in clients to show a description to the end-user."
           },
           "base_url": {
             "title": "Base Url",
@@ -1558,6 +1804,32 @@
               }
             ],
             "description": "JSON API links object, pointing to a homepage URL for this implementation"
+          },
+          "link_type": {
+            "title": "Link Type",
+            "enum": [
+              "child",
+              "root",
+              "external",
+              "providers"
+            ],
+            "description": "The type of the linked relation.\nMUST be one of these values: 'child', 'root', 'external', 'providers'."
+          },
+          "aggregate": {
+            "title": "Aggregate",
+            "enum": [
+              "ok",
+              "test",
+              "staging",
+              "no"
+            ],
+            "description": "A string indicating whether a client that is following links to aggregate results from different OPTIMADE implementations should follow this link or not.\nThis flag SHOULD NOT be indicated for links where `link_type` is not `child`.\n\nIf not specified, clients MAY assume that the value is `ok`.\nIf specified, and the value is anything different than `ok`, the client MUST assume that the server is suggesting not to follow the link during aggregation by default (also if the value is not among the known ones, in case a future specification adds new accepted values).\n\nSpecific values indicate the reason why the server is providing the suggestion.\nA client MAY follow the link anyway if it has reason to do so (e.g., if the client is looking for all test databases, it MAY follow the links marked with `aggregate`=`test`).\n\nIf specified, it MUST be one of the values listed in section Link Aggregate Options.",
+            "default": "ok"
+          },
+          "no_aggregate_reason": {
+            "title": "No Aggregate Reason",
+            "type": "string",
+            "description": "An OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link.\nIt SHOULD NOT be present if `aggregate`=`ok`."
           }
         },
         "description": "Links endpoint resource object attributes"
@@ -1571,6 +1843,7 @@
         "properties": {
           "data": {
             "title": "Data",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "type": "array",
@@ -1584,22 +1857,30 @@
                   "type": "object"
                 }
               }
-            ]
+            ],
+            "description": "List of unique OPTIMADE links resource objects"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+              "$ref": "#/components/schemas/Error"
             },
-            "description": "A list of errors"
+            "description": "A list of unique errors"
           },
           "included": {
             "title": "Included",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "type": "array",
@@ -1622,7 +1903,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -1641,6 +1922,68 @@
         "type": "object",
         "properties": {},
         "description": "Non-standard meta-information that can not be represented as an attribute or relationship."
+      },
+      "OptimadeError": {
+        "title": "OptimadeError",
+        "required": [
+          "detail"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          }
+        },
+        "description": "detail MUST be present"
       },
       "Person": {
         "title": "Person",
@@ -1745,6 +2088,7 @@
           },
           "data": {
             "title": "Data",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "allOf": [
@@ -1785,12 +2129,12 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section `Definition of Terms`_.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - See section `Definition of Terms`_.\n\n- **Examples**:\n\n  - :val:`\"db/1234567\"`\n  - :val:`\"cod/2000000\"`\n  - :val:`\"cod/2000000@1234567\"`\n  - :val:`\"nomad/L1234567890\"`\n  - :val:`\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
           },
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "The name of the type of an entry. Any entry MUST be able to be fetched using the `base URL <Base URL_>`_ type and ID at the url :endpoint:`<base URL>/<type>/<id>`.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: Support for queries on this property is OPTIONAL.\n    If supported, only a subset of string comparison operators MAY be supported.\n\n- **Requirements/Conventions**: MUST be an existing entry type.\n- **Example**: :val:`\"structures\"`"
+            "description": "The name of the type of an entry.\n- **Type**: string.\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n- **Example**: `\"structures\"`"
           },
           "links": {
             "title": "Links",
@@ -1820,10 +2164,10 @@
                 "$ref": "#/components/schemas/EntryRelationships"
               }
             ],
-            "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
-        "description": "The :entry:`references` entries describe bibliographic references.\nThe following properties are used to provide the bibliographic details:\n\n- **address**, **annote**, **booktitle**, **chapter**, **crossref**, **edition**, **howpublished**, **institution**, **journal**, **key**, **month**,\n  **note**, **number**, **organization**, **pages**, **publisher**, **school**, **series**, **title**, **type**, **volume**, **year**:\n  Meanings of these properties match the `BibTeX specification <http://bibtexml.sourceforge.net/btxdoc.pdf>`__, values are strings;\n\n- **authors** and **editors**: lists of *person objects* which are dictionaries with the following keys:\n\n  - **name**: Full name of the person, REQUIRED.\n  - **firstname**, **lastname**: Parts of the person's name, OPTIONAL.\n\n- **doi** and **url**: values are strings.\n\n- **Requirements/Conventions**:\n\n  - **Response**: Every references entry MUST contain at least one of the properties.\n  - **Query**: Support for queries on any of these properties is OPTIONAL.\n    If supported, filters MAY support only a subset of comparison operators. "
+        "description": "The `references` entries describe bibliographic references.\nThe following properties are used to provide the bibliographic details:\n\n- **address**, **annote**, **booktitle**, **chapter**, **crossref**, **edition**, **howpublished**, **institution**, **journal**, **key**, **month**, **note**, **number**, **organization**, **pages**, **publisher**, **school**, **series**, **title**, **volume**, **year**: meanings of these properties match the [BibTeX specification](http://bibtexml.sourceforge.net/btxdoc.pdf), values are strings;\n- **bib_type**: type of the reference, corresponding to **type** property in the BibTeX specification, value is string;\n- **authors** and **editors**: lists of *person objects* which are dictionaries with the following keys:\n    - **name**: Full name of the person, REQUIRED.\n    - **firstname**, **lastname**: Parts of the person's name, OPTIONAL.\n- **doi** and **url**: values are strings.\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., any of the properties MAY be `null`.\n    - **Query**: Support for queries on any of these properties is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - Every references entry MUST contain at least one of the properties.\n\n    "
       },
       "ReferenceResourceAttributes": {
         "title": "ReferenceResourceAttributes",
@@ -1835,12 +2179,12 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID).\nThis is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants.\nThis ID maps to the version-specific record, in case it changes in the future.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: OPTIONAL in the response.\n  - **Query**: If present, MUST be a queryable property with support for all mandatory filter operators.\n\n- **Examples**:\n\n  - :val:`\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n  - :val:`\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
-            "description": "Date and time representing when the entry was last modified.\n- **Type**: timestamp.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n\n- **Example**:\n\n  - As part of JSON response format: :VAL:`\"2007-04-05T14:30Z\"`\n    (i.e., encoded as an `RFC 3339 Internet Date/Time Format <https://tools.ietf.org/html/rfc3339#section-5.6>`__ string.)",
+            "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
             "format": "date-time"
           },
           "authors": {
@@ -1994,6 +2338,7 @@
         "properties": {
           "data": {
             "title": "Data",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "type": "array",
@@ -2007,22 +2352,30 @@
                   "type": "object"
                 }
               }
-            ]
+            ],
+            "description": "List of unique OPTIMADE references entry resource objects"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+              "$ref": "#/components/schemas/Error"
             },
-            "description": "A list of errors"
+            "description": "A list of unique errors"
           },
           "included": {
             "title": "Included",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "type": "array",
@@ -2045,7 +2398,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -2070,27 +2423,39 @@
             "title": "Data",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ReferenceResource"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ReferenceResource"
+                  }
+                ]
               },
               {
                 "type": "object"
               }
-            ]
+            ],
+            "description": "A single references entry resource"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+              "$ref": "#/components/schemas/Error"
             },
-            "description": "A list of errors"
+            "description": "A list of unique errors"
           },
           "included": {
             "title": "Included",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "type": "array",
@@ -2113,7 +2478,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -2148,7 +2513,7 @@
                 ]
               }
             ],
-            "description": "A link to itself"
+            "description": "A link for the relationship itself (a 'relationship link').\nThis link allows the client to directly manipulate the relationship.\nWhen fetched successfully, this link returns the [linkage](https://jsonapi.org/format/1.0/#document-resource-object-linkage) for the related resources as its primary data.\n(See [Fetching Relationships](https://jsonapi.org/format/1.0/#fetching-relationships).)"
           },
           "related": {
             "title": "Related",
@@ -2167,10 +2532,10 @@
                 ]
               }
             ],
-            "description": "A related resource link"
+            "description": "A [related resource link](https://jsonapi.org/format/1.0/#document-resource-object-related-resource-links)."
           }
         },
-        "description": "A resource object **MAY** contain references to other resource objects (\"relationships\").\nRelationships may be to-one or to-many. Relationships can be specified by including a member in a resource's links object."
+        "description": "A resource object **MAY** contain references to other resource objects (\"relationships\").\nRelationships may be to-one or to-many.\nRelationships can be specified by including a member in a resource's links object."
       },
       "Relationships": {
         "title": "Relationships",
@@ -2230,10 +2595,10 @@
                 "$ref": "#/components/schemas/Relationships"
               }
             ],
-            "description": "a relationships object describing relationships between the resource and other JSON:API resources."
+            "description": "[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)\ndescribing relationships between the resource and other JSON API resources."
           }
         },
-        "description": "Resource objects appear in a JSON:API document to represent resources."
+        "description": "Resource objects appear in a JSON API document to represent resources."
       },
       "ResourceLinks": {
         "title": "ResourceLinks",
@@ -2280,29 +2645,29 @@
                 "$ref": "#/components/schemas/ResponseMetaQuery"
               }
             ],
-            "description": "information on the query that was requested"
+            "description": "Information on the Query that was requested"
           },
           "api_version": {
             "title": "Api Version",
             "type": "string",
-            "description": "a string containing the version of the API implementation, e.g. v0.9.5"
+            "description": "A string containing the version of the API implementation."
           },
           "time_stamp": {
             "title": "Time Stamp",
             "type": "string",
-            "description": "a string containing the date and time at which the query was exexcuted",
+            "description": "A timestamp containing the date and time at which the query was executed.",
             "format": "date-time"
           },
           "data_returned": {
             "title": "Data Returned",
             "minimum": 0.0,
             "type": "integer",
-            "description": "an integer containing the number of data objects returned for the query."
+            "description": "An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination."
           },
           "more_data_available": {
             "title": "More Data Available",
             "type": "boolean",
-            "description": "`false` if all data has been returned, and `true` if not."
+            "description": "`false` if all data resource objects for this `filter` query have been returned in the response or if it is the last page of a paginated response, and `true` otherwise."
           },
           "provider": {
             "title": "Provider",
@@ -2316,7 +2681,7 @@
           "data_available": {
             "title": "Data Available",
             "type": "integer",
-            "description": "an integer containing the total number of data objects available in the database"
+            "description": "An integer containing the total number of data resource objects available in the database for the endpoint."
           },
           "last_id": {
             "title": "Last Id",
@@ -2339,11 +2704,12 @@
           },
           "warnings": {
             "title": "Warnings",
+            "uniqueItems": true,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Warnings"
             },
-            "description": "List of warning resource objects representing non-critical errors or warnings. A warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\". The field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features. The field status, representing a HTTP response status code, MUST NOT be present for a warning resource object. This is an exclusive field for error resource objects."
+            "description": "A list of warning resource objects representing non-critical errors or warnings.\nA warning resource object is defined similarly to a [JSON API error object](http://jsonapi.org/format/1.0/#error-objects), but MUST also include the field `type`, which MUST have the value `\"warning\"`.\nThe field `detail` MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\nThe field `status`, representing a HTTP response status code, MUST NOT be present for a warning resource object.\nThis is an exclusive field for error resource objects."
           }
         },
         "description": "A [JSON API meta member](https://jsonapi.org/format/1.0#document-meta)\nthat contains JSON API meta objects of non-standard\nmeta-information.\n\nOPTIONAL additional information global to the query that is not\nspecified in this document, MUST start with a\ndatabase-provider-specific prefix."
@@ -2382,7 +2748,7 @@
             "items": {
               "type": "string"
             },
-            "description": "MUST be a list of strings of all chemical elements composing this species.\n\n- It MUST be one of the following:\n\n  - a valid chemical-element name, or\n  - the special value :val:`\"X\"` to represent a non-chemical element, or\n  - the special value :val:`\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the :property:`concentration` list, see below).\n\n-  If any one entry in the :property:`species` list has a :property:`chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list :property:`structure_features` (see property `structure_features`_)."
+            "description": "MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:\n\n- a valid chemical-element name, or\n- the special value `\"X\"` to represent a non-chemical element, or\n- the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\nIf any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`."
           },
           "concentration": {
             "title": "Concentration",
@@ -2390,7 +2756,7 @@
             "items": {
               "type": "number"
             },
-            "description": "MUST be a list of floats, with same length as :property:`chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species.\nThe numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n  - Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations :val:`1/3` and :val:`2/3`, the concentration might look something like :val:`[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n  - Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\nNote that concentrations are uncorrelated between different site (even of the same species)."
+            "description": "MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n- Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n- Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\nNote that concentrations are uncorrelated between different site (even of the same species)."
           },
           "mass": {
             "title": "Mass",
@@ -2400,10 +2766,26 @@
           "original_name": {
             "title": "Original Name",
             "type": "string",
-            "description": "Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\nNote: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.\nThe main use of this field is for source databases that use species names, containing characters that are not allowed (see description of the list property `species_at_sites`_)."
+            "description": "Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\nNote: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation."
+          },
+          "attached": {
+            "title": "Attached",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element."
+          },
+          "nattached": {
+            "title": "Nattached",
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key."
           }
         },
-        "description": "A list describing the species of the sites of this structure.\nSpecies can be pure chemical elements, or virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements.\n\n- **Examples**:\n\n    - :val:`[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - :val:`[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - :val:`[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": 88.5} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - :val:`[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": 12.0} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - :val:`[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": 13.0} ]`: any site with this species is occupied by a carbon isotope with mass 13."
+        "description": "A list describing the species of the sites of this structure.\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a\nstatistical occupation of a given site by multiple chemical elements, and/or a\nlocation to which there are attached atoms, i.e., atoms whose precise location are\nunknown beyond that they are attached to that position (frequently used to indicate\nhydrogen atoms attached to another element, e.g., a carbon with three attached\nhydrogens might represent a methyl group, -CH3).\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": 88.5} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": 12.0} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": 13.0} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.\n\n    "
       },
       "StructureRelationship": {
         "title": "StructureRelationship",
@@ -2420,6 +2802,7 @@
           },
           "data": {
             "title": "Data",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "allOf": [
@@ -2460,12 +2843,12 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section `Definition of Terms`_.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - See section `Definition of Terms`_.\n\n- **Examples**:\n\n  - :val:`\"db/1234567\"`\n  - :val:`\"cod/2000000\"`\n  - :val:`\"cod/2000000@1234567\"`\n  - :val:`\"nomad/L1234567890\"`\n  - :val:`\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
           },
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "The name of the type of an entry. Any entry MUST be able to be fetched using the `base URL <Base URL_>`_ type and ID at the url :endpoint:`<base URL>/<type>/<id>`.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: Support for queries on this property is OPTIONAL.\n    If supported, only a subset of string comparison operators MAY be supported.\n\n- **Requirements/Conventions**: MUST be an existing entry type.\n- **Example**: :val:`\"structures\"`"
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Examples**:\n    - `\"structures\"`"
           },
           "links": {
             "title": "Links",
@@ -2495,7 +2878,7 @@
                 "$ref": "#/components/schemas/EntryRelationships"
               }
             ],
-            "description": "a dictionary containing references to other entries according to the description in section `Relationships`_\nencoded as `JSON API Relationships <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__.\nThe OPTIONAL human-readable description of the relationship MAY be provided in the :field:`description` field inside the :field:`meta` dictionary."
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
           }
         },
         "description": "Representing a structure."
@@ -2513,8 +2896,8 @@
           "dimension_types",
           "cartesian_site_positions",
           "nsites",
-          "species_at_sites",
           "species",
+          "species_at_sites",
           "structure_features"
         ],
         "type": "object",
@@ -2522,12 +2905,12 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID).\nThis is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants.\nThis ID maps to the version-specific record, in case it changes in the future.\n- **Type**: string.\n- **Requirements/Conventions**:\n\n  - **Response**: OPTIONAL in the response.\n  - **Query**: If present, MUST be a queryable property with support for all mandatory filter operators.\n\n- **Examples**:\n\n  - :val:`\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n  - :val:`\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
-            "description": "Date and time representing when the entry was last modified.\n- **Type**: timestamp.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n\n- **Example**:\n\n  - As part of JSON response format: :VAL:`\"2007-04-05T14:30Z\"`\n    (i.e., encoded as an `RFC 3339 Internet Date/Time Format <https://tools.ietf.org/html/rfc3339#section-5.6>`__ string.)",
+            "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
             "format": "date-time"
           },
           "elements": {
@@ -2536,12 +2919,12 @@
             "items": {
               "type": "string"
             },
-            "description": "Names of the different elements present in the structure.\n- **Type**: list of strings.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - The strings are the chemical symbols, written as uppercase letter plus optional lowercase letters.\n  - The order MUST be alphabetical.\n  - Note: This may not contain the \"x\" that is suggested in chemical_symbols for the :property:`species` property.\n\n- **Examples**:\n\n  - :val:`[\"Si\"]`\n  - :val:`[\"Al\",\"O\",\"Si\"]`\n\n- **Query examples**:\n  - A filter that matches all records of structures that contain Si, Al **and** O, and possibly other elements: :filter:`elements HAS ALL \"Si\", \"Al\", \"O\"`.\n  - To match structures with exactly these three elements, use :filter:`elements HAS ALL \"Si\", \"Al\", \"O\" AND LENGTH elements = 3`."
+            "description": "Names of the different elements present in the structure.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The strings are the chemical symbols, i.e., either a single uppercase letter or an uppercase letter followed by a number of lowercase letters.\n    - The order MUST be alphabetical.\n    - Note: This property SHOULD NOT contain the string \"X\" to indicate non-chemical elements or \"vacancy\" to indicate vacancies (in contrast to the field `chemical_symbols` for the `species` property).\n\n- **Examples**:\n    - `[\"Si\"]`\n    - `[\"Al\",\"O\",\"Si\"]`\n\n- **Query examples**:\n    - A filter that matches all records of structures that contain Si, Al **and** O, and possibly other elements: `elements HAS ALL \"Si\", \"Al\", \"O\"`.\n    - To match structures with exactly these three elements, use `elements HAS ALL \"Si\", \"Al\", \"O\" AND elements LENGTH 3`."
           },
           "nelements": {
             "title": "Nelements",
             "type": "integer",
-            "description": "Number of different elements in the structure as an integer.\n- **Type**: integer\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n\n- **Example**: :val:`3`\n- **Querying**:\n\n  -  Note: queries on this property can equivalently be formulated using :filter-fragment:`LENGTH elements`.\n  -  A filter that matches structures that have exactly 4 elements: :filter:`nelements=4`.\n  -  A filter that matches structures that have between 2 and 7 elements: :filter:`nelements>=2 AND nelements<=7`."
+            "description": "Number of different elements in the structure as an integer.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `3`\n\n- **Querying**:\n    - Note: queries on this property can equivalently be formulated using `elements LENGTH`.\n    - A filter that matches structures that have exactly 4 elements: `nelements=4`.\n    - A filter that matches structures that have between 2 and 7 elements: `nelements>=2 AND nelements<=7`."
           },
           "elements_ratios": {
             "title": "Elements Ratios",
@@ -2549,64 +2932,133 @@
             "items": {
               "type": "number"
             },
-            "description": "Relative proportions of different elements in the structure.\n- **Type**: list of floats\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - Composed by the proportions of elements in the structure as a list of floating point numbers.\n  - The sum of the numbers MUST be 1.0 (within floating point accuracy)\n\n- **Examples**:\n\n  - :val:`[1.0]`\n  - :val:`[0.3333333333333333, 0.2222222222222222, 0.4444444444444444]`\n\n- **Query examples**:\n\n  - Note: useful filters can be formulated using the set operator syntax for correlated values. However, since the values are floating point values, the use of equality comparisons is generally not recommended.\n  - A filter that matches structures where approximately 1/3 of the atoms in the structure are the element Al is: :filter:`elements:elements_ratios HAS ALL \"Al\":>0.3333, \"Al\":<0.3334`."
+            "description": "Relative proportions of different elements in the structure.\n\n- **Type**: list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - Composed by the proportions of elements in the structure as a list of floating point numbers.\n    - The sum of the numbers MUST be 1.0 (within floating point accuracy)\n\n- **Examples**:\n    - `[1.0]`\n    - `[0.3333333333333333, 0.2222222222222222, 0.4444444444444444]`\n\n- **Query examples**:\n    - Note: Useful filters can be formulated using the set operator syntax for correlated values.\n      However, since the values are floating point values, the use of equality comparisons is generally inadvisable.\n    - OPTIONAL: a filter that matches structures where approximately 1/3 of the atoms in the structure are the element Al is: `elements:elements_ratios HAS ALL \"Al\":>0.3333, \"Al\":<0.3334`."
           },
           "chemical_formula_descriptive": {
             "title": "Chemical Formula Descriptive",
             "type": "string",
-            "description": "The chemical formula for a structure as a string in a form chosen by the API implementation.\n- **Type**: string\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n  - The chemical formula is given as a string consisting of properly capitalized element symbols followed by integers or decimal numbers, balanced parentheses, square, and curly brackets ``(``, ``)``, ``[``, ``]``, ``{``, ``}``, commas, the ``+``, ``-``, ``:`` and ``=`` symbols.\n    The parentheses are allowed to be followed by a number.\n    Spaces are allowed anywhere except within chemical symbols.\n    The order of elements and any groupings indicated by parentheses or brackets are chosen freely by the API implementation.\n  - The string SHOULD be arithmetically consistent with the element ratios in the :property:`chemical_formula_reduced` property.\n  - It is RECOMMENDED, but not mandatory, that symbols, parentheses and brackets, if used, are used with the meanings prescribed by `IUPAC's Nomenclature of Organic Chemistry <https://www.qmul.ac.uk/sbcs/iupac/bibliog/blue.html>`__.\n\n- **Examples**:\n\n  - :val:`\"(H2O)2 Na\"`\n  - :val:`\"NaCl\"`\n  - :val:`\"CaCO3\"`\n  - :val:`\"CCaO3\"`\n  - :val:`\"(CH3)3N+ - [CH2]2-OH = Me3N+ - CH2 - CH2OH\"`\n\n- **Query examples**:\n\n  - Note: the free-form nature of this property is likely to make queries on it across different databases inconsistent.\n  - A filter that matches an exactly given formula: :filter:`chemical_formula_descriptive=\"(H2O)2 Na\"`.\n  - A filter that does a partial match: :filter:`chemical_formula_descriptive CONTAINS \"H2O\"`."
+            "description": "The chemical formula for a structure as a string in a form chosen by the API implementation.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The chemical formula is given as a string consisting of properly capitalized element symbols followed by integers or decimal numbers, balanced parentheses, square, and curly brackets `(`,`)`, `[`,`]`, `{`, `}`, commas, the `+`, `-`, `:` and `=` symbols. The parentheses are allowed to be followed by a number. Spaces are allowed anywhere except within chemical symbols. The order of elements and any groupings indicated by parentheses or brackets are chosen freely by the API implementation.\n    - The string SHOULD be arithmetically consistent with the element ratios in the `chemical_formula_reduced` property.\n    - It is RECOMMENDED, but not mandatory, that symbols, parentheses and brackets, if used, are used with the meanings prescribed by [IUPAC's Nomenclature of Organic Chemistry](https://www.qmul.ac.uk/sbcs/iupac/bibliog/blue.html).\n\n- **Examples**:\n    - `\"(H2O)2 Na\"`\n    - `\"NaCl\"`\n    - `\"CaCO3\"`\n    - `\"CCaO3\"`\n    - `\"(CH3)3N+ - [CH2]2-OH = Me3N+ - CH2 - CH2OH\"`\n\n- **Query examples**:\n    - Note: the free-form nature of this property is likely to make queries on it across different databases inconsistent.\n    - A filter that matches an exactly given formula: `chemical_formula_descriptive=\"(H2O)2 Na\"`.\n    - A filter that does a partial match: `chemical_formula_descriptive CONTAINS \"H2O\"`."
           },
           "chemical_formula_reduced": {
             "title": "Chemical Formula Reduced",
             "type": "string",
-            "description": "The reduced chemical formula for a structure as a string with element symbols and integer chemical proportion numbers.\n  The proportion number MUST be omitted if it is 1.\n- **Type**: string\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n\n  - **Query**: MUST be a queryable property.\n    However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n    Intricate querying on formula components are instead recommended to be formulated using set-type filter operators on the multi valued :property:`elements` and :property:`elements_proportions` properties.\n  - Element names MUST have proper capitalization (e.g., :val:`\"Si\"`, not :VAL:`\"SI\"` for \"silicon\").\n  - Elements MUST be placed in alphabetical order, followed by their integer chemical proportion number.\n  - For structures with no partial occupation, the chemical proportion numbers are the smallest integers for which the chemical proportion is exactly correct.\n  - For structures with partial occupation, the chemical proportion numbers are integers that within reasonable approximation indicate the correct chemical proportions. The precise details of how to perform the rounding is chosen by the API implementation.\n  - No spaces or separators are allowed.\n\n- **Examples**:\n\n  - :val:`\"H2NaO\"`\n  - :val:`\"ClNa\"`\n  - :val:`\"CCaO3\"`\n\n- **Query examples**:\n\n  - A filter that matches an exactly given formula is :filter:`chemical_formula_reduced=\"H2NaO\"`."
+            "description": "The reduced chemical formula for a structure as a string with element symbols and integer chemical proportion numbers.\nThe proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n      Intricate queries on formula components are instead suggested to be formulated using set-type filter operators on the multi valued `elements` and `elements_ratios` properties.\n    - Element names MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in alphabetical order, followed by their integer chemical proportion number.\n    - For structures with no partial occupation, the chemical proportion numbers are the smallest integers for which the chemical proportion is exactly correct.\n    - For structures with partial occupation, the chemical proportion numbers are integers that within reasonable approximation indicate the correct chemical proportions. The precise details of how to perform the rounding is chosen by the API implementation.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2NaO\"`\n    - `\"ClNa\"`\n    - `\"CCaO3\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_reduced=\"H2NaO\"`."
           },
           "chemical_formula_hill": {
             "title": "Chemical Formula Hill",
             "type": "string",
-            "description": "The chemical formula for a structure in `Hill form <https://dx.doi.org/10.1021/ja02046a005>`__ with element symbols followed by integer chemical proportion numbers.\n  The proportion number MUST be omitted if it is 1.\n- **Type**: string\n- **Requirements/Conventions**:\n\n  - **Response**: OPTIONAL in the response.\n  - **Query**: Support for queries on these properties are OPTIONAL. If supported, only a subset of filter operators MAY be supported.\n  - The overall scale factor of the chemical proportions is chosen such that the resulting values are integers that indicate the most chemically relevant unit of which the system is composed.\n    For example, if the structure is a repeating unit cell with four hydrogens and four oxygens that represents two hydroperoxide molecules, :property:`chemical_formula_hill` is :val:`\"H2O2\"` (i.e., not :val:`\"HO\"`, nor :val:`\"H4O4\"`).\n  - If the chemical insight needed to ascribe a Hill formula to the system is not present, the property MUST be handled as unset.\n  - Element names MUST have proper capitalization (e.g., :val:`\"Si\"`, not :VAL:`\"SI\"` for \"silicon\").\n  - Elements MUST be placed in `Hill order <https://dx.doi.org/10.1021/ja02046a005>`__, followed by their integer chemical proportion number.\n    Hill order means: if carbon is present, it is placed first, and if also present, hydrogen is placed second.\n    After that, all other elements are ordered alphabetically.\n    If carbon is not present, all elements are ordered alphabetically.\n  - If the system has sites with partial occupation and the total occupations of each element do not all sum up to integers, then the Hill formula SHOULD be handled as unset.\n  - No spaces or separators are allowed.\n\n- **Examples**:\n  - :val:`\"H2O2\"`\n\n- **Query examples**:\n\n  - A filter that matches an exactly given formula is :filter:`chemical_formula_hill=\"H2O2\"`."
+            "description": "The chemical formula for a structure in [Hill form](https://dx.doi.org/10.1021/ja02046a005) with element symbols followed by integer chemical proportion numbers. The proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, only a subset of the filter features MAY be supported.\n    - The overall scale factor of the chemical proportions is chosen such that the resulting values are integers that indicate the most chemically relevant unit of which the system is composed.\n      For example, if the structure is a repeating unit cell with four hydrogens and four oxygens that represents two hydroperoxide molecules, `chemical_formula_hill` is `\"H2O2\"` (i.e., not `\"HO\"`, nor `\"H4O4\"`).\n    - If the chemical insight needed to ascribe a Hill formula to the system is not present, the property MUST be handled as unset.\n    - Element names MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in [Hill order](https://dx.doi.org/10.1021/ja02046a005), followed by their integer chemical proportion number.\n      Hill order means: if carbon is present, it is placed first, and if also present, hydrogen is placed second.\n      After that, all other elements are ordered alphabetically.\n      If carbon is not present, all elements are ordered alphabetically.\n    - If the system has sites with partial occupation and the total occupations of each element do not all sum up to integers, then the Hill formula SHOULD be handled as unset.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2O2\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_hill=\"H2O2\"`."
           },
           "chemical_formula_anonymous": {
             "title": "Chemical Formula Anonymous",
             "type": "string",
-            "description": "The anonymous formula is the :property:`chemical_formula_reduced`, but where the elements are instead first ordered by their chemical proportion number, and then, in order left to right, replaced by anonymous symbols A, B, C, ..., Z, Aa, Ba, ..., Za, Ab, Bb, ... and so on.\n- **Type**: string\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property. However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n\n- **Examples**:\n\n  - :val:`\"A2B\"`\n  - :val:`\"A42B42C16D12E10F9G5\"`\n\n- **Querying**:\n  - A filter that matches an exactly given formula is :filter:`chemical_formula_anonymous=\"A2B\"`."
+            "description": "The anonymous formula is the `chemical_formula_reduced`, but where the elements are instead first ordered by their chemical proportion number, and then, in order left to right, replaced by anonymous symbols A, B, C, ..., Z, Aa, Ba, ..., Za, Ab, Bb, ... and so on.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n\n- **Examples**:\n    - `\"A2B\"`\n    - `\"A42B42C16D12E10F9G5\"`\n\n- **Querying**:\n    - A filter that matches an exactly given formula is `chemical_formula_anonymous=\"A2B\"`."
           },
           "dimension_types": {
             "title": "Dimension Types",
             "type": "array",
-            "items": {},
-            "description": "List of three integers.\n  For each of the three directions indicated by the three lattice vectors (see property `lattice_vectors`_).\n  This list indicates if the direction is periodic (value :val:`1`) or non-periodic (value :val:`0`).\n  Note: the elements in this list each refer to the direction of the corresponding entry in property `lattice_vectors`_ and *not* the Cartesian x, y, z directions.\n- **Type**: list of integers.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property. Support for equality comparison is REQUIRED, support for other comparison operators are OPTIONAL.\n  - MUST be a list of length 3.\n  - Each integer element MUST assume only the value 0 or 1.\n\n- **Examples**:\n\n  - For a molecule: :val:`[0, 0, 0]`\n  - For a wire along the direction specified by the third lattice vector: :val:`[0, 0, 1]`\n  - For a 2D surface/slab, periodic on the plane defined by the first and third lattice vectors: :val:`[1, 0, 1]`\n  - For a bulk 3D system: :val:`[1, 1, 1]`"
+            "items": [
+              {
+                "enum": [
+                  0,
+                  1
+                ],
+                "type": "integer"
+              },
+              {
+                "enum": [
+                  0,
+                  1
+                ],
+                "type": "integer"
+              },
+              {
+                "enum": [
+                  0,
+                  1
+                ],
+                "type": "integer"
+              }
+            ],
+            "description": "List of three integers.\nFor each of the three directions indicated by the three lattice vectors (see property `lattice_vectors`), this list indicates if the direction is periodic (value `1`) or non-periodic (value `0`).\nNote: the elements in this list each refer to the direction of the corresponding entry in `lattice_vectors` and *not* the Cartesian x, y, z directions.\n\n- **Type**: list of integers.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n    - MUST be a list of length 3.\n    - Each integer element MUST assume only the value 0 or 1.\n\n- **Examples**:\n    - For a molecule: `[0, 0, 0]`\n    - For a wire along the direction specified by the third lattice vector: `[0, 0, 1]`\n    - For a 2D surface/slab, periodic on the plane defined by the first and third lattice vectors: `[1, 0, 1]`\n    - For a bulk 3D system: `[1, 1, 1]`"
+          },
+          "nperiodic_dimensions": {
+            "title": "Nperiodic Dimensions",
+            "type": "integer",
+            "description": "An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in `dimension_types`.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The integer value MUST be between 0 and 3 inclusive and MUST be equal to the sum of the items in the `dimension_types` property.\n    - This property only reflects the treatment of the lattice vectors provided for the structure, and not any physical interpretation of the dimensionality of its contents.\n\n- **Examples**:\n    - `2` should be indicated in cases where `dimension_types` is any of `[1, 1, 0]`, `[1, 0, 1]`, `[0, 1, 1]`.\n\n- **Query examples**:\n    - Match only structures with exactly 3 periodic dimensions: `nperiodic_dimensions=3`\n    - Match all structures with 2 or fewer periodic dimensions: `nperiodic_dimensions<=2`"
           },
           "lattice_vectors": {
             "title": "Lattice Vectors",
             "type": "array",
-            "items": {
-              "type": "array",
-              "items": {}
-            },
-            "description": "The three lattice vectors in Cartesian coordinates, in \u00e5ngstr\u00f6m (\u00c5).\n- **Type**: list of list of floats.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded, except when property `dimension_types`_ is equal to :val:`[0, 0, 0]` (in this case it is OPTIONAL).\n  - **Query**: Support for queries on this property is OPTIONAL. If supported, filters MAY support only a subset of comparison operators.\n  - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.\n    (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).\n  - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.\n  - This property MUST be an array of dimensions 3 times 3 regardless of the elements of property `dimension_types`_. The vectors SHOULD by convention be chosen so the determinant of the :property:`lattice_vectors` matrix is different from zero. The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.\n\n- **Examples**:\n\n  - :val:`[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is :val:`(4, 0, 0)`, i.e., a vector aligned along the :val:`x` axis of length 4 \u00c5; the second vector is :val:`(0, 4, 0)`; and the third vector is :val:`(0, 1, 4)`."
+            "items": [
+              {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            ],
+            "description": "The three lattice vectors in Cartesian coordinates, in \u00e5ngstr\u00f6m (\u00c5).\n\n- **Type**: list of list of floats or unknown values.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.\n      (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).\n    - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.\n    - MUST always contain three vectors of three coordinates each, independently of the elements of property `dimension_types`.\n      The vectors SHOULD by convention be chosen so the determinant of the `lattice_vectors` matrix is different from zero.\n      The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.\n    - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which `dimension_types` is `0`) MAY be given as a list of all `null` values.\n        If a lattice vector contains the value `null`, all coordinates of that lattice vector MUST be `null`.\n\n- **Examples**:\n    - `[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is `(4, 0, 0)`, i.e., a vector aligned along the `x` axis of length 4 \u00c5; the second vector is `(0, 4, 0)`; and the third vector is `(0, 1, 4)`."
           },
           "cartesian_site_positions": {
             "title": "Cartesian Site Positions",
             "type": "array",
             "items": {
               "type": "array",
-              "items": {}
+              "items": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ]
             },
-            "description": "Cartesian positions of each site. A site is an atom, a site potentially occupied by an atom, or a placeholder for a virtual mixture of atoms (e.g., in a virtual crystal approximation).\n- **Type**: list of list of floats and/or unknown values\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: Support for queries on this property is OPTIONAL. If supported, filters MAY support only a subset of comparison operators.\n  - It MUST be a list of length N times 3, where N is the number of sites in the structure.\n  - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`_).\n  - If a component of the position is unknown, the :val:`null` value should be provided instead (see section `Properties with unknown value`_).\n    Otherwise, it should be a float value, expressed in angstrom (\u00c5).\n    If at least one of the coordinates is unknown, the correct flag in the list property `structure_features`_ MUST be set.\n  - **Notes**: (for implementers) While this is unrelated to this OPTIMADE specification: If you decide to store internally the :property: `cartesian_site_positions` as a float array, you might want to represent :val:`null` values with :field-val:`NaN` values.\n    The latter being valid float numbers in the IEEE 754 standard in `IEEE 754-1985 <https://doi.org/10.1109/IEEESTD.1985.82928>`__ and in the updated version `IEEE 754-2008 <https://doi.org/10.1109/IEEESTD.2008.4610935>`__.\n\n- **Examples**:\n\n  - :val:`[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along the (positive) *z*-axis, 2 \u00c5 away from the origin."
+            "description": "Cartesian positions of each site in the structure.\nA site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.\n\n- **Type**: list of list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - It MUST be a list of length equal to the number of sites in the structure, where every element is a list of the three Cartesian coordinates of a site expressed as float values in the unit angstrom (\u00c5).\n    - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`).\n\n- **Examples**:\n    - `[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along the (positive) *z*-axis, 2 \u00c5 away from the origin."
           },
           "nsites": {
             "title": "Nsites",
             "type": "integer",
-            "description": "An integer specifying the length of the :property:`cartesian_site_positions` property.\n- **Type**: integer\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: MUST be a queryable property with support for all mandatory filter operators.\n\n- **Examples**:\n\n  - :val:`42`\n\n- **Query examples**:\n\n  - Match only structures with exactly 4 sites: :filter:`nsites=4`\n  - Match structures that have between 2 and 7 sites: :filter:`nsites>=2 AND nsites<=7`"
-          },
-          "species_at_sites": {
-            "title": "Species At Sites",
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`_).\n  The properties of the species are found in the property `species`_.\n- **Type**: list of strings.\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: Support for queries on this property is OPTIONAL. If supported, filters MAY support only a subset of comparison operators.\n  - MUST have length equal to the number of sites in the structure (first dimension of the list property `cartesian_site_positions`_).\n  - Each species MUST have a unique name.\n  - Each species name mentioned in the :property:`species_at_sites` list MUST be described in the list property `species`_ (i.e. for each value in the :property:`species_at_sites` list there MUST exist exactly one dictionary in the :property:`species` list with the :property:`name` attribute equal to the corresponding :property:`species_at_sites` value).\n  - Each site MUST be associated only to a single species.\n    **Note**: However, species can represent mixtures of atoms, and multiple species MAY be defined for the same chemical element.\n    This latter case is useful when different atoms of the same type need to be grouped or distinguished, for instance in simulation codes to assign different initial spin states.\n\n- **Examples**:\n\n  - :val:`[\"Ti\",\"O2\"]` indicates that the first site is hosting a species labeled :val:`\"Ti\"` and the second a species labeled :val:`\"O2\"`."
+            "description": "An integer specifying the length of the `cartesian_site_positions` property.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `42`\n\n- **Query examples**:\n    - Match only structures with exactly 4 sites: `nsites=4`\n    - Match structures that have between 2 and 7 sites: `nsites>=2 AND nsites<=7`"
           },
           "species": {
             "title": "Species",
@@ -2614,7 +3066,15 @@
             "items": {
               "$ref": "#/components/schemas/Species"
             },
-            "description": "A list describing the species of the sites of this structure. Species can be pure chemical elements, or virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements.\n- **Type**: list of dictionary with keys:\n\n  - :property:`name`: string (REQUIRED)\n  - :property:`chemical_symbols`: list of strings (REQUIRED)\n  - :property:`concentration`: list of float (REQUIRED)\n  - :property:`mass`: float (OPTIONAL)\n  - :property:`original_name`: string (OPTIONAL).\n\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response unless explicitly excluded.\n  - **Query**: Support for queries on this property is OPTIONAL. If supported, filters MAY support only a subset of comparison operators.\n  - Each list member MUST be a dictionary with the following keys:\n\n    - **name**: REQUIRED; gives the name of the species; the **name** value MUST be unique in the :property:`species` list;\n\n    - **chemical_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing this species.\n\n      - It MUST be one of the following:\n\n        - a valid chemical-element name, or\n        - the special value :val:`\"X\"` to represent a non-chemical element, or\n        - the special value :val:`\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the :property:`concentration` list, see below).\n\n      -  If any one entry in the :property:`species` list has a :property:`chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list :property:`structure_features` (see property `structure_features`_).\n\n    - **concentration**: REQUIRED; MUST be a list of floats, with same length as :property:`chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species.\n      The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n      - Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations :val:`1/3` and :val:`2/3`, the concentration might look something like :val:`[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n      - Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\n      Note that concentrations are uncorrelated between different site (even of the same species).\n\n    - **mass**: OPTIONAL. If present MUST be a float expressed in a.m.u.\n    - **original_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\n        Note: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.\n            The main use of this field is for source databases that use species names, containing characters that are not allowed (see description of the list property `species_at_sites`_).\n\n  - For systems that have only species formed by a single chemical symbol, and that have at most one species per chemical symbol, SHOULD use the chemical symbol as species name (e.g., :val:`\"Ti\"` for titanium, :val:`\"O\"` for oxygen, etc.)\n    However, note that this is OPTIONAL, and client implementations MUST NOT assume that the key corresponds to a chemical symbol, nor assume that if the species name is a valid chemical symbol, that it represents a species with that chemical symbol.\n    This means that a species :val:`{\"name\": \"C\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]}` is valid and represents a titanium species (and *not* a carbon species).\n  - It is NOT RECOMMENDED that a structure includes species that do not have at least one corresponding site.\n\n- **Examples**:\n\n  - :val:`[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n  - :val:`[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n  - :val:`[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": 88.5} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n  - :val:`[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": 12.0} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n  - :val:`[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": 13.0} ]`: any site with this species is occupied by a carbon isotope with mass 13."
+            "description": "A list describing the species of the sites of this structure.\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to another element, e.g., a carbon with three attached hydrogens might represent a methyl group, -CH3).\n\n- **Type**: list of dictionary with keys:\n    - `name`: string (REQUIRED)\n    - `chemical_symbols`: list of strings (REQUIRED)\n    - `concentration`: list of float (REQUIRED)\n    - `mass`: float (OPTIONAL)\n    - `original_name`: string (OPTIONAL).\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - Each list member MUST be a dictionary with the following keys:\n        - **name**: REQUIRED; gives the name of the species; the **name** value MUST be unique in the `species` list;\n        - **chemical_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing this species.\n          Each item of the list MUST be one of the following:\n            - a valid chemical-element name, or\n            - the special value `\"X\"` to represent a non-chemical element, or\n            - the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\n          If any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.\n\n        - **concentration**: REQUIRED; MUST be a list of floats, with same length as `chemical_symbols`.\n          The numbers represent the relative concentration of the corresponding chemical symbol in this species.\n          The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n            - Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n            - Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\n            Note that concentrations are uncorrelated between different sites (even of the same species).\n\n        - **attached**: OPTIONAL; if provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.\n\n        - **nattached**: OPTIONAL; if provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the `attached` key.\n\n          The implementation MUST include either both or none of the `attached` and `nattached` keys, and if they are provided, they MUST be of the same length.\n          Furthermore, if they are provided, the `structure_features` property MUST include the string `site_attachments`.\n\n        - **mass**: OPTIONAL. If present MUST be a float expressed in a.m.u.\n\n        - **original_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\n          Note: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.\n\n          The main use of this field is for source databases that use species names, containing characters that are not allowed (see description of the list property `species_at_sites`).\n\n    - For systems that have only species formed by a single chemical symbol, and that have at most one species per chemical symbol, SHOULD use the chemical symbol as species name (e.g., `\"Ti\"` for titanium, `\"O\"` for oxygen, etc.)\n      However, note that this is OPTIONAL, and client implementations MUST NOT assume that the key corresponds to a chemical symbol, nor assume that if the species name is a valid chemical symbol, that it represents a species with that chemical symbol.\n      This means that a species `{\"name\": \"C\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]}` is valid and represents a titanium species (and *not* a carbon species).\n    - It is NOT RECOMMENDED that a structure includes species that do not have at least one corresponding site.\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": 88.5} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": 12.0} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": 13.0} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms."
+          },
+          "species_at_sites": {
+            "title": "Species At Sites",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`).\nThe properties of the species are found in the property `species`.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST have length equal to the number of sites in the structure (first dimension of the list property `cartesian_site_positions`).\n    - Each species name mentioned in the `species_at_sites` list MUST be described in the list property `species` (i.e. for each value in the `species_at_sites` list there MUST exist exactly one dictionary in the `species` list with the `name` attribute equal to the corresponding `species_at_sites` value).\n    - Each site MUST be associated only to a single species.\n      **Note**: However, species can represent mixtures of atoms, and multiple species MAY be defined for the same chemical element.\n      This latter case is useful when different atoms of the same type need to be grouped or distinguished, for instance in simulation codes to assign different initial spin states.\n\n- **Examples**:\n    - `[\"Ti\",\"O2\"]` indicates that the first site is hosting a species labeled `\"Ti\"` and the second a species labeled `\"O2\"`.\n    - `[\"Ac\", \"Ac\", \"Ag\", \"Ir\"]` indicating the first two sites contains the `\"Ac\"` species, while the third and fourth sites contain the `\"Ag\"` and `\"Ir\"` species, respectively."
           },
           "assemblies": {
             "title": "Assemblies",
@@ -2622,15 +3082,20 @@
             "items": {
               "$ref": "#/components/schemas/Assembly"
             },
-            "description": "A description of groups of sites that are statistically correlated.\n- **Type**: list of dictionary with keys:\n\n  - :property:`sites_in_groups`: list of list of integers (REQUIRED)\n  - :property:`group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n\n  - **Response**: OPTIONAL in the response (SHOULD be absent if there are no partial occupancies).\n  - **Query**: Support for queries on this property is OPTIONAL.\n    If supported, filters MAY support only a subset of comparison operators.\n  - If present, the correct flag MUST be set in the list :property:`structure_features` (see property `structure_features`_).\n  - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n  - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n\n    - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n      Example: :val:`[[1], [2]]`: two groups, one with the second site, one with the third.\n\n      Example: :val:`[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n   - **group_probabilities**: Statistical probability of each group. It MUST have the same length as :property:`sites_in_groups`.\n     It SHOULD sum to one.\n     See below for examples of how to specify the probability of the occurrence of a vacancy.\n     The possible reasons for the values not to sum to one are the same as already specified above for the :property:`concentration` of each :property:`species`, see property `species`_.\n\n  - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n  - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n\n  - :val:`{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n    Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n  - :val:`{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n    The second group is formed by the fourth site.\n    Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n    30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n\n  - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n  - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n  - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n    For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n    - Using a single species:\n\n      .. code:: jsonc\n\n           {\n             \"cartesian_site_positions\": [[0,0,0]],\n             \"species_at_sites\": [\"SiGe-vac\"],\n             \"species\": [\n                 {\n                   \"name\": \"SiGe-vac\",\n                   \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                   \"concentration\": [0.3, 0.5, 0.2]\n                 }\n             ]\n             // ...\n           }\n\n\n    - Using multiple species and the assemblies:\n\n      .. code:: jsonc\n\n           {\n             \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n             \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n             \"species\": {\n               \"Si\": { \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n               \"Ge\": { \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n               \"vac\": { \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n             },\n             \"assemblies\": [\n               {\n                 \"sites_in_groups\": [ [0], [1], [2] ],\n                 \"group_probabilities\": [0.3, 0.5, 0.2]\n               }\n             ]\n             // ...\n           }\n\n  - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n    However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n  - The probabilities of occurrence of different assemblies are uncorrelated.\n    So, for instance in the following case with two assemblies:\n\n    .. code:: jsonc\n\n         {\n           \"assemblies\": [\n             {\n               \"sites_in_groups\": [ [0], [1] ],\n               \"group_probabilities\": [0.2, 0.8],\n             },\n             {\n               \"sites_in_groups\": [ [2], [3] ],\n               \"group_probabilities\": [0.3, 0.7]\n             }\n           ]\n         }\n\n    Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n    These two sites are correlated (either site 2 or 3 is present).\n    However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability)."
+            "description": "A description of groups of sites that are statistically correlated.\n\n- **Type**: list of dictionary with keys:\n    - `sites_in_groups`: list of list of integers (REQUIRED)\n    - `group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - The property SHOULD be `null` for entries that have no partial occupancies.\n    - If present, the correct flag MUST be set in the list `structure_features`.\n    - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n    - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n        - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n            Example: `[[1], [2]]`: two groups, one with the second site, one with the third.\n            Example: `[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n        - **group_probabilities**: Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\n            It SHOULD sum to one.\n            See below for examples of how to specify the probability of the occurrence of a vacancy.\n            The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.\n\n    - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n    - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n    - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n\n    - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n\n    - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n        For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n        - Using a single species:\n            ```json\n            {\n              \"cartesian_site_positions\": [[0,0,0]],\n              \"species_at_sites\": [\"SiGe-vac\"],\n              \"species\": [\n              {\n                \"name\": \"SiGe-vac\",\n                \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                \"concentration\": [0.3, 0.5, 0.2]\n              }\n              ]\n              // ...\n            }\n            ```\n\n        - Using multiple species and the assemblies:\n            ```json\n            {\n              \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n              \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n              \"species\": {\n                \"Si\": { \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n                \"Ge\": { \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n                \"vac\": { \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n              },\n              \"assemblies\": [\n                {\n              \"sites_in_groups\": [ [0], [1], [2] ],\n              \"group_probabilities\": [0.3, 0.5, 0.2]\n                }\n              ]\n              // ...\n            }\n            ```\n\n    - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n        However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n\n    - The probabilities of occurrence of different assemblies are uncorrelated.\n        So, for instance in the following case with two assemblies:\n        ```json\n        {\n          \"assemblies\": [\n            {\n              \"sites_in_groups\": [ [0], [1] ],\n              \"group_probabilities\": [0.2, 0.8],\n            },\n            {\n              \"sites_in_groups\": [ [2], [3] ],\n              \"group_probabilities\": [0.3, 0.7]\n            }\n          ]\n        }\n        ```\n\n        Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n        These two sites are correlated (either site 2 or 3 is present).\n        However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability)."
           },
           "structure_features": {
             "title": "Structure Features",
             "type": "array",
             "items": {
-              "type": "string"
+              "enum": [
+                "disorder",
+                "implicit_atoms",
+                "site_attachments",
+                "assemblies"
+              ]
             },
-            "description": "A list of strings that flag which special features are used by the structure.\n- **Type**: list of strings\n- **Requirements/Conventions**:\n\n  - **Response**: REQUIRED in the response (SHOULD be absent if there are no partial occupancies).\n  - **Query**: MUST be a queryable property. Filters on the list MUST support all mandatory HAS-type queries. Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.\n  - MUST be an empty list if no special features are used.\n  - MUST be sorted alphabetically.\n  - If a special feature listed below is used, the list MUST contain the corresponding string.\n  - If a special feature listed below is not used, the list MUST NOT contain the corresponding string.\n  - **List of strings used to indicate special structure features**:\n\n    - :val:`disorder`: This flag MUST be present if any one entry in the :property:`species` list has a :property:`chemical_symbols` list that is longer than 1 element.\n    - :val:`unknown_positions`: This flag MUST be present if at least one component of the :property:`cartesian_site_positions` list of lists has value :val:`null`.\n    - :val:`assemblies`: This flag MUST be present if the property `assemblies`_ is present.\n\n-  **Examples**: A structure having unknown positions and using assemblies: :val:`[\"assemblies\", \"unknown_positions\"]`"
+            "description": "A list of strings that flag which special features are used by the structure.\n\n- **Type**: list of strings\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property.\n    Filters on the list MUST support all mandatory HAS-type queries.\n    Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.\n    - MUST be an empty list if no special features are used.\n    - MUST be sorted alphabetically.\n    - If a special feature listed below is used, the list MUST contain the corresponding string.\n    - If a special feature listed below is not used, the list MUST NOT contain the corresponding string.\n    - **List of strings used to indicate special structure features**:\n        - `disorder`: this flag MUST be present if any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element.\n        - `implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites` (e.g., because their positions are unknown).\n           When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`, `species` and `assemblies` properties.\n        - `site_attachments`: this flag MUST be present if any one entry in the `species` list includes `attached` and `nattached`.\n        - `assemblies`: this flag MUST be present if the property `assemblies` is present.\n\n- **Examples**: A structure having implicit atoms and using assemblies: `[\"assemblies\", \"implicit_atoms\"]`"
           }
         },
         "description": "This class contains the Field for the attributes used to represent a structure, e.g. unit cell, atoms, positions."
@@ -2644,6 +3109,7 @@
         "properties": {
           "data": {
             "title": "Data",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "type": "array",
@@ -2657,22 +3123,30 @@
                   "type": "object"
                 }
               }
-            ]
+            ],
+            "description": "List of unique OPTIMADE structures entry resource objects"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+              "$ref": "#/components/schemas/Error"
             },
-            "description": "A list of errors"
+            "description": "A list of unique errors"
           },
           "included": {
             "title": "Included",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "type": "array",
@@ -2695,7 +3169,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -2720,27 +3194,39 @@
             "title": "Data",
             "anyOf": [
               {
-                "$ref": "#/components/schemas/StructureResource"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/StructureResource"
+                  }
+                ]
               },
               {
                 "type": "object"
               }
-            ]
+            ],
+            "description": "A single structures entry resource"
           },
           "meta": {
-            "$ref": "#/components/schemas/ResponseMeta"
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
           },
           "errors": {
             "title": "Errors",
             "uniqueItems": true,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/optimade__models__jsonapi__Error"
+              "$ref": "#/components/schemas/Error"
             },
-            "description": "A list of errors"
+            "description": "A list of unique errors"
           },
           "included": {
             "title": "Included",
+            "uniqueItems": true,
             "anyOf": [
               {
                 "type": "array",
@@ -2763,7 +3249,7 @@
                 "$ref": "#/components/schemas/ToplevelLinks"
               }
             ],
-            "description": "Links associated with the primary data"
+            "description": "Links associated with the primary data or errors"
           },
           "jsonapi": {
             "title": "Jsonapi",
@@ -2945,128 +3431,7 @@
             "description": "Warnings must be of type \"warning\""
           }
         },
-        "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\nFrom the specification:\n\n    A warning resource object is defined similarly to a JSON API\n    error object, but MUST also include the field type, which MUST\n    have the value \"warning\". The field detail MUST be present and\n    SHOULD contain a non-critical message, e.g., reporting\n    unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."
-      },
-      "optimade__models__jsonapi__Error": {
-        "title": "Error",
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "string",
-            "description": "A unique identifier for this particular occurrence of the problem."
-          },
-          "links": {
-            "title": "Links",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorLinks"
-              }
-            ],
-            "description": "A links object storing about"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "description": "the HTTP status code applicable to this problem, expressed as a string value."
-          },
-          "code": {
-            "title": "Code",
-            "type": "string",
-            "description": "an application-specific error code, expressed as a string value."
-          },
-          "title": {
-            "title": "Title",
-            "type": "string",
-            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
-          },
-          "detail": {
-            "title": "Detail",
-            "type": "string",
-            "description": "A human-readable explanation specific to this occurrence of the problem."
-          },
-          "source": {
-            "title": "Source",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorSource"
-              }
-            ],
-            "description": "An object containing references to the source of the error"
-          },
-          "meta": {
-            "title": "Meta",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Meta"
-              }
-            ],
-            "description": "a meta object containing non-standard meta-information about the error."
-          }
-        },
-        "description": "An error response"
-      },
-      "optimade__models__optimade_json__Error": {
-        "title": "Error",
-        "required": [
-          "detail"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "string",
-            "description": "A unique identifier for this particular occurrence of the problem."
-          },
-          "links": {
-            "title": "Links",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorLinks"
-              }
-            ],
-            "description": "A links object storing about"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string",
-            "description": "the HTTP status code applicable to this problem, expressed as a string value."
-          },
-          "code": {
-            "title": "Code",
-            "type": "string",
-            "description": "an application-specific error code, expressed as a string value."
-          },
-          "title": {
-            "title": "Title",
-            "type": "string",
-            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
-          },
-          "detail": {
-            "title": "Detail",
-            "type": "string",
-            "description": "A human-readable explanation specific to this occurrence of the problem."
-          },
-          "source": {
-            "title": "Source",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ErrorSource"
-              }
-            ],
-            "description": "An object containing references to the source of the error"
-          },
-          "meta": {
-            "title": "Meta",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Meta"
-              }
-            ],
-            "description": "a meta object containing non-standard meta-information about the error."
-          }
-        },
-        "description": "detail MUST be present"
+        "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\n\nFrom the specification:\n\nA warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\".\nThe field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."
       }
     }
   }

--- a/schemas/openapi_schema.json
+++ b/schemas/openapi_schema.json
@@ -925,6 +925,7 @@
           },
           "version": {
             "title": "Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "A string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
           }
@@ -943,6 +944,7 @@
         "properties": {
           "api_version": {
             "title": "Api Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "Presently used version of the OPTIMADE API"
           },
@@ -2649,6 +2651,7 @@
           },
           "api_version": {
             "title": "Api Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
             "description": "A string containing the version of the API implementation."
           },


### PR DESCRIPTION
This PR updates the OpenAPI schema from optimade-python-tools v0.8.4, which should now be ready for a 1.0.0-rc2 release (I have used this version number to generate the schemas).

These changes can be summarised as:
- addition of the new properties added to the spec since 0.10.1
- updated of the property descriptions to match the text in the specification
- changed formatting of descriptions to markdown to allow for better rendering in Swagger, mkdocs etc. This mostly just involves removing `:property:` etc. tags and also internal links.

The Swagger docs that would be linked from optimade.org once this PR is merged can be previewed at our heroku deployment: https://optimade.herokuapp.com/v0/extensions/docs#/