### PR TITLE
Support fuzzy comparison lists

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -2580,7 +2580,7 @@ The Filter Language EBNF Grammar
                      | STARTS, [ WITH ], Value
                      | ENDS, [ WITH ], Value ;
 
-    SetOpRhs = HAS, ( ( Value | EqualityOperator, Value | RelativeComparisonOperator, OrderedValue ) | ALL, ValueList | ANY, ValueList | ONLY, ValueList ) ;
+    SetOpRhs = HAS, ( ( Value | EqualityOperator, Value | RelativeComparisonOperator, OrderedValue | FuzzyStringOpRhs ) | ALL, ValueList | ANY, ValueList | ONLY, ValueList ) ;
     (* Note: support for the alternatives with EqualityOperator, RelativeComparisonOperator, and ONLY in SetOpRhs are OPTIONAL *)
 
     SetZipOpRhs = PropertyZipAddon, HAS, ( ValueZip | ONLY, ValueZipList | ALL, ValueZipList | ANY, ValueZipList ) ;

--- a/optimade.rst
+++ b/optimade.rst
@@ -2537,7 +2537,7 @@ The Filter Language EBNF Grammar
     OrderedValue = ( OrderedConstant | Property ) ;
     (* Note: support for Property in OrderedValue is OPTIONAL *)
 
-    ValueListEntry = ( Value | ValueEqRhs | ValueRelCompRhs ) ;
+    ValueListEntry = ( Value | ValueEqRhs | ValueRelCompRhs | FuzzyStringOpRhs ) ;
     (* Note: support for ValueEqRhs and ValueRelCompRhs in ValueListEntry are OPTIONAL *)
 
     ValueList = ValueListEntry, { Comma, ValueListEntry } ;

--- a/optimade.rst
+++ b/optimade.rst
@@ -2538,7 +2538,7 @@ The Filter Language EBNF Grammar
     (* Note: support for Property in OrderedValue is OPTIONAL *)
 
     ValueListEntry = ( Value | ValueEqRhs | ValueRelCompRhs | FuzzyStringOpRhs ) ;
-    (* Note: support for ValueEqRhs and ValueRelCompRhs in ValueListEntry are OPTIONAL *)
+    (* Note: support for ValueEqRhs, ValueRelCompRhs and FuzzyStringOpRhs in ValueListEntry are OPTIONAL *)
 
     ValueList = ValueListEntry, { Comma, ValueListEntry } ;
     ValueZip = ValueListEntry, Colon, ValueListEntry, { Colon, ValueListEntry } ;
@@ -2581,7 +2581,7 @@ The Filter Language EBNF Grammar
                      | ENDS, [ WITH ], Value ;
 
     SetOpRhs = HAS, ( ( Value | EqualityOperator, Value | RelativeComparisonOperator, OrderedValue | FuzzyStringOpRhs ) | ALL, ValueList | ANY, ValueList | ONLY, ValueList ) ;
-    (* Note: support for the alternatives with EqualityOperator, RelativeComparisonOperator, and ONLY in SetOpRhs are OPTIONAL *)
+    (* Note: support for the alternatives with EqualityOperator, RelativeComparisonOperator, FuzzyStringOpRhs, and ONLY in SetOpRhs are OPTIONAL *)
 
     SetZipOpRhs = PropertyZipAddon, HAS, ( ValueZip | ONLY, ValueZipList | ALL, ValueZipList | ANY, ValueZipList ) ;
 

--- a/tests/cases/Filter_080.inp
+++ b/tests/cases/Filter_080.inp
@@ -1,0 +1,1 @@
+name:surname HAS STARTS WITH "J":CONTAINS "Doe"

--- a/tests/cases/Filter_080.opt
+++ b/tests/cases/Filter_080.opt
@@ -1,0 +1,1 @@
+Filter_001.opt

--- a/tests/cases/Filter_081.inp
+++ b/tests/cases/Filter_081.inp
@@ -1,0 +1,1 @@
+title HAS ENDS WITH "MOF"

--- a/tests/cases/Filter_081.opt
+++ b/tests/cases/Filter_081.opt
@@ -1,0 +1,1 @@
+tests/generated/Filter.g

--- a/tests/cases/Filter_082.inp
+++ b/tests/cases/Filter_082.inp
@@ -1,0 +1,1 @@
+elements HAS ALL STARTS WITH "S"

--- a/tests/cases/Filter_082.opt
+++ b/tests/cases/Filter_082.opt
@@ -1,0 +1,1 @@
+tests/generated/Filter.g

--- a/tests/outputs/Filter_032.out
+++ b/tests/outputs/Filter_032.out
@@ -37,7 +37,8 @@ Error: in tests/cases/Filter_032.inp: line 1:
     "-", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "a",
     "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n",
     "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "_",
-    "!", "=", "<", ">", "ALL", "ANY", or "ONLY"
+    "!", "=", "<", ">", "CONTAINS", "STARTS", "ENDS", "ALL", "ANY", or
+    "ONLY"
 
 elements HAS IS "H"
              ^

