### PR TITLE
Patch Grammatica to compile on Ubuntu 18.04 and 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Install dependencies
+      run: apt-get install xmlstarlet
     - run: make audit_grammars
 
   audit-authors:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Install dependencies
-      run: apt-get install xmlstarlet
+      run: sudo apt-get install xmlstarlet
     - run: make audit_grammars
 
   audit-authors:

--- a/dependencies/Debian-8.6/install.sh
+++ b/dependencies/Debian-8.6/install.sh
@@ -3,4 +3,5 @@
 sudo apt-get install -y \
     default-jdk \
     unzip \
+    xmlstarlet \
 ;

--- a/tests/makefiles/Makelocal-tools
+++ b/tests/makefiles/Makelocal-tools
@@ -35,6 +35,8 @@ ${GRAMMATICA_LOG}:
 		|| (rm -vf ${GRAMMATICA_ZIP}; exit 12)
 	cd $(dir $@) && rm -rf $(notdir $(basename $@))
 	cd $(dir $@) && unzip ${GRAMMATICA_ZIP}
+	cd $(dir $@)$(notdir $(basename $@)) && xmlstarlet ed --inplace -u "//*[local-name()='javac']/@source" -v 1.6 build.xml
+	cd $(dir $@)$(notdir $(basename $@)) && xmlstarlet ed --inplace -u "//*[local-name()='javac']/@target" -v 1.6 build.xml
 	cd $(dir $@); ( set -uex; cd $(notdir $(basename $@)); ant -k ) 2>&1 \
 		| tee $(notdir $@)
 


### PR DESCRIPTION
Fixes #379. This PR implements my solution to set source and target to 1.6 for `javac` in Grammatica's `build.xml`.