### PR TITLE
Add `database` field to `meta` for describing the current database

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -643,6 +643,17 @@ Every response SHOULD contain the following fields, and MUST contain at least :f
 
   Implementation note: the functionality of this field overlaps to some degree with features provided by the HTTP error :http-error:`429 Too Many Requests` and the `Retry-After HTTP header <https://tools.ietf.org/html/rfc7231.html#section-7.1.3>`__. Implementations are suggested to provide consistent handling of request overload through both mechanisms.
 
+  - **database**: a dictionary describing the specific database accessible at this OPTIMADE API.
+    If provided, the dictionary fields SHOULD match those provided in the corresponding the links entry for the database in the provider's index meta-database, outlined in `Links Endpoint JSON Response Schema`_.
+    The dictionary should contain the OPTIONAL fields:
+
+    - **name**: a human-readable name for the database, e.g., for use in clients.
+    - **description**: a human-readable description of the database, e.g., for use in clients.
+    - **homepage**: a `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__, pointing to a homepage for the particular database.
+    - **maintainer**: a dictionary providing details about the maintainer of the database, which MUST contain the single field:
+
+      - **email** with the maintainer's email address.
+
   - **implementation**: a dictionary describing the server implementation, containing the OPTIONAL fields:
 
     - **name**: name of the implementation.
@@ -709,6 +720,14 @@ Every response SHOULD contain the following fields, and MUST contain at least :f
                "email": "admin@example.com"
              },
              "issue_tracker": "http://tracker.example.com/exmpl-optimade"
+           },
+           "database": {
+             "name": "Example database 1 (of many)",
+             "description": "The first example database in a series hosted by the Example Provider.",
+             "homepage": "http://database_one.example.com",
+             "maintainer": {
+               "email": "science_lead@example.com"
+             }
            }
          }
          // ...

--- a/optimade.rst
+++ b/optimade.rst
@@ -647,6 +647,7 @@ Every response SHOULD contain the following fields, and MUST contain at least :f
     If provided, the dictionary fields SHOULD match those provided in the corresponding links entry for the database in the provider's index meta-database, outlined in `Links Endpoint JSON Response Schema`_.
     The dictionary can contain the OPTIONAL fields:
 
+    - **id**: the identifier of this database within those served by this provider, i.e., the ID under which this database is served in this provider's index meta-database.
     - **name**: a human-readable name for the database, e.g., for use in clients.
     - **version**: a string describing the version of the database.
     - **description**: a human-readable description of the database, e.g., for use in clients.

--- a/optimade.rst
+++ b/optimade.rst
@@ -644,8 +644,8 @@ Every response SHOULD contain the following fields, and MUST contain at least :f
   Implementation note: the functionality of this field overlaps to some degree with features provided by the HTTP error :http-error:`429 Too Many Requests` and the `Retry-After HTTP header <https://tools.ietf.org/html/rfc7231.html#section-7.1.3>`__. Implementations are suggested to provide consistent handling of request overload through both mechanisms.
 
   - **database**: a dictionary describing the specific database accessible at this OPTIMADE API.
-    If provided, the dictionary fields SHOULD match those provided in the corresponding the links entry for the database in the provider's index meta-database, outlined in `Links Endpoint JSON Response Schema`_.
-    The dictionary should contain the OPTIONAL fields:
+    If provided, the dictionary fields SHOULD match those provided in the corresponding links entry for the database in the provider's index meta-database, outlined in `Links Endpoint JSON Response Schema`_.
+    The dictionary can contain the OPTIONAL fields:
 
     - **name**: a human-readable name for the database, e.g., for use in clients.
     - **description**: a human-readable description of the database, e.g., for use in clients.

--- a/optimade.rst
+++ b/optimade.rst
@@ -723,6 +723,7 @@ Every response SHOULD contain the following fields, and MUST contain at least :f
              "issue_tracker": "http://tracker.example.com/exmpl-optimade"
            },
            "database": {
+               "id": "example_db",
              "name": "Example database 1 (of many)",
              "description": "The first example database in a series hosted by the Example Provider.",
              "homepage": "http://database_one.example.com",

--- a/optimade.rst
+++ b/optimade.rst
@@ -651,7 +651,7 @@ Every response SHOULD contain the following fields, and MUST contain at least :f
     - **name**: a human-readable name for the database, e.g., for use in clients.
     - **version**: a string describing the version of the database.
     - **description**: a human-readable description of the database, e.g., for use in clients.
-    - **homepage**: a `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__, pointing to a homepage for the particular database.
+    - **homepage**: a `JSON API link <http://jsonapi.org/format/1.0/#document-links>`__, pointing to a homepage for the particular database.
     - **maintainer**: a dictionary providing details about the maintainer of the database, which MUST contain the single field:
 
       - **email** with the maintainer's email address.

--- a/optimade.rst
+++ b/optimade.rst
@@ -648,6 +648,7 @@ Every response SHOULD contain the following fields, and MUST contain at least :f
     The dictionary can contain the OPTIONAL fields:
 
     - **name**: a human-readable name for the database, e.g., for use in clients.
+    - **version**: a string describing the version of the database.
     - **description**: a human-readable description of the database, e.g., for use in clients.
     - **homepage**: a `JSON API links object <http://jsonapi.org/format/1.0/#document-links>`__, pointing to a homepage for the particular database.
     - **maintainer**: a dictionary providing details about the maintainer of the database, which MUST contain the single field:

--- a/optimade.rst
+++ b/optimade.rst
@@ -724,7 +724,7 @@ Every response SHOULD contain the following fields, and MUST contain at least :f
              "issue_tracker": "http://tracker.example.com/exmpl-optimade"
            },
            "database": {
-               "id": "example_db",
+             "id": "example_db",
              "name": "Example database 1 (of many)",
              "description": "The first example database in a series hosted by the Example Provider.",
              "homepage": "http://database_one.example.com",


### PR DESCRIPTION
Closes #422.

This PR adds the optional `database` field to all `meta` responses. It can be used to provide the same data on an individual database as that found at the index meta-database, without requiring several requests and potential filtering of the index meta-database response.

----
Only other thought when writing this up is that this info could also be provided as a `self` entry in the `links` field for every response (though the fields would be limited to just using a `meta` field as part of a JSON API Links object).

If we prefer this route, then an alternative note could be added to the "JSON Response Schema: Common Fields" section of the spec that reserves the `self` keyword or something similar for this use, the only complication being that JSON:API `self` links should just return the exact URL of the current response.

----
Or one final option is just to add this kind of info at `/info/` directly, and exclude it from `meta`.