### PR TITLE
Update schemas for v1.0.0

### DIFF
--- a/schemas/index_openapi_schema.json
+++ b/schemas/index_openapi_schema.json
@@ -245,9 +245,9 @@
                 "schema": {}
               }
             }
-	  }
+          }
         }
-      }	
+      }
     }
   },
   "components": {
@@ -656,7 +656,7 @@
               }
             ],
             "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the homepage of the implementation."
-          },	    
+          },
           "source_url": {
             "title": "Source Url",
             "anyOf": [
@@ -1516,7 +1516,7 @@
             "title": "More Data Available",
             "type": "boolean",
             "description": "`false` if the response contains all data for the request (e.g., a request issued to a single entry endpoint, or a `filter` query at the last page of a paginated response) and `true` if the response is incomplete in the sense that multiple objects match the request, and not all of them have been included in the response (e.g., a query with multiple pages that is not at the last page)."
-          },	    
+          },
           "schema": {
             "title": "Schema",
             "anyOf": [
@@ -1534,7 +1534,7 @@
                 ]
               }
             ],
-            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."            
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
           },
           "time_stamp": {
             "title": "Time Stamp",

--- a/schemas/index_openapi_schema.json
+++ b/schemas/index_openapi_schema.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API - Index meta-database",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.9.1) v0.9.1.",
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.9.7) v0.9.7.",
     "version": "1.0.0"
   },
   "paths": {
@@ -23,7 +23,7 @@
                 }
               }
             }
-	  }
+          }
         }
       }
     },
