### PR TITLE
Means to specify database license

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -1022,9 +1022,9 @@ The single resource object's response dictionary MUST include the following fiel
   - **formats**: List of available output formats.
   - **entry\_types\_by\_format**: Available entry endpoints as a function of output formats.
   - **available\_endpoints**: List of available endpoints (i.e., the string to be appended to the versioned or unversioned base URL serving the API).
-  - **license**: A `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__ giving a pointer to a license covering all the data and metadata provided under this database.
-    If the license is included in the `SPDX License List <https://spdx.org/licenses/>`__, then the URL MUST point to SPDX-hosted license fulltext, i.e., it MUST start with :field-val:`https://spdx.org/licenses/`, but MUST NOT include the terminating :field-val:`.html`.
-    Example: :field-val:`https://spdx.org/licenses/CC0-1.0`.
+  - **license**: A `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__ giving a URL to a web page containing a human-readable text describing the license (or licensing options if there are multiple) covering all the data and metadata provided by this database.
+    Clients are advised not to try automated parsing of this link or its content, but rather rely on the field :field:`available_licenses` instead.
+    Example: :field-val:`https://example.com/licenses/example_license.html`.
 
   :field:`attributes` MAY also include the following OPTIONAL fields:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1021,15 +1021,16 @@ The single resource object's response dictionary MUST include the following fiel
   - **license**: A `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__ giving a pointer to a license covering all the data and metadata provided under this database.
     If the license is included in the `SPDX License List <https://spdx.org/licenses/>`__, then the URL MUST point to SPDX-hosted license fulltext, i.e., it MUST start with :field-val:`https://spdx.org/licenses/`, but MUST NOT include the terminating :field-val:`.html`.
     Example: :field-val:`https://spdx.org/licenses/CC0-1.0`.
-  - **compatible\_licenses**: List of SPDX license identifiers giving licenses the data and metadata in a database is compatible with.
-    In case the data and metadata is multiply-licensed, identifiers of these multiple licenses SHOULD be provided to let clients know under which conditions the data and metadata could be used.
-    If :field:`license` and :field:`compatible_licenses` contradict, :field:`compatible_licenses` has precedence.
 
   :field:`attributes` MAY also include the following OPTIONAL fields:
 
   - **is\_index**: if :field-val:`true`, this is an index meta-database base URL (see section `Index Meta-Database`_).
 
     If this member is *not* provided, the client MUST assume this is **not** an index meta-database base URL (i.e., the default is for :field:`is_index` to be :field-val:`false`).
+
+  - **compatible\_licenses**: List of SPDX license identifiers giving licenses the data and metadata in a database is compatible with.
+    In case the data and metadata is multiply-licensed, identifiers of these multiple licenses SHOULD be provided to let clients know under which conditions the data and metadata could be used.
+    If :field:`license` and :field:`compatible_licenses` contradict, :field:`compatible_licenses` has precedence.
 
 If this is an index meta-database base URL (see section `Index Meta-Database`_), then the response dictionary MUST also include the field:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1021,8 +1021,9 @@ The single resource object's response dictionary MUST include the following fiel
   - **license**: A `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__ giving a pointer to a license covering all the data and metadata provided under this database.
     If the license is included in the `SPDX License List <https://spdx.org/licenses/>`__, then the URL MUST point to SPDX-hosted license fulltext, i.e., it MUST start with :field-val:`https://spdx.org/licenses/`, but MUST NOT include the terminating :field-val:`.html`.
     Example: :field-val:`https://spdx.org/licenses/CC0-1.0`.
-  - **license_is_compatible_with_cc_by_4_0**: Boolean value indicating compatibility with `Creative Commons Attribution 4.0 International license <https://spdx.org/licenses/CC-BY-4.0>`__.
-    This field may be used to check whether a particular database allows aggregation of its data and metadata.
+  - **compatible\_licenses**: List of SPDX license identifiers giving licenses the data and metadata in a database is compatible with.
+    In case the data and metadata is multiply-licensed, identifiers of these multiple licenses SHOULD be provided to let clients know under which conditions the data and metadata could be used.
+    If :field:`license` and :field:`compatible_licenses` contradict, :field:`compatible_licenses` has precedence.
 
   :field:`attributes` MAY also include the following OPTIONAL fields:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1018,11 +1018,11 @@ The single resource object's response dictionary MUST include the following fiel
   - **formats**: List of available output formats.
   - **entry\_types\_by\_format**: Available entry endpoints as a function of output formats.
   - **available\_endpoints**: List of available endpoints (i.e., the string to be appended to the versioned or unversioned base URL serving the API).
