### PR TITLE
Patch Grammatica to compile on Ubuntu 18.04 and 20.04 (more lightweight solution)

### DIFF
--- a/dependencies/Debian-8.6/install.sh
+++ b/dependencies/Debian-8.6/install.sh
@@ -2,5 +2,6 @@
 
 sudo apt-get install -y \
     default-jdk \
+    patch \
     unzip \
 ;

--- a/tests/makefiles/Makelocal-tools
+++ b/tests/makefiles/Makelocal-tools
@@ -35,6 +35,7 @@ ${GRAMMATICA_LOG}:
 		|| (rm -vf ${GRAMMATICA_ZIP}; exit 12)
 	cd $(dir $@) && rm -rf $(notdir $(basename $@))
 	cd $(dir $@) && unzip ${GRAMMATICA_ZIP}
+	patch $(dir $@)/$(notdir $(basename $@))/build.xml $(dir $@)/grammatica-build.patch
 	cd $(dir $@); ( set -uex; cd $(notdir $(basename $@)); ant -k ) 2>&1 \
 		| tee $(notdir $@)
 

--- a/tests/tools/grammatica-build.patch
+++ b/tests/tools/grammatica-build.patch
@@ -1,0 +1,12 @@
+73,74c73,74
+<            source="1.4"
+<            target="1.5"
+---
+>            source="1.6"
+>            target="1.6"
+116,117c116,117
+<            source="1.4"
+<            target="1.5"
+---
+>            source="1.6"
+>            target="1.6"


### PR DESCRIPTION
Fixes #379. This solution, suggested by @sauliusg, is an alternative to #387, using `patch` instead of `xmlstarlet`. `patch` is a bit more lightweight tool to modify the build system, but most likely it would fail with Grammatica versions other than 1.6.