--- a/tests/outputs/Filter_037.out
+++ b/tests/outputs/Filter_037.out
@@ -70,7 +70,8 @@ Error: in tests/cases/Filter_037.inp: line 1:
     "-", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "a",
     "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n",
     "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "_",
-    "!", "=", "<", ">", "ONLY", "ALL", or "ANY"
+    "!", "=", "<", ">", "CONTAINS", "STARTS", "ENDS", "ONLY", "ALL",
+    or "ANY"
 
 elements:element_counts HAS IS 'H':6,'He':7
                             ^

--- a/tests/outputs/Filter_080.out
+++ b/tests/outputs/Filter_080.out
@@ -1,0 +1,103 @@
+Parse tree from tests/cases/Filter_080.inp:
+Filter(9999)
+  Expression(9999)
+    ExpressionClause(9999)
+      ExpressionPhrase(9999)
+        Comparison(9999)
+          PropertyFirstComparison(9999)
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_95(9999): "n", line: 1, col: 1
+                LowercaseLetter(9999)
+                  TOKEN_82(9999): "a", line: 1, col: 2
+                LowercaseLetter(9999)
+                  TOKEN_94(9999): "m", line: 1, col: 3
+                LowercaseLetter(9999)
+                  TOKEN_86(9999): "e", line: 1, col: 4
+            SetZipOpRhs(9999)
+              PropertyZipAddon(9999)
+                Colon(9999)
+                  TOKEN_26(9999): ":", line: 1, col: 5
+                Property(9999)
+                  Identifier(9999)
+                    LowercaseLetter(9999)
+                      TOKEN_100(9999): "s", line: 1, col: 6
+                    LowercaseLetter(9999)
+                      TOKEN_102(9999): "u", line: 1, col: 7
+                    LowercaseLetter(9999)
+                      TOKEN_99(9999): "r", line: 1, col: 8
+                    LowercaseLetter(9999)
+                      TOKEN_95(9999): "n", line: 1, col: 9
+                    LowercaseLetter(9999)
+                      TOKEN_82(9999): "a", line: 1, col: 10
+                    LowercaseLetter(9999)
+                      TOKEN_94(9999): "m", line: 1, col: 11
+                    LowercaseLetter(9999)
+                      TOKEN_86(9999): "e", line: 1, col: 12
+                    Spaces(9999)
+                      Space(9999)
+                        TOKEN_1(9999): " ", line: 1, col: 13
+              HAS(9999)
+                TOKEN_47(9999): "HAS", line: 1, col: 14
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 17
+              ValueZip(9999)
+                ValueListEntry(9999)
+                  FuzzyStringOpRhs(9999)
+                    STARTS(9999)
+                      TOKEN_65(9999): "STARTS", line: 1, col: 18
+                      Spaces(9999)
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 24
+                    WITH(9999)
+                      TOKEN_72(9999): "WITH", line: 1, col: 25
+                      Spaces(9999)
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 29
+                    Value(9999)
+                      OrderedValue(9999)
+                        OrderedConstant(9999)
+                          String(9999)
+                            TOKEN_3(9999): """, line: 1, col: 30
+                            EscapedChar(9999)
+                              UnescapedChar(9999)
+                                Letter(9999)
+                                  UppercaseLetter(9999)
+                                    TOKEN_50(9999): "J", line: 1, col: 31
+                            TOKEN_3(9999): """, line: 1, col: 32
+                Colon(9999)
+                  TOKEN_26(9999): ":", line: 1, col: 33
+                ValueListEntry(9999)
+                  FuzzyStringOpRhs(9999)
+                    CONTAINS(9999)
+                      TOKEN_39(9999): "CONTAINS", line: 1, col: 34
+                      Spaces(9999)
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 42
+                    Value(9999)
+                      OrderedValue(9999)
+                        OrderedConstant(9999)
+                          String(9999)
+                            TOKEN_3(9999): """, line: 1, col: 43
+                            EscapedChar(9999)
+                              UnescapedChar(9999)
+                                Letter(9999)
+                                  UppercaseLetter(9999)
+                                    TOKEN_40(9999): "D", line: 1, col: 44
+                            EscapedChar(9999)
+                              UnescapedChar(9999)
+                                Letter(9999)
+                                  LowercaseLetter(9999)
+                                    TOKEN_96(9999): "o", line: 1, col: 45
+                            EscapedChar(9999)
+                              UnescapedChar(9999)
+                                Letter(9999)
+                                  LowercaseLetter(9999)
+                                    TOKEN_86(9999): "e", line: 1, col: 46
+                            TOKEN_3(9999): """, line: 1, col: 47
+                            Spaces(9999)
+                              Space(9999)
+                                nl(9999)
+                                  SPECIAL_1(9999): "(...)", line: 1, col: 48

