### PR TITLE
Space group additions: `space_group_hall` and `space_group_it_number`

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -2056,6 +2056,17 @@ lattice\_vectors
 
   - :val:`[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is :val:`(4, 0, 0)`, i.e., a vector aligned along the :val:`x` axis of length 4 Å; the second vector is :val:`(0, 4, 0)`; and the third vector is :val:`(0, 1, 4)`.
 
+space\_group\_it\_number
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Description**: Symmetry space group number as defined in International Tables for Crystallography Vol. A.
+- **Type**: integer
+- **Requirements/Conventions**:
+
+  - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
+  - **Query**: Support for queries on this property is OPTIONAL.
+  - The integer value MUST be between 1 and 230.
+
 cartesian\_site\_positions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2056,6 +2056,22 @@ lattice\_vectors
 
   - :val:`[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is :val:`(4, 0, 0)`, i.e., a vector aligned along the :val:`x` axis of length 4 Å; the second vector is :val:`(0, 4, 0)`; and the third vector is :val:`(0, 1, 4)`.
 
+space\_group\_hall
+~~~~~~~~~~~~~~~~~~
+
+- **Description**: Symmetry space group name as defined in Hall, S. R. (1981), Acta Cryst. A37, 517-525 and erratum (1981), A37, 921.
+- **Type**: string
+- **Requirements/Conventions**:
+
+  - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
+  - **Query**: Support for queries on this property is OPTIONAL.
+  - Each component of the space group name MUST be separated by a single space symbol.
+
+- **Examples**:
+
+  - :val:`P 2c -2ac`
+  - :val:`-I 4bd 2ab 3`
+
 space\_group\_it\_number
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2065,7 +2065,9 @@ space\_group\_hall
 
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
   - **Query**: Support for queries on this property is OPTIONAL.
-  - Each component of the space group name MUST be separated by a single space symbol.
+  - Each component of the Hall symbol MUST be separated by a single space symbol.
+  - If there exists a standard Hall symbol which represents the symmetry it SHOULD be used.
+  - MUST be null if :property:`nperiodic_dimensions` is not equal to 3.
 
 - **Examples**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2084,7 +2084,7 @@ space\_group\_it\_number
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
   - **Query**: Support for queries on this property is OPTIONAL.
   - The integer value MUST be between 1 and 230.
-  - MUST be null if :property:`nperiodic_dimensions` is not equal to 3.
+  - MUST be :val:`null` if :property:`nperiodic_dimensions` is not equal to 3.
 
 cartesian\_site\_positions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/optimade.rst
+++ b/optimade.rst
@@ -2059,7 +2059,7 @@ lattice\_vectors
 space\_group\_hall
 ~~~~~~~~~~~~~~~~~~
 
-- **Description**: Symmetry space group name as defined in Hall, S. R. (1981), Acta Cryst. A37, 517-525 and erratum (1981), A37, 921.
+- **Description**: A Hall space group symbol representing the symmetry of the structure as defined in Hall, S. R. (1981), Acta Cryst. A37, 517-525 and erratum (1981), A37, 921.
 - **Type**: string
 - **Requirements/Conventions**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2084,6 +2084,7 @@ space\_group\_it\_number
   - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
   - **Query**: Support for queries on this property is OPTIONAL.
   - The integer value MUST be between 1 and 230.
+  - MUST be null if :property:`nperiodic_dimensions` is not equal to 3.
 
 cartesian\_site\_positions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/optimade.rst
+++ b/optimade.rst
@@ -2081,7 +2081,7 @@ space\_group\_it\_number
 - **Type**: integer
 - **Requirements/Conventions**:
 
-  - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
+  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.
   - **Query**: Support for queries on this property is OPTIONAL.
   - The integer value MUST be between 1 and 230.
   - MUST be :val:`null` if :property:`nperiodic_dimensions` is not equal to 3.

--- a/optimade.rst
+++ b/optimade.rst
@@ -2063,7 +2063,7 @@ space\_group\_hall
 - **Type**: string
 - **Requirements/Conventions**:
 
-  - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be :val:`null`.
+  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.
   - **Query**: Support for queries on this property is OPTIONAL.
   - Each component of the Hall symbol MUST be separated by a single space symbol.
   - If there exists a standard Hall symbol which represents the symmetry it SHOULD be used.

--- a/optimade.rst
+++ b/optimade.rst
@@ -2077,7 +2077,7 @@ space\_group\_hall
 space\_group\_it\_number
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Description**: Symmetry space group number as defined in International Tables for Crystallography Vol. A.
+- **Description**: Space group number for the structure assigned by the International Tables for Crystallography Vol. A.
 - **Type**: integer
 - **Requirements/Conventions**:
 


### PR DESCRIPTION
Partially addresses #35  This PR introduces two symmetry space group notations, Hall symbol and IT number, closely following their usage in CIF. Both Hall symbol and IT number have their drawbacks: in some cases both need additional information to uniquely define symmetry space group of a crystal. To cover this drawback, a list of symmetry operations is needed, and its introduction is envisaged in #35. Nevertheless standardizing Hall symbol and IT number would facilitate searches on these widely used notations.