### PR TITLE
Remove a space in an example URL

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -1409,7 +1409,7 @@ In particular, this means the client MUST escape special characters in string va
 
 Examples of syntactically correct query strings embedded in queries:
 
--  :query-url:`http://example.org/optimade/v1/structures?filter=_exmpl_melting_point%3C300+AND+ nelements=4+AND+elements="Si,O2"&response_format=xml`
+-  :query-url:`http://example.org/optimade/v1/structures?filter=_exmpl_melting_point%3C300+AND+nelements=4+AND+elements="Si,O2"&response_format=xml`
 
 Or, fully URL encoded :
 


### PR DESCRIPTION
I found a space in URL, which I guess is unintended, although the URL is used to illustrate partially URL-encoded request. If showcasing usage of spaces instead of `+` characters is intended, I suggest replacing all `+` with spaces in this particular example.