### PR TITLE
Make clean additional files

### DIFF
--- a/tests/makefiles/Makelocal-authors
+++ b/tests/makefiles/Makelocal-authors
@@ -19,3 +19,10 @@ tests/generated/AUTHORS.sorted: AUTHORS
 	| awk -F: '{print $$2}' \
 	| sed 's/Di_/Di /' \
 	>> $@
+
+.PHONY: clean clean_authors
+
+clean: clean_authors
+
+clean_authors:
+	rm -f tests/generated/AUTHORS.sorted

--- a/tests/makefiles/Makelocal-tests
+++ b/tests/makefiles/Makelocal-tests
@@ -163,6 +163,7 @@ test-clean:
 	rm -f ${DIFF_FILES}
 
 test-distclean test-cleanAll: test-clean
+	rm -f ${DEPEND}
 
 clean: test-clean
 


### PR DESCRIPTION
This PR slightly modifies the makefiles to also remove additional unversioned files upon running "make clean".

I noticed that running `make; make distclean;` did not remove all of the generated unversioned files (files can be easily listed by running `git status --ignored`).

The `make rules` involving the `tests/tools/grammatica-1.6.zip` unversioned file were not modified since it is seems to be purposely preserved during `make distclean`. 