@@ -1065,7 +1065,7 @@
         "title": "LinksResponse",
         "required": [
           "data",
-	  "meta"
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -1498,7 +1498,7 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version of the API implementation. The version number string MUST NOT be prefixed by, e.g., 'v'. Example: `1.0.0`."
+            "description": "A string containing the full version of the API implementation. The version number string MUST NOT be prefixed by, e.g., 'v'. Examples: `1.0.0`, `1.0.0-rc.2`"
           },
           "schema": {
             "title": "Schema",

--- a/schemas/index_openapi_schema.json
+++ b/schemas/index_openapi_schema.json
@@ -1096,7 +1096,7 @@
         "title": "LinksResponse",
         "required": [
           "data",
-	  "meta"
+          "meta"
         ],
         "type": "object",
         "properties": {

--- a/schemas/index_openapi_schema.json
+++ b/schemas/index_openapi_schema.json
@@ -521,8 +521,8 @@
       "ErrorResponse": {
         "title": "ErrorResponse",
         "required": [
-           "meta",
-           "errors"
+          "meta",
+          "errors"
         ],
         "type": "object",
         "properties": {

--- a/schemas/index_openapi_schema.json
+++ b/schemas/index_openapi_schema.json
@@ -6,41 +6,20 @@
     "version": "1.0.0"
   },
   "paths": {
-    "/versions": {
-      "get": {
-        "tags": [
-          "Versions"
-        ],
-        "summary": "Get Versions",
-        "operationId": "get_versions",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/csv": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/info": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Info",
-        "operationId": "get_info_v1_info_get",
+        "operationId": "get_info_info_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Info V1 Info Get",
+                  "title": "Response Get Info Info Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/IndexInfoResponse"
@@ -62,7 +41,7 @@
           "Links"
         ],
         "summary": "Get Links",
-        "operationId": "get_links_v1_links_get",
+        "operationId": "get_links_links_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
@@ -224,7 +203,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Links V1 Links Get",
+                  "title": "Response Get Links Links Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/LinksResponse"
@@ -249,6 +228,26 @@
           }
         }
       }
+    },
+    "/versions": {
+      "get": {
+        "tags": [
+          "Versions"
+        ],
+        "summary": "Get Versions",
+        "description": "Respond with the text/csv representation for the served versions.",
+        "operationId": "get_versions_versions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/csv": {
+                "schema": {}
+              }
+            }
+	  }
+        }
+      }	
     }
   },
   "components": {
@@ -280,7 +279,7 @@
             "title": "Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
+            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`."
           }
         },
         "description": "A JSON object containing information about an available API version"
@@ -522,7 +521,8 @@
       "ErrorResponse": {
         "title": "ErrorResponse",
         "required": [
-          "errors"
+           "meta",
+           "errors"
         ],
         "type": "object",
         "properties": {
@@ -638,13 +638,43 @@
             "type": "string",
             "description": "version string of the current implementation"
           },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the homepage of the implementation."
+          },	    
           "source_url": {
             "title": "Source Url",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
-            "description": "URL of the implementation source, either downloadable archive or version control system",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation source, either downloadable archive or version control system."
           },
           "maintainer": {
             "title": "Maintainer",
@@ -688,7 +718,7 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used version of the OPTIMADE API"
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
           },
           "available_api_versions": {
             "title": "Available Api Versions",
@@ -787,7 +817,8 @@
       "IndexInfoResponse": {
         "title": "IndexInfoResponse",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -1065,7 +1096,7 @@
         "title": "LinksResponse",
         "required": [
           "data",
-          "meta"
+	  "meta"
         ],
         "type": "object",
         "properties": {
@@ -1235,7 +1266,7 @@
           "prefix": {
             "title": "Prefix",
             "type": "string",
-            "description": "database-provider-specific prefix as found in Appendix 1."
+            "description": "database-provider-specific prefix as found in section Database-Provider-Specific Namespace Prefixes."
           },
           "homepage": {
             "title": "Homepage",
@@ -1255,25 +1286,6 @@
               }
             ],
             "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to homepage of the database provider, either directly as a string, or as a link object."
-          },
-          "index_base_url": {
-            "title": "Index Base Url",
-            "anyOf": [
-              {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 65536,
-                "format": "uri"
-              },
-              {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Link"
-                  }
-                ]
-              }
-            ],
-            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to the base URL for the `index` meta-database as specified in Appendix 1, either directly as a string, or as a link object."
           }
         },
         "description": "Information on the database provider of the implementation."
@@ -1498,8 +1510,13 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version of the API implementation. The version number string MUST NOT be prefixed by, e.g., 'v'. Examples: `1.0.0`, `1.0.0-rc.2`"
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
           },
+          "more_data_available": {
+            "title": "More Data Available",
+            "type": "boolean",
+            "description": "`false` if the response contains all data for the request (e.g., a request issued to a single entry endpoint, or a `filter` query at the last page of a paginated response) and `true` if the response is incomplete in the sense that multiple objects match the request, and not all of them have been included in the response (e.g., a query with multiple pages that is not at the last page)."
+          },	    
           "schema": {
             "title": "Schema",
             "anyOf": [
@@ -1517,8 +1534,8 @@
                 ]
               }
             ],
-            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) that points to a schema for the response. If it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema. It is possible that future versions of this specification allows for alternative schema types. Hence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
-          },	    
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."            
+          },
           "time_stamp": {
             "title": "Time Stamp",
             "type": "string",
@@ -1530,11 +1547,6 @@
             "minimum": 0.0,
             "type": "integer",
             "description": "An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination."
-          },
-          "more_data_available": {
-            "title": "More Data Available",
-            "type": "boolean",
-            "description": "`false` if all data resource objects for this `filter` query have been returned in the response or if it is the last page of a paginated response, and `true` otherwise."
           },
           "provider": {
             "title": "Provider",
@@ -1591,7 +1603,7 @@
           "representation": {
             "title": "Representation",
             "type": "string",
-            "description": "a string with the part of the URL that follows the base URL. Example: '/structures?'"
+            "description": "A string with the part of the URL following the versioned or unversioned base URL that serves the API.\nQuery parameters that have not been used in processing the request MAY be omitted.\nIn particular, if no query parameters have been involved in processing the request, the query pary of the URL MAY be excluded.\nExample: `/structures?filter=nelements=2`"
           }
         },
         "description": "Information on the query that was requested. "

--- a/schemas/index_openapi_schema.json
+++ b/schemas/index_openapi_schema.json
@@ -3,10 +3,31 @@
   "info": {
     "title": "OPTIMADE API - Index meta-database",
     "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.9.1) v0.9.1.",
-    "version": "1.0.0-rc.2"
+    "version": "1.0.0"
   },
   "paths": {
-    "/v1/info": {
+    "/versions": {
+      "get": {
+        "tags": [
+          "Versions"
+        ],
+        "summary": "Get Versions",
+        "operationId": "get_versions",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+	  }
+        }
+      }
+    },
+    "/info": {
       "get": {
         "tags": [
           "Info"
@@ -35,7 +56,7 @@
         }
       }
     },
-    "/v1/links": {
+    "/links": {
       "get": {
         "tags": [
           "Links"
@@ -1043,7 +1064,8 @@
       "LinksResponse": {
         "title": "LinksResponse",
         "required": [
-          "data"
+          "data",
+	  "meta"
         ],
         "type": "object",
         "properties": {
@@ -1459,10 +1481,7 @@
         "required": [
           "query",
           "api_version",
-          "time_stamp",
-          "data_returned",
-          "more_data_available",
-          "provider"
+          "more_data_available"
         ],
         "type": "object",
         "properties": {
@@ -1479,8 +1498,27 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the version of the API implementation."
+            "description": "A string containing the full version of the API implementation. The version number string MUST NOT be prefixed by, e.g., 'v'. Example: `1.0.0`."
           },
+          "schema": {
+            "title": "Schema",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) that points to a schema for the response. If it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema. It is possible that future versions of this specification allows for alternative schema types. Hence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
+          },	    
           "time_stamp": {
             "title": "Time Stamp",
             "type": "string",

--- a/schemas/openapi_schema.json
+++ b/schemas/openapi_schema.json
@@ -3,10 +3,31 @@
   "info": {
     "title": "OPTIMADE API",
     "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.9.1) v0.9.1.",
-    "version": "1.0.0-rc.2"
+    "version": "1.0.0"
   },
   "paths": {
-    "/v1/info": {
+    "/versions": {
+      "get": {
+        "tags": [
+          "Versions"
+        ],
+        "summary": "Get Versions",
+        "operationId": "get_versions",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+	  }
+        }
+      }
+    },
+    "/info": {
       "get": {
         "tags": [
           "Info"
@@ -35,7 +56,7 @@
         }
       }
     },
-    "/v1/info/{entry}": {
+    "/info/{entry}": {
       "get": {
         "tags": [
           "Info"
@@ -85,7 +106,7 @@
         }
       }
     },
-    "/v1/links": {
+    "/links": {
       "get": {
         "tags": [
           "Links"
@@ -279,7 +300,7 @@
         }
       }
     },
-    "/v1/references": {
+    "/references": {
       "get": {
         "tags": [
           "References"
@@ -473,7 +494,7 @@
         }
       }
     },
-    "/v1/references/{entry_id}": {
+    "/references/{entry_id}": {
       "get": {
         "tags": [
           "References"
@@ -573,7 +594,7 @@
         }
       }
     },
-    "/v1/structures": {
+    "/structures": {
       "get": {
         "tags": [
           "Structures"
@@ -767,7 +788,7 @@
         }
       }
     },
-    "/v1/structures/{entry_id}": {
+    "/structures/{entry_id}": {
       "get": {
         "tags": [
           "Structures"
@@ -946,7 +967,7 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used version of the OPTIMADE API"
+            "description": "Presently used full version of the OPTIMADE API. The version number string MUST NOT be prefixed by, e.g., 'v'. Example: `1.0.0`."
           },
           "available_api_versions": {
             "title": "Available Api Versions",
@@ -1103,7 +1124,7 @@
           "unit": {
             "title": "Unit",
             "type": "string",
-            "description": "The physical unit of the entry property.\nIt is RECOMMENDED that non-standard (non-SI) units are described in the description for the property."
+            "description": "The physical unit of the entry property. This MUST be a valid representation of units according to version 2.1 of [The Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html). It is RECOMMENDED that non-standard (non-SI) units are described in the description for the property."
           },
           "sortable": {
             "title": "Sortable",
@@ -1173,7 +1194,8 @@
       "EntryInfoResponse": {
         "title": "EntryInfoResponse",
         "required": [
-          "data"
+          "data",
+	  "meta"
         ],
         "type": "object",
         "properties": {
@@ -1426,7 +1448,8 @@
       "ErrorResponse": {
         "title": "ErrorResponse",
         "required": [
-          "errors"
+          "errors",
+	  "meta"  
         ],
         "type": "object",
         "properties": {
@@ -1542,11 +1565,42 @@
             "type": "string",
             "description": "version string of the current implementation"
           },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to homepage of the implementation."
+          },	    
           "source_url": {
             "title": "Source Url",
-            "maxLength": 65536,
-            "minLength": 1,
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
             "description": "URL of the implementation source, either downloadable archive or version control system",
             "format": "uri"
           },
@@ -1581,7 +1635,8 @@
       "InfoResponse": {
         "title": "InfoResponse",
         "required": [
-          "data"
+          "data",
+	  "meta"
         ],
         "type": "object",
         "properties": {
@@ -1839,7 +1894,8 @@
       "LinksResponse": {
         "title": "LinksResponse",
         "required": [
-          "data"
+          "data",
+	  "meta"
         ],
         "type": "object",
         "properties": {
@@ -2053,25 +2109,6 @@
             ],
             "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to homepage of the database provider, either directly as a string, or as a link object."
           },
-          "index_base_url": {
-            "title": "Index Base Url",
-            "anyOf": [
-              {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 65536,
-                "format": "uri"
-              },
-              {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Link"
-                  }
-                ]
-              }
-            ],
-            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to the base URL for the `index` meta-database as specified in Appendix 1, either directly as a string, or as a link object."
-          }
         },
         "description": "Information on the database provider of the implementation."
       },
@@ -2334,7 +2371,8 @@
       "ReferenceResponseMany": {
         "title": "ReferenceResponseMany",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -2417,7 +2455,8 @@
       "ReferenceResponseOne": {
         "title": "ReferenceResponseOne",
         "required": [
-          "data"
+          "data",
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -2633,10 +2672,7 @@
         "required": [
           "query",
           "api_version",
-          "time_stamp",
-          "data_returned",
-          "more_data_available",
-          "provider"
+          "more_data_available"
         ],
         "type": "object",
         "properties": {
@@ -2653,8 +2689,27 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the version of the API implementation."
+            "description": "A string containing the full version of the API implementation. The version number string MUST NOT be prefixed by, e.g., 'v'. Example: `1.0.0`."
           },
+          "schema": {
+            "title": "Schema",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536,
+                "format": "uri"
+              },
+              {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Link"
+                  }
+                ]
+              }
+            ],
+            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) that points to a schema for the response. If it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema. It is possible that future versions of this specification allows for alternative schema types. Hence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
+          },	    
           "time_stamp": {
             "title": "Time Stamp",
             "type": "string",
@@ -3106,7 +3161,8 @@
       "StructureResponseMany": {
         "title": "StructureResponseMany",
         "required": [
-          "data"
+          "data",
+	  "meta"
         ],
         "type": "object",
         "properties": {
@@ -3189,7 +3245,8 @@
       "StructureResponseOne": {
         "title": "StructureResponseOne",
         "required": [
-          "data"
+          "data",
+	  "meta"
         ],
         "type": "object",
         "properties": {

--- a/schemas/openapi_schema.json
+++ b/schemas/openapi_schema.json
@@ -1194,7 +1194,7 @@
         "title": "EntryInfoResponse",
         "required": [
           "data",
-	  "meta"
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -1634,7 +1634,7 @@
         "title": "InfoResponse",
         "required": [
           "data",
-	  "meta"
+         "meta"
         ],
         "type": "object",
         "properties": {
@@ -1893,7 +1893,7 @@
         "title": "LinksResponse",
         "required": [
           "data",
-	  "meta"
+         "meta"
         ],
         "type": "object",
         "properties": {
@@ -2733,7 +2733,7 @@
               }
             ],
             "description": "information on the database provider of the implementation."
-          },	    
+          },
           "data_available": {
             "title": "Data Available",
             "type": "integer",
@@ -3160,7 +3160,7 @@
         "title": "StructureResponseMany",
         "required": [
           "data",
-	  "meta"
+         "meta"
         ],
         "type": "object",
         "properties": {
@@ -3244,7 +3244,7 @@
         "title": "StructureResponseOne",
         "required": [
           "data",
-	  "meta"
+         "meta"
         ],
         "type": "object",
         "properties": {

--- a/schemas/openapi_schema.json
+++ b/schemas/openapi_schema.json
@@ -23,7 +23,7 @@
                 }
               }
             }
-	  }
+          }
         }
       }
     },
@@ -967,7 +967,7 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used full version of the OPTIMADE API. The version number string MUST NOT be prefixed by, e.g., 'v'. Example: `1.0.0`."
+            "description": "Presently used full version of the OPTIMADE API. The version number string MUST NOT be prefixed by, e.g., 'v'. Examples: `1.0.0`, `1.0.0-rc.2`."
           },
           "available_api_versions": {
             "title": "Available Api Versions",
@@ -1195,7 +1195,7 @@
         "title": "EntryInfoResponse",
         "required": [
           "data",
-	  "meta"
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -1449,7 +1449,7 @@
         "title": "ErrorResponse",
         "required": [
           "errors",
-	  "meta"  
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -1636,7 +1636,7 @@
         "title": "InfoResponse",
         "required": [
           "data",
-	  "meta"
+         "meta"
         ],
         "type": "object",
         "properties": {
@@ -1895,7 +1895,7 @@
         "title": "LinksResponse",
         "required": [
           "data",
-	  "meta"
+         "meta"
         ],
         "type": "object",
         "properties": {
@@ -2689,7 +2689,7 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version of the API implementation. The version number string MUST NOT be prefixed by, e.g., 'v'. Example: `1.0.0`."
+            "description": "A string containing the full version of the API implementation. The version number string MUST NOT be prefixed by, e.g., 'v'. Examples: `1.0.0`, `1.0.0-rc.2`."
           },
           "schema": {
             "title": "Schema",
@@ -3162,7 +3162,7 @@
         "title": "StructureResponseMany",
         "required": [
           "data",
-	  "meta"
+         "meta"
         ],
         "type": "object",
         "properties": {
@@ -3246,7 +3246,7 @@
         "title": "StructureResponseOne",
         "required": [
           "data",
-	  "meta"
+         "meta"
         ],
         "type": "object",
         "properties": {

--- a/schemas/openapi_schema.json
+++ b/schemas/openapi_schema.json
@@ -883,7 +883,7 @@
                 "schema": {}
               }
             }
-	  }
+          }
         }
       }
     }
@@ -1582,7 +1582,7 @@
               }
             ],
             "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the homepage of the implementation."
-          },	    
+          },
           "source_url": {
             "title": "Source Url",
             "anyOf": [
@@ -1634,7 +1634,7 @@
         "title": "InfoResponse",
         "required": [
           "data",
-         "meta"
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -1893,7 +1893,7 @@
         "title": "LinksResponse",
         "required": [
           "data",
-         "meta"
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -2712,7 +2712,7 @@
               }
             ],
             "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
-          },	    
+          },
           "time_stamp": {
             "title": "Time Stamp",
             "type": "string",
@@ -3160,7 +3160,7 @@
         "title": "StructureResponseMany",
         "required": [
           "data",
-         "meta"
+          "meta"
         ],
         "type": "object",
         "properties": {
@@ -3244,7 +3244,7 @@
         "title": "StructureResponseOne",
         "required": [
           "data",
-         "meta"
+          "meta"
         ],
         "type": "object",
         "properties": {

--- a/schemas/openapi_schema.json
+++ b/schemas/openapi_schema.json
@@ -2,45 +2,24 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.9.1) v0.9.1.",
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.9.7) v0.9.7.",
     "version": "1.0.0"
   },
   "paths": {
-    "/versions": {
-      "get": {
-        "tags": [
-          "Versions"
-        ],
-        "summary": "Get Versions",
-        "operationId": "get_versions",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/csv": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/info": {
       "get": {
         "tags": [
           "Info"
         ],
         "summary": "Get Info",
-        "operationId": "get_info_v1_info_get",
+        "operationId": "get_info_info_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Info V1 Info Get",
+                  "title": "Response Get Info Info Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/InfoResponse"
@@ -62,7 +41,7 @@
           "Info"
         ],
         "summary": "Get Entry Info",
-        "operationId": "get_entry_info_v1_info__entry__get",
+        "operationId": "get_entry_info_info__entry__get",
         "parameters": [
           {
             "required": true,
@@ -80,7 +59,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Entry Info V1 Info  Entry  Get",
+                  "title": "Response Get Entry Info Info  Entry  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/EntryInfoResponse"
@@ -112,7 +91,7 @@
           "Links"
         ],
         "summary": "Get Links",
-        "operationId": "get_links_v1_links_get",
+        "operationId": "get_links_links_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
@@ -274,7 +253,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Links V1 Links Get",
+                  "title": "Response Get Links Links Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/LinksResponse"
@@ -306,7 +285,7 @@
           "References"
         ],
         "summary": "Get References",
-        "operationId": "get_references_v1_references_get",
+        "operationId": "get_references_references_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
@@ -468,7 +447,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get References V1 References Get",
+                  "title": "Response Get References References Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/ReferenceResponseMany"
@@ -500,7 +479,7 @@
           "References"
         ],
         "summary": "Get Single Reference",
-        "operationId": "get_single_reference_v1_references__entry_id__get",
+        "operationId": "get_single_reference_references__entry_id__get",
         "parameters": [
           {
             "required": true,
@@ -568,7 +547,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Single Reference V1 References  Entry Id  Get",
+                  "title": "Response Get Single Reference References  Entry Id  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/ReferenceResponseOne"
@@ -600,7 +579,7 @@
           "Structures"
         ],
         "summary": "Get Structures",
-        "operationId": "get_structures_v1_structures_get",
+        "operationId": "get_structures_structures_get",
         "parameters": [
           {
             "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
@@ -762,7 +741,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Structures V1 Structures Get",
+                  "title": "Response Get Structures Structures Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/StructureResponseMany"
@@ -794,7 +773,7 @@
           "Structures"
         ],
         "summary": "Get Single Structure",
-        "operationId": "get_single_structure_v1_structures__entry_id__get",
+        "operationId": "get_single_structure_structures__entry_id__get",
         "parameters": [
           {
             "required": true,
@@ -862,7 +841,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Single Structure V1 Structures  Entry Id  Get",
+                  "title": "Response Get Single Structure Structures  Entry Id  Get",
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/StructureResponseOne"
@@ -885,6 +864,26 @@
               }
             }
           }
+        }
+      }
+    },
+    "/versions": {
+      "get": {
+        "tags": [
+          "Versions"
+        ],
+        "summary": "Get Versions",
+        "description": "Respond with the text/csv representation for the served versions.",
+        "operationId": "get_versions_versions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/csv": {
+                "schema": {}
+              }
+            }
+	  }
         }
       }
     }
@@ -948,7 +947,7 @@
             "title": "Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version number of the API served at that versioned base URL. The version number string MUST NOT be prefixed by, e.g., 'v'."
+            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`."
           }
         },
         "description": "A JSON object containing information about an available API version"
