### PR TITLE
Fixing docker to run the tests

### DIFF
--- a/tests/tools/Dockerfile
+++ b/tests/tools/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update \
         make \
         default-jdk \
         subversion \
+        curl \
+        jq \ 
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/tests/tools/Dockerfile
+++ b/tests/tools/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
         default-jdk \
         subversion \
         curl \
-        jq \ 
+        jq \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8


### PR DESCRIPTION
The quick fix to installing the missing dependencies. On a non-ubuntu/debian machine, the docker still seems to be the best way to run the tests.