### PR TITLE
Adapt creation of AUTHORS.sorted to changes in format of AUTHORS

### DIFF
--- a/tests/makefiles/Makelocal-authors
+++ b/tests/makefiles/Makelocal-authors
@@ -7,7 +7,7 @@
 test_authors: tests/generated/AUTHORS.sorted
 	diff -u AUTHORS tests/generated/AUTHORS.sorted || true
 
-AUTHORS_TAG=The OPTIMADE development team in alphabetical order:
+AUTHORS_TAG=Contributors to the development of the OPTIMADE specification and implementation in alphabetical order:
 
 tests/generated/AUTHORS.sorted: AUTHORS
 	awk '{print} /${AUTHORS_TAG}/ {exit}' $< > $@


### PR DESCRIPTION
The recent changes in the format of AUTHORS have broken the automatic auditing of the alphabetical order in AUTHORS. This PR fixes that problem.

Would be great to get this in for v1.1.