-  - **license**: A `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__ giving a pointer to a license covering all the data provided under this database.
+  - **license**: A `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__ giving a pointer to a license covering all the data and metadata provided under this database.
     If the license is included in the `SPDX License List <https://spdx.org/licenses/>`__, then the URL MUST point to SPDX-hosted license fulltext, i.e., it MUST start with :field-val:`https://spdx.org/licenses/`, but MUST NOT include the terminating :field-val:`.html`.
     Example: :field-val:`https://spdx.org/licenses/CC0-1.0`.
   - **license_is_compatible_with_cc_by_4_0**: Boolean value indicating compatibility with `Creative Commons Attribution 4.0 International license <https://spdx.org/licenses/CC-BY-4.0>`__.
-    This field may be used to check whether a particular database allows aggregation of its data.
+    This field may be used to check whether a particular database allows aggregation of its data and metadata.
 
   :field:`attributes` MAY also include the following OPTIONAL fields:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1019,6 +1019,9 @@ The single resource object's response dictionary MUST include the following fiel
   - **entry\_types\_by\_format**: Available entry endpoints as a function of output formats.
   - **available\_endpoints**: List of available endpoints (i.e., the string to be appended to the versioned or unversioned base URL serving the API).
 
+  - **license**: A `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__ providing a pointer to a license covering all the data provided under this database.
+    If the license is included in the `SPDX License List <https://spdx.org/licenses/>`__, then the URL MUST point to SPDX-hosted license fulltext, i.e., it MUST start with `https://spdx.org/licenses/`.
+
   :field:`attributes` MAY also include the following OPTIONAL fields:
 
   - **is\_index**: if :field-val:`true`, this is an index meta-database base URL (see section `Index Meta-Database`_).

--- a/optimade.rst
+++ b/optimade.rst
@@ -1020,7 +1020,8 @@ The single resource object's response dictionary MUST include the following fiel
   - **available\_endpoints**: List of available endpoints (i.e., the string to be appended to the versioned or unversioned base URL serving the API).
 
   - **license**: A `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__ providing a pointer to a license covering all the data provided under this database.
-    If the license is included in the `SPDX License List <https://spdx.org/licenses/>`__, then the URL MUST point to SPDX-hosted license fulltext, i.e., it MUST start with `https://spdx.org/licenses/`.
+    If the license is included in the `SPDX License List <https://spdx.org/licenses/>`__, then the URL MUST point to SPDX-hosted license fulltext, i.e., it MUST start with :field-val:`https://spdx.org/licenses/`, but MUST NOT include the terminating :field-val:`.html`.
+    Example: :field-val:`https://spdx.org/licenses/CC0-1.0`.
 
   :field:`attributes` MAY also include the following OPTIONAL fields:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1032,12 +1032,12 @@ The single resource object's response dictionary MUST include the following fiel
 
     If this member is *not* provided, the client MUST assume this is **not** an index meta-database base URL (i.e., the default is for :field:`is_index` to be :field-val:`false`).
 
-  - **available\_licenses**: List of SPDX license identifiers specifying a set of alternative licenses under which the client is granted access to the data and metadata in this database.
+  - **available\_licenses**: List of `SPDX license identifiers <https://spdx.org/licenses/>` specifying a set of alternative licenses under which the client is granted access to all the data and metadata in this database.
+    If the data and metadata is available under multiple alternative licenses, identifiers of these multiple licenses SHOULD be provided to let clients know under which conditions the data and metadata can be used.
     Inclusion of a license identifier in the list is a commitment of the database that the rights are in place to grant clients access to all the data and metadata according to the terms of either of these licenses (at the choice of the client).
     If the licensing information provided via the field :field:`license` omits licensing options specified in :field:`available_licenses`, or if it otherwise contradicts them, a client MUST still be allowed to interpret the inclusion of a license in :field:`available_licenses` as a full commitment from the database that the data and metadata is available, without exceptions, under the respective licenses.
     If the database cannot make that commitment, e.g., if only part of the data is available under a license, the corresponding license identifier MUST NOT appear in :field:`available_licenses` (but, rather, the field :field:`license` is to be used to clarify the licensing situation.)