--- a/tests/outputs/Filter_081.out
+++ b/tests/outputs/Filter_081.out
@@ -1,0 +1,64 @@
+Parse tree from tests/cases/Filter_081.inp:
+Filter(9999)
+  Expression(9999)
+    ExpressionClause(9999)
+      ExpressionPhrase(9999)
+        Comparison(9999)
+          PropertyFirstComparison(9999)
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_101(9999): "t", line: 1, col: 1
+                LowercaseLetter(9999)
+                  TOKEN_90(9999): "i", line: 1, col: 2
+                LowercaseLetter(9999)
+                  TOKEN_101(9999): "t", line: 1, col: 3
+                LowercaseLetter(9999)
+                  TOKEN_93(9999): "l", line: 1, col: 4
+                LowercaseLetter(9999)
+                  TOKEN_86(9999): "e", line: 1, col: 5
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 6
+            SetOpRhs(9999)
+              HAS(9999)
+                TOKEN_47(9999): "HAS", line: 1, col: 7
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 10
+              FuzzyStringOpRhs(9999)
+                ENDS(9999)
+                  TOKEN_42(9999): "ENDS", line: 1, col: 11
+                  Spaces(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 15
+                WITH(9999)
+                  TOKEN_72(9999): "WITH", line: 1, col: 16
+                  Spaces(9999)
+                    Space(9999)
+                      TOKEN_1(9999): " ", line: 1, col: 20
+                Value(9999)
+                  OrderedValue(9999)
+                    OrderedConstant(9999)
+                      String(9999)
+                        TOKEN_3(9999): """, line: 1, col: 21
+                        EscapedChar(9999)
+                          UnescapedChar(9999)
+                            Letter(9999)
+                              UppercaseLetter(9999)
+                                TOKEN_55(9999): "M", line: 1, col: 22
+                        EscapedChar(9999)
+                          UnescapedChar(9999)
+                            Letter(9999)
+                              UppercaseLetter(9999)
+                                TOKEN_58(9999): "O", line: 1, col: 23
+                        EscapedChar(9999)
+                          UnescapedChar(9999)
+                            Letter(9999)
+                              UppercaseLetter(9999)
+                                TOKEN_43(9999): "F", line: 1, col: 24
+                        TOKEN_3(9999): """, line: 1, col: 25
+                        Spaces(9999)
+                          Space(9999)
+                            nl(9999)
+                              SPECIAL_1(9999): "(...)", line: 1, col: 26

--- a/tests/outputs/Filter_082.out
+++ b/tests/outputs/Filter_082.out
@@ -1,0 +1,67 @@
+Parse tree from tests/cases/Filter_082.inp:
+Filter(9999)
+  Expression(9999)
+    ExpressionClause(9999)
+      ExpressionPhrase(9999)
+        Comparison(9999)
+          PropertyFirstComparison(9999)
+            Property(9999)
+              Identifier(9999)
+                LowercaseLetter(9999)
+                  TOKEN_86(9999): "e", line: 1, col: 1
+                LowercaseLetter(9999)
+                  TOKEN_93(9999): "l", line: 1, col: 2
+                LowercaseLetter(9999)
+                  TOKEN_86(9999): "e", line: 1, col: 3
+                LowercaseLetter(9999)
+                  TOKEN_94(9999): "m", line: 1, col: 4
+                LowercaseLetter(9999)
+                  TOKEN_86(9999): "e", line: 1, col: 5
+                LowercaseLetter(9999)
+                  TOKEN_95(9999): "n", line: 1, col: 6
+                LowercaseLetter(9999)
+                  TOKEN_101(9999): "t", line: 1, col: 7
+                LowercaseLetter(9999)
+                  TOKEN_100(9999): "s", line: 1, col: 8
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 9
+            SetOpRhs(9999)
+              HAS(9999)
+                TOKEN_47(9999): "HAS", line: 1, col: 10
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 13
+              ALL(9999)
+                TOKEN_34(9999): "ALL", line: 1, col: 14
+                Spaces(9999)
+                  Space(9999)
+                    TOKEN_1(9999): " ", line: 1, col: 17
+              ValueList(9999)
+                ValueListEntry(9999)
+                  FuzzyStringOpRhs(9999)
+                    STARTS(9999)
+                      TOKEN_65(9999): "STARTS", line: 1, col: 18
+                      Spaces(9999)
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 24
+                    WITH(9999)
+                      TOKEN_72(9999): "WITH", line: 1, col: 25
+                      Spaces(9999)
+                        Space(9999)
+                          TOKEN_1(9999): " ", line: 1, col: 29
+                    Value(9999)
+                      OrderedValue(9999)
+                        OrderedConstant(9999)
+                          String(9999)
+                            TOKEN_3(9999): """, line: 1, col: 30
+                            EscapedChar(9999)
+                              UnescapedChar(9999)
+                                Letter(9999)
+                                  UppercaseLetter(9999)
+                                    TOKEN_64(9999): "S", line: 1, col: 31
+                            TOKEN_3(9999): """, line: 1, col: 32
+                            Spaces(9999)
+                              Space(9999)
+                                nl(9999)
+                                  SPECIAL_1(9999): "(...)", line: 1, col: 33


### PR DESCRIPTION
Fixes #393 by allowing `FuzzyStringOpRhs` in list comparisons and zip comparisons. All additions in this PR are OPTIONAL.