### PR TITLE
Clarify encoding of OPTIMADE timestamp in property definitions.

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -1927,10 +1927,10 @@ The format described in this subsection forms a subset of the `JSON Schema Valid
 
   For OPTIMADE data types not covered above:
 
-  - timestamps are represented by setting the fields :field:`type` to :val:`"string"` and :field:`format` to :val:`"date-time"`.
+  - timestamps are represented by setting the :field:`type` field to :val:`"string"` and the :field:`format` field to :val:`"date-time"`.
     In this case it is MANDATORY to include the field :field:`format`.
 
-  Output formats that represent these OPTIMADE data types in other ways have to recognize them and reinterprete the definition accordingly.
+  Output formats that represent these OPTIMADE data types in other ways have to recognize them and reinterpret the definition accordingly.
 
 ..
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1925,6 +1925,13 @@ The format described in this subsection forms a subset of the `JSON Schema Valid
   - One of the strings :val:`"boolean"`, :val:`"object"` (refers to an OPTIMADE dictionary), :val:`"array"` (refers to an OPTIMADE list), :val:`"number"` (refers to an OPTIMADE float), :val:`"string"`, or :val:`"integer"`.
   - A list where the first item MUST be one of the strings above, and the second item MUST be the string :val:`"null"`.
 
+  For OPTIMADE data types not covered above:
+
+  - timestamps are represented by setting the field :field:`type` to :val:`"string"` and :field:`format` to :val:`"date-time"`.
+    In this case it is MANDATORY to include the field :field:`format`.
+
+  Output formats that represent these OPTIMADE data types in other ways have to recognize them and reinterprete the definition accordingly.
+
 ..
 
   Implementation notes:

--- a/optimade.rst
+++ b/optimade.rst
@@ -1927,7 +1927,7 @@ The format described in this subsection forms a subset of the `JSON Schema Valid
 
   For OPTIMADE data types not covered above:
 
-  - timestamps are represented by setting the field :field:`type` to :val:`"string"` and :field:`format` to :val:`"date-time"`.
+  - timestamps are represented by setting the fields :field:`type` to :val:`"string"` and :field:`format` to :val:`"date-time"`.
     In this case it is MANDATORY to include the field :field:`format`.
 
   Output formats that represent these OPTIMADE data types in other ways have to recognize them and reinterprete the definition accordingly.


### PR DESCRIPTION
Fix to resolve #443 by explaining how to encode a timestamp in a property definition.