### PR TITLE
Redefine species.mass as a list of floats

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -2119,7 +2119,7 @@ species
   - :property:`concentration`: list of float (REQUIRED)
   - :property:`attached`: list of strings (OPTIONAL)
   - :property:`nattached`: list of integers (OPTIONAL)
-  - :property:`mass`: float (OPTIONAL)
+  - :property:`mass`: list of floats (OPTIONAL)
   - :property:`original_name`: string (OPTIONAL).
 
 - **Requirements/Conventions**:
@@ -2153,7 +2153,7 @@ species
       The implementation MUST include either both or none of the :field:`attached` and :field:`nattached` keys, and if they are provided, they MUST be of the same length.
       Furthermore, if they are provided, the `structure_features`_ property MUST include the string :val:`site_attachments`.
 
-    - **mass**: OPTIONAL. If present MUST be a float expressed in a.m.u.
+    - **mass**: OPTIONAL. If present MUST be a list of floats, with same length as :property:`chemical_symbols`, providing element masses expressed in a.m.u. Elements denoting vacancies MUST have masses equal to 0.
     - **original\_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.
 
           Note: With regards to "source database", we refer to the immediate source being queried via the OPTIMADE API implementation.
@@ -2168,9 +2168,9 @@ species
 
   - :val:`[ {"name": "Ti", "chemical_symbols": ["Ti"], "concentration": [1.0]} ]`: any site with this species is occupied by a Ti atom.
   - :val:`[ {"name": "Ti", "chemical_symbols": ["Ti", "vacancy"], "concentration": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.
-  - :val:`[ {"name": "BaCa", "chemical_symbols": ["vacancy", "Ba", "Ca"], "concentration": [0.05, 0.45, 0.5], "mass": 88.5} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.
-  - :val:`[ {"name": "C12", "chemical_symbols": ["C"], "concentration": [1.0], "mass": 12.0} ]`: any site with this species is occupied by a carbon isotope with mass 12.
-  - :val:`[ {"name": "C13", "chemical_symbols": ["C"], "concentration": [1.0], "mass": 13.0} ]`: any site with this species is occupied by a carbon isotope with mass 13.
+  - :val:`[ {"name": "BaCa", "chemical_symbols": ["vacancy", "Ba", "Ca"], "concentration": [0.05, 0.45, 0.5], "mass": [0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability.
+  - :val:`[ {"name": "C12", "chemical_symbols": ["C"], "concentration": [1.0], "mass": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.
+  - :val:`[ {"name": "C13", "chemical_symbols": ["C"], "concentration": [1.0], "mass": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.
   - :val:`[ {"name": "CH3", "chemical_symbols": ["C"], "concentration": [1.0], "attached": ["H"], "nattached": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.
 
 assemblies

--- a/optimade.rst
+++ b/optimade.rst
@@ -2153,7 +2153,8 @@ species
       The implementation MUST include either both or none of the :field:`attached` and :field:`nattached` keys, and if they are provided, they MUST be of the same length.
       Furthermore, if they are provided, the `structure_features`_ property MUST include the string :val:`site_attachments`.
 
-    - **mass**: OPTIONAL. If present MUST be a list of floats, with same length as :property:`chemical_symbols`, providing element masses expressed in a.m.u. Elements denoting vacancies MUST have masses equal to 0.
+    - **mass**: OPTIONAL. If present MUST be a list of floats, with the same length as :property:`chemical_symbols`, providing element masses expressed in a.m.u.
+      Elements denoting vacancies MUST have masses equal to 0.
     - **original\_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.
 
           Note: With regards to "source database", we refer to the immediate source being queried via the OPTIMADE API implementation.

--- a/optimade.rst
+++ b/optimade.rst
@@ -2168,7 +2168,7 @@ species
 
   - :val:`[ {"name": "Ti", "chemical_symbols": ["Ti"], "concentration": [1.0]} ]`: any site with this species is occupied by a Ti atom.
   - :val:`[ {"name": "Ti", "chemical_symbols": ["Ti", "vacancy"], "concentration": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.
-  - :val:`[ {"name": "BaCa", "chemical_symbols": ["vacancy", "Ba", "Ca"], "concentration": [0.05, 0.45, 0.5], "mass": [0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability.
+  - :val:`[ {"name": "BaCa", "chemical_symbols": ["vacancy", "Ba", "Ca"], "concentration": [0.05, 0.45, 0.5], "mass": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability.
   - :val:`[ {"name": "C12", "chemical_symbols": ["C"], "concentration": [1.0], "mass": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.
   - :val:`[ {"name": "C13", "chemical_symbols": ["C"], "concentration": [1.0], "mass": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.
   - :val:`[ {"name": "CH3", "chemical_symbols": ["C"], "concentration": [1.0], "attached": ["H"], "nattached": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.


### PR DESCRIPTION
When looking into means to differentiate hydrogen, deuterium and tritium (see #327), I found out that information about isotopes in multi-species sites can easily be lost, because `species.mass` defined per-site, not per-species. Thus I suggest redefining `species.mass` as a list of floats.

Redefinition brings a problem of backwards-incompatibility. Here are ways to solve it:

1. Use different property name. We may retain `species.mass` with its current definition, and make `species.masses` a list of floats. This retains backwards compatibility, but does not sound good (all subproperties of `species` are in singular). Another suggestion is `species.element_mass`.
2. Declare that defining `species.mass` with a single float value was a bug. Then redefining is a bugfix, thus does not qualify as a breaking change.