### PR TITLE
Explain our "media_type" is the same as MIME type

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -2914,7 +2914,7 @@ size
 media\_type
 ~~~~~~~~~~~
 
-- **Description**: Media type identifier for a file as per `RFC 6838 Media Type Specifications and Registration Procedures <https://datatracker.ietf.org/doc/html/rfc6838>`__.
+- **Description**: Media type identifier (also known as MIME type), for a file as per `RFC 6838 Media Type Specifications and Registration Procedures <https://datatracker.ietf.org/doc/html/rfc6838>`__.
 - **Type**: string
 - **Requirements/Conventions**:
 


### PR DESCRIPTION
I think MIME type is the more common term for the media type definition we give here.
Using "MIME type" instead of "media type" in a search, should make it easier for users/servers to find the correct media type for a particular file type.