-    In case the data and metadata is multiply-licensed, identifiers of these multiple licenses SHOULD be provided to let clients know under which conditions the data and metadata can be used.
-
+    An empty list indicates that none of the SPDX licenses apply for the entirety of the database and that the licensing situation is clarified in human readable form in the field :field:`license`.
 If this is an index meta-database base URL (see section `Index Meta-Database`_), then the response dictionary MUST also include the field:
 
 - **relationships**: Dictionary that MAY contain a single `JSON API relationships object <https://jsonapi.org/format/1.0/#document-resource-object-relationships>`__:

--- a/optimade.rst
+++ b/optimade.rst
@@ -1028,7 +1028,7 @@ The single resource object's response dictionary MUST include the following fiel
 
     If this member is *not* provided, the client MUST assume this is **not** an index meta-database base URL (i.e., the default is for :field:`is_index` to be :field-val:`false`).
 
-  - **compatible\_licenses**: List of SPDX license identifiers giving licenses the data and metadata in a database is compatible with.
+  - **compatible\_licenses**: List of SPDX license identifiers giving licenses that the data and metadata in a database is compatible with.
     In case the data and metadata is multiply-licensed, identifiers of these multiple licenses SHOULD be provided to let clients know under which conditions the data and metadata could be used.
     If :field:`license` and :field:`compatible_licenses` contradict, :field:`compatible_licenses` has precedence.
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1018,10 +1018,11 @@ The single resource object's response dictionary MUST include the following fiel
   - **formats**: List of available output formats.
   - **entry\_types\_by\_format**: Available entry endpoints as a function of output formats.
   - **available\_endpoints**: List of available endpoints (i.e., the string to be appended to the versioned or unversioned base URL serving the API).
-
-  - **license**: A `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__ providing a pointer to a license covering all the data provided under this database.
+  - **license**: A `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__ giving a pointer to a license covering all the data provided under this database.
     If the license is included in the `SPDX License List <https://spdx.org/licenses/>`__, then the URL MUST point to SPDX-hosted license fulltext, i.e., it MUST start with :field-val:`https://spdx.org/licenses/`, but MUST NOT include the terminating :field-val:`.html`.
     Example: :field-val:`https://spdx.org/licenses/CC0-1.0`.
+  - **license_is_compatible_with_cc_by_4_0**: Boolean value indicating compatibility with `Creative Commons Attribution 4.0 International license <https://spdx.org/licenses/CC-BY-4.0>`__.
+    This field may be used to check whether a particular database allows aggregation of its data.
 
   :field:`attributes` MAY also include the following OPTIONAL fields:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1032,9 +1032,11 @@ The single resource object's response dictionary MUST include the following fiel
 
     If this member is *not* provided, the client MUST assume this is **not** an index meta-database base URL (i.e., the default is for :field:`is_index` to be :field-val:`false`).
 
-  - **compatible\_licenses**: List of SPDX license identifiers giving licenses that the data and metadata in a database is compatible with.
-    In case the data and metadata is multiply-licensed, identifiers of these multiple licenses SHOULD be provided to let clients know under which conditions the data and metadata could be used.
-    If :field:`license` and :field:`compatible_licenses` contradict, :field:`compatible_licenses` has precedence.
+  - **available\_licenses**: List of SPDX license identifiers specifying a set of alternative licenses under which the client is granted access to the data and metadata in this database.
+    Inclusion of a license identifier in the list is a commitment of the database that the rights are in place to grant clients access to all the data and metadata according to the terms of either of these licenses (at the choice of the client).
+    If the licensing information provided via the field :field:`license` omits licensing options specified in :field:`available_licenses`, or if it otherwise contradicts them, a client MUST still be allowed to interpret the inclusion of a license in :field:`available_licenses` as a full commitment from the database that the data and metadata is available, without exceptions, under the respective licenses.
+    If the database cannot make that commitment, e.g., if only part of the data is available under a license, the corresponding license identifier MUST NOT appear in :field:`available_licenses` (but, rather, the field :field:`license` is to be used to clarify the licensing situation.)
+    In case the data and metadata is multiply-licensed, identifiers of these multiple licenses SHOULD be provided to let clients know under which conditions the data and metadata can be used.
 
 If this is an index meta-database base URL (see section `Index Meta-Database`_), then the response dictionary MUST also include the field:
 


### PR DESCRIPTION
Fixes #102. After discussions with @rartino in #102 I became convinced that for now a single license for all the data in a database should be sufficient. Should there be parts of database belonging under a different license, they should either be described in database-wide license document, or moved to a separate "sibling" database under a different license.