### PR TITLE
Add v1.0.1 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ This is a minor release that primarily patches minor specification errors and in
 - Multiple typos, grammatical errors, and incorrect API examples have been fixed.
 - The OpenAPI schemas are now fully compliant with the Swagger validator.
 
+## v1.0.1 (July 28, 2021)
+
+This is release v1.0.1 of the OPTIMADE API specification.
+
+This release contains all of the patches from [v1.1.0](https://github.com/Materials-Consortia/OPTIMADE/releases/tag/v1.1.0), whilst maintaining compatibility with v1.0.
 
 ## v1.0.0 (July 1, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This is a minor release that primarily patches minor specification errors and in
 
 This is release v1.0.1 of the OPTIMADE API specification.
 
-This release contains all of the patches from [v1.1.0](https://github.com/Materials-Consortia/OPTIMADE/releases/tag/v1.1.0), whilst maintaining compatibility with v1.0.
+This release contains all of the patches from [v1.1.0](https://github.com/Materials-Consortia/OPTIMADE/releases/tag/v1.1.0), whilst maintaining compatibility with v1.0.0.
 
 ## v1.0.0 (July 1, 2020)
 


### PR DESCRIPTION
This PR simply adds v1.0.1 to the CHANGELOG so that it is included/advertised in the next release.

Once this PR is merged (and any suggestions are also applied to the v1.0 branch), the HEAD of v1.0 will be tagged with `v1.0.1` (but not released to avoid it bumping off v1.1 as the top release in GitHub).