@@ -967,7 +966,7 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used full version of the OPTIMADE API. The version number string MUST NOT be prefixed by, e.g., 'v'. Examples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
           },
           "available_api_versions": {
             "title": "Available Api Versions",
@@ -1124,7 +1123,7 @@
           "unit": {
             "title": "Unit",
             "type": "string",
-            "description": "The physical unit of the entry property. This MUST be a valid representation of units according to version 2.1 of [The Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html). It is RECOMMENDED that non-standard (non-SI) units are described in the description for the property."
+            "description": "The physical unit of the entry property.\nThis MUST be a valid representation of units according to version 2.1 of [The Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html).\nIt is RECOMMENDED that non-standard (non-SI) units are described in the description for the property."
           },
           "sortable": {
             "title": "Sortable",
@@ -1195,7 +1194,7 @@
         "title": "EntryInfoResponse",
         "required": [
           "data",
-          "meta"
+	  "meta"
         ],
         "type": "object",
         "properties": {
@@ -1448,8 +1447,8 @@
       "ErrorResponse": {
         "title": "ErrorResponse",
         "required": [
-          "errors",
-          "meta"
+          "meta",
+          "errors"
         ],
         "type": "object",
         "properties": {
@@ -1582,7 +1581,7 @@
                 ]
               }
             ],
-            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to homepage of the implementation."
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the homepage of the implementation."
           },	    
           "source_url": {
             "title": "Source Url",
@@ -1601,8 +1600,7 @@
                 ]
               }
             ],
