### PR TITLE
Add CHANGELOG containing release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ This is a minor release that primarily clarifies the specification, with only tw
 
 ### Changes
 
-- The `mass` field of the `species` attribute for the `structures` type has been updated from a float to a list of floats [#344](https://github.com/Materials-Consortia/OPTIMADE/pull/344). This is a breaking change for any implementations that serve this optional field.
-- The `implementation` field of the general `meta` response has been updated to include an `issue_tracker` field [#339](https://github.com/Materials-Consortia/OPTIMADE/pull/339).
+- The `mass` field of the `species` attribute for the `structures` type has been updated from a float to a list of floats ([#344](https://github.com/Materials-Consortia/OPTIMADE/pull/344)). This is a breaking change for any implementations that serve this optional field.
+- The `implementation` field of the general `meta` response has been updated to include an `issue_tracker` field ([#339](https://github.com/Materials-Consortia/OPTIMADE/pull/339)).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## v1.1.0 (08/07/2021)
+
+This is release v1.1.0 of the OPTIMADE API specification.
+
+This is a minor release that primarily clarifies the specification, with only two additions.
+
+### Changes
+
+- The `mass` field of the `species` attribute for the `structures` type has been updated from a float to a list of floats [#344](https://github.com/Materials-Consortia/OPTIMADE/pull/344). This is a breaking change for any implementations that serve this optional field.
+- The `implementation` field of the general `meta` response has been updated to include an `issue_tracker` field [#339](https://github.com/Materials-Consortia/OPTIMADE/pull/339).
+
+### Fixes
+
+- The specification text has been clarified in several places.
+- Multiple typos, grammatical errors, and incorrect API examples have been fixed.
+- The OpenAPI schemas are now fully compliant with the Swagger validator.
+
+
+## v1.0.0 (01/07/2020)
+
+This is release v1.0.0 of the OPTIMADE API specification.
+
+The specification has undergone a few changes since v1.0.0-rc.2, some not backward compatible.
+
+A few highlighted changes directly affecting the API:
+- Several changes related to version negotiation for future releases of the API have been added.
+- The API may now be served on both the unversioned and versioned URLs.
+- The top-level `meta` field has undergone major revision:
+   - It is now mandatory, with a few mandatory subfields (e.g., `api_version`), and most other fields made optional.
+   - A link to a schema may be provided.
+   - It no longer contains an `index_base_url`, since this functionality is covered by `root` links in the `/links` endpoint.
+
+- The `unit` field for describing properties in the `/info` endpoints is now standardized to use the Unified Code for Units of Measure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ This is a minor release that primarily patches minor specification errors and in
 
 ### Patches
 
-- The `mass` field of the `species` attribute for the `structures` entry type has been updated from a float to a list of floats ([#344](https://github.com/Materials-Consortia/OPTIMADE/pull/344)). 
-    - This was deemed a specification bug that now is fixed in both the specification text and the schemas. 
+- The `mass` field of the `species` attribute for the `structures` entry type has been updated from a float to a list of floats ([#344](https://github.com/Materials-Consortia/OPTIMADE/pull/344)).
+    - This was deemed a specification bug that now is fixed in both the specification text and the schemas.
     - Note: this could constitute a breaking change for software implemented to strictly adhere to the v1.0.0 specification.
 - The specification text has been clarified in several places without change of intended meaning.
 - Multiple typos, grammatical errors, and incorrect API examples have been fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is a minor release that primarily clarifies the specification, with only tw
 
 ### Changes
 
-- The `mass` field of the `species` attribute for the `structures` type has been updated from a float to a list of floats ([#344](https://github.com/Materials-Consortia/OPTIMADE/pull/344)). This is a breaking change for any implementations that serve this optional field.
+- The `mass` field of the `species` attribute for the `structures` entry type has been updated from a float to a list of floats ([#344](https://github.com/Materials-Consortia/OPTIMADE/pull/344)). This is a breaking change for any implementations that serve this optional field.
 - The `implementation` field of the general `meta` response has been updated to include an `issue_tracker` field ([#339](https://github.com/Materials-Consortia/OPTIMADE/pull/339)).
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,25 @@
 # Changelog
 
-## v1.1.0 (08/07/2021)
+## v1.1.0 (July 8, 2021)
 
 This is release v1.1.0 of the OPTIMADE API specification.
 
-This is a minor release that primarily clarifies the specification, with only two additions.
+This is a minor release that primarily patches minor specification errors and introduces one new feature.
 
-### Changes
+### New features
 
-- The `mass` field of the `species` attribute for the `structures` entry type has been updated from a float to a list of floats ([#344](https://github.com/Materials-Consortia/OPTIMADE/pull/344)). This is a breaking change for any implementations that serve this optional field.
 - The `implementation` field of the general `meta` response has been updated to include an `issue_tracker` field ([#339](https://github.com/Materials-Consortia/OPTIMADE/pull/339)).
 
-### Fixes
+### Patches
 
-- The specification text has been clarified in several places.
+- The `mass` field of the `species` attribute for the `structures` entry type has been updated from a float to a list of floats ([#344](https://github.com/Materials-Consortia/OPTIMADE/pull/344)). 
+    - This was deemed a specification bug that now is fixed in both the specification text and the schemas. 
+    - Note: this could constitute a breaking change for software implemented to strictly adhere to the v1.0.0 specification.
+- The specification text has been clarified in several places without change of intended meaning.
 - Multiple typos, grammatical errors, and incorrect API examples have been fixed.
 - The OpenAPI schemas are now fully compliant with the Swagger validator.
 
 
-## v1.0.0 (01/07/2020)
+## v1.0.0 (July 1, 2020)
 
 This is release v1.0.0 of the OPTIMADE API specification.
-
-The specification has undergone a few changes since v1.0.0-rc.2, some not backward compatible.
-
-A few highlighted changes directly affecting the API:
-- Several changes related to version negotiation for future releases of the API have been added.
-- The API may now be served on both the unversioned and versioned URLs.
-- The top-level `meta` field has undergone major revision:
-   - It is now mandatory, with a few mandatory subfields (e.g., `api_version`), and most other fields made optional.
-   - A link to a schema may be provided.
-   - It no longer contains an `index_base_url`, since this functionality is covered by `root` links in the `/links` endpoint.
-
-- The `unit` field for describing properties in the `/info` endpoints is now standardized to use the Unified Code for Units of Measure.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the specification of the OPTIMADE API.
 
 * [optimade.rst](optimade.rst): The API specification.
 * [AUTHORS](AUTHORS): List of contributors.
+* [CHANGELOG](CHANGELOG.md): The release notes for each version of the specification.
 * [optimade.org](https://www.optimade.org): Public OPTIMADE web site
 * [OPTIMADE wiki](https://github.com/Materials-Consortia/OPTIMADE/wiki): Information for developers
 


### PR DESCRIPTION
This PR adds a CHANGELOG that contains the release notes that I would have typed into GitHub for the upcoming release. These notes can instead be copied from here. I think we discussed adding a CHANGELOG at some point, so hopefully this is not controversial (though please make suggestions on the text, if you have any).

I also took the release notes (written by @rartino?) for v1.0.0 and added them here.

**This** *should* be the final PR/commit before locally merging #365 and releasing.