-            "description": "URL of the implementation source, either downloadable archive or version control system",
-            "format": "uri"
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation source, either downloadable archive or version control system."
           },
           "maintainer": {
             "title": "Maintainer",
@@ -1636,7 +1634,7 @@
         "title": "InfoResponse",
         "required": [
           "data",
-         "meta"
+	  "meta"
         ],
         "type": "object",
         "properties": {
@@ -1895,7 +1893,7 @@
         "title": "LinksResponse",
         "required": [
           "data",
-         "meta"
+	  "meta"
         ],
         "type": "object",
         "properties": {
@@ -2088,7 +2086,7 @@
           "prefix": {
             "title": "Prefix",
             "type": "string",
-            "description": "database-provider-specific prefix as found in Appendix 1."
+            "description": "database-provider-specific prefix as found in section Database-Provider-Specific Namespace Prefixes."
           },
           "homepage": {
             "title": "Homepage",
@@ -2108,7 +2106,7 @@
               }
             ],
             "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to homepage of the database provider, either directly as a string, or as a link object."
-          },
+          }
         },
         "description": "Information on the database provider of the implementation."
       },
@@ -2689,7 +2687,12 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version of the API implementation. The version number string MUST NOT be prefixed by, e.g., 'v'. Examples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+          },
+          "more_data_available": {
+            "title": "More Data Available",
+            "type": "boolean",
+            "description": "`false` if the response contains all data for the request (e.g., a request issued to a single entry endpoint, or a `filter` query at the last page of a paginated response) and `true` if the response is incomplete in the sense that multiple objects match the request, and not all of them have been included in the response (e.g., a query with multiple pages that is not at the last page)."
           },
           "schema": {
             "title": "Schema",
@@ -2708,7 +2711,7 @@
                 ]
               }
             ],
-            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) that points to a schema for the response. If it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema. It is possible that future versions of this specification allows for alternative schema types. Hence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
           },	    
           "time_stamp": {
             "title": "Time Stamp",
@@ -2722,11 +2725,6 @@
             "type": "integer",
             "description": "An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination."
           },
-          "more_data_available": {
-            "title": "More Data Available",
-            "type": "boolean",
-            "description": "`false` if all data resource objects for this `filter` query have been returned in the response or if it is the last page of a paginated response, and `true` otherwise."
-          },
           "provider": {
             "title": "Provider",
             "allOf": [
@@ -2735,7 +2733,7 @@
               }
             ],
             "description": "information on the database provider of the implementation."
-          },
+          },	    
           "data_available": {
             "title": "Data Available",
             "type": "integer",
@@ -2782,7 +2780,7 @@
           "representation": {
             "title": "Representation",
             "type": "string",
-            "description": "a string with the part of the URL that follows the base URL. Example: '/structures?'"
+            "description": "A string with the part of the URL following the versioned or unversioned base URL that serves the API.\nQuery parameters that have not been used in processing the request MAY be omitted.\nIn particular, if no query parameters have been involved in processing the request, the query pary of the URL MAY be excluded.\nExample: `/structures?filter=nelements=2`"
           }
         },
         "description": "Information on the query that was requested. "
@@ -3162,7 +3160,7 @@
         "title": "StructureResponseMany",
         "required": [
           "data",
-         "meta"
+	  "meta"
         ],
         "type": "object",
         "properties": {
@@ -3246,7 +3244,7 @@
         "title": "StructureResponseOne",
         "required": [
           "data",
-         "meta"
+	  "meta"
         ],
         "type": "object",
         "properties": {


### PR DESCRIPTION
It can understandably take a bit of time for optimade-python-tools to catch up with the specification. Since we were hoping to release v1.0.0 this evening, I've taken the liberty of hand-editing in the rather small anticipated changes between v1.0.0-rc.2 and v1.0.0. This way, we won't be release-blocked by waiting for updated schemas.

However, of course, I'd happily see these hand-edits replaced by generated schemas, if they get ready in time. Perhaps looking at the diff of this PR can help point out what needs to be updated in optimade-python-tools.

I've tried to be careful. But, should there happen to be some omission or schema bug, I see no problem with a `v1.0.1` release that just fixes that schema bug. I just don't want us to release v1.0.0 with v1.0.0-rc.2 schemas, since that would look a bit sloppy.

Fixes #294 

Note: this PR assumes #298 will be merged, and so should not be merged before that PR.