### PR TITLE
Changes to property definitions

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -1872,7 +1872,7 @@ A Property Definition MUST be composed according to the combination of the requi
 **REQUIRED keys for all levels of the Property Definition:**
 
 - :field:`x-optimade-type`: String
-  Specifies the OPTIMADE data type, i.e., MUST be one of :val:`"string"`, :val:`"integer"`, :val:`"float"`, :val:`"boolean"`, :val:`"timestamp"`, :val:`"list"`, or :val:`"dictionary"`.
+  Specifies the OPTIMADE data type for this level of the defined property, i.e., MUST be one of :val:`"string"`, :val:`"integer"`, :val:`"float"`, :val:`"boolean"`, :val:`"timestamp"`, :val:`"list"`, or :val:`"dictionary"`.
 
 - :field:`x-optimade-unit`: String.
   A (compound) symbol for the physical unit in which the value of the defined property is given or one of the strings :val:`dimensionless` or :val:`inapplicable`.
@@ -1945,26 +1945,29 @@ The format described in this subsection forms a subset of the `JSON Schema Valid
 **REQUIRED keys**
 
 - :field:`type`: String or List.
-  The string or list specifies the type of the defined property.
+  Specifies the corresponding JSON type for this level of the defined property.
+  The value is directly correlated with :field:`x-optimade-type` as explained below.
+
   It MUST be one of:
 
-  - One of the strings :val:`"boolean"`, :val:`"object"` (refers to an OPTIMADE dictionary), :val:`"array"` (refers to an OPTIMADE list), :val:`"number"` (refers to an OPTIMADE float), :val:`"string"`, or :val:`"integer"`.
-  - A list where the first item MUST be one of the strings above, and the second item MUST be the string :val:`"null"`.
+  - A string correlated with :field:`x-optimade-type` as follows.
+    If :field:`x-optimade-type` is:
 
-  For OPTIMADE data types not covered above:
+    * :val:`"boolean"`, `"string"`, or `"integer"` then :field:`type` is the same string.
+    * :val:`"dictionary"` then :field:`type` is `"object"`.
+    * :val:`"list"` then :field:`type` is `"array"`.
+    * :val:`"float"` then :field:`type` is `"number"`.
+    * :val:`"timestamp"` then :field:`type` is `"string"`.
 
-  - timestamps are represented by setting the :field:`type` field to :val:`"string"` and the :field:`format` field to :val:`"date-time"`.
-    In this case it is MANDATORY to include the field :field:`format`.
-
-  Output formats that represent these OPTIMADE data types in other ways have to recognize them and reinterpret the definition accordingly.
+  - A list where the first item MUST be the string above (correlated to the field :field:`x-optimade-type` in the same way) and the second item MUST be the string :val:`"null"`.
 
 ..
 
   Implementation notes:
 
-    - The strings used in the :field:`type` field are JSON type names encoded as strings, but they refer to the corresponding OPTIMADE data types.
-      Nevertheless, for consistency across formats, the JSON type names MUST be used regardless of the standard type names of the output format.
-      The motivation for this design decision is that it makes the JSON representation of a Property Definition a fully valid standard JSON Schema.
+    - The field :field:`type` can be derived from the field :field:`x-optimade-type` and its role is only to provide the JSON type names corresponding to :field:`x-optimade-type`.
+      The motivation to include these type names is that it makes the JSON representation of a Property Definition a fully valid standard JSON Schema.
+      Nevertheless, for consistency across formats, these JSON type names MUST still be included when a property definition is represented in other output format (i.e., the JSON names MUST NOT be translated into the type names of that output format).
 
     - The allowed values of the :field:`type` field are highly restricted compared to what is permitted using the full JSON Schema standard.
       Values can only be defined to be a single OPTIMADE data type or, optionally, :val:`null`.
@@ -1973,7 +1976,7 @@ The format described in this subsection forms a subset of the `JSON Schema Valid
 **OPTIONAL keys**
 
 - :field:`$id`: String.
-  A static URI identifier that is a URN or URL representing the specific version of the property.
+  A static URI identifier that is a URN or URL representing the specific version of this level of the defined property.
   It SHOULD NOT be changed as long as the property definition remains the same, and SHOULD be changed when the property definition changes.
   (If it is a URL, clients SHOULD NOT assign any interpretation to the response when resolving that URL.)
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1181,7 +1181,9 @@ Example (note: the description strings have been wrapped for readability only):
         "description": "a structures entry",
         "properties": {
           "nelements": {
+            "$id": "urn:uuid:10a05e55-0c20-4f68-89ad-35a18eb7076f",
             "title": "Number of elements",
+            "x-optimade-type": "integer",
             "type": ["integer", "null"],
             "description": "Number of different elements in the structure as an integer.\n
              \n
@@ -1192,7 +1194,7 @@ Example (note: the description strings have been wrapped for readability only):
               3
             ],
             "x-optimade-property": {
-              "property-uri": "urn:uuid:10a05e55-0c20-4f68-89ad-35a18eb7076f",
+               "property-format": "1.2"
             },
             "x-optimade-unit": "dimensionless",
             "x-optimade-implementation": {
@@ -1206,7 +1208,9 @@ Example (note: the description strings have been wrapped for readability only):
             }
           },
           "lattice_vectors": {
+            "$id": "urn:uuid:81edf372-7b1b-4518-9c14-7d482bd67834",
             "title": "Unit cell lattice vectors",
+            "x-optimade-type": "list",
             "type": ["array", "null"],
             "description": "The three lattice vectors in Cartesian coordinates, in ångström (Å).\n
             \n
@@ -1218,7 +1222,7 @@ Example (note: the description strings have been wrapped for readability only):
             ],
             "x-optimade-unit": "inapplicable",
             "x-optimade-property": {
-              "property-uri": "urn:uuid:81edf372-7b1b-4518-9c14-7d482bd67834",
+              "property-format": "1.2",
               "unit-definitions": [
                 {
                   "symbol": "angstrom",
@@ -1244,22 +1248,24 @@ Example (note: the description strings have been wrapped for readability only):
             "maxItems": 3
             "minItems": 3
             "items": {
-               "type": "array",
-               "x-optimade-unit": "inapplicable",
-               "maxItems": 3
-               "minItems": 3
-               "items": {
-                 "type": "number",
-                 "x-optimade-unit": "angstrom",
-                 "x-optimade-implementation": {
-                   "sortable": true,
-                   "query-support": "none"
-                 },
-                 "x-optimade-requirements": {
-                   "sortable": false,
-                   "query-support": "none"
-                 }
-               }
+              "type": "array",
+              "x-optimade-type": "list",
+              "x-optimade-unit": "inapplicable",
+              "maxItems": 3
+              "minItems": 3
+              "items": {
+                "type": "number",
+                "x-optimade-type": "float",
+                "x-optimade-unit": "angstrom",
+              "x-optimade-implementation": {
+                  "sortable": true,
+                  "query-support": "none"
+                },
+                "x-optimade-requirements": {
+                  "sortable": false,
+                  "query-support": "none"
+                }
+              }
             }
           }
           // ... <other property descriptions>
@@ -1823,7 +1829,7 @@ A Property Definition MUST be composed according to the combination of the requi
 
 **REQUIRED keys for the outermost level of the Property Definition:**
 
-- :field:`title`: String and :field:`description`: String.
+- :field:`$id`, :field:`title`: String, and :field:`description`: String.
   See the subsection `Property definition keys from JSON Schema`_ for the definitions of these fields.
   They are defined in that subsection as OPTIONAL on any level of the Property Definition, but are REQUIRED on the outermost level.
 
@@ -1839,11 +1845,6 @@ A Property Definition MUST be composed according to the combination of the requi
     In implementations of the present version of the standard, the value MUST be exactly :field-val:`1.2`.
     A client MUST disregard the property definition if the field is not a string of the format MAJOR.MINOR or if the MAJOR version number is unrecognized.
     This field allows future versions of this standard to support implementations keeping definitions that adhere to older versions of the property definition format.
-
-  - :field:`property-uri`: String.
-    A static URI identifier that is a URN or URL representing the specific version of the property.
-    It SHOULD NOT be changed as long as the property definition remains the same, and SHOULD be changed when the property definition changes.
-    (If it is a URL, clients SHOULD NOT assign any interpretation to the response when resolving that URL.)
 
   **OPTIONAL keys:**
 
@@ -1869,6 +1870,9 @@ A Property Definition MUST be composed according to the combination of the requi
       A URI of the external resource (which MAY be a resolvable URL).
 
 **REQUIRED keys for all levels of the Property Definition:**
+
+- :field:`x-optimade-type`: String
+  Specifies the OPTIMADE data type, i.e., MUST be one of :val:`"string"`, :val:`"integer"`, :val:`"float"`, :val:`"boolean"`, :val:`"timestamp"`, :val:`"list"`, or :val:`"dictionary"`.
 
 - :field:`x-optimade-unit`: String.
   A (compound) symbol for the physical unit in which the value of the defined property is given or one of the strings :val:`dimensionless` or :val:`inapplicable`.
@@ -1967,6 +1971,11 @@ The format described in this subsection forms a subset of the `JSON Schema Valid
       This restriction is intended to reduce the complexity of possible data types that implementations have to handle in different formats and database backends.
 
 **OPTIONAL keys**
+
+- :field:`$id`: String.
+  A static URI identifier that is a URN or URL representing the specific version of the property.
+  It SHOULD NOT be changed as long as the property definition remains the same, and SHOULD be changed when the property definition changes.
+  (If it is a URL, clients SHOULD NOT assign any interpretation to the response when resolving that URL.)
 
 - :field:`title`: String.
   A short single-line human-readable explanation of the defined property appropriate to show as part of a user interface.

--- a/optimade.rst
+++ b/optimade.rst
@@ -1829,7 +1829,7 @@ A Property Definition MUST be composed according to the combination of the requi
 
 **REQUIRED keys for the outermost level of the Property Definition:**
 
-- :field:`$id`, :field:`title`: String, and :field:`description`: String.
+- :field:`$id`: String, :field:`title`: String, and :field:`description`: String.
   See the subsection `Property definition keys from JSON Schema`_ for the definitions of these fields.
   They are defined in that subsection as OPTIONAL on any level of the Property Definition, but are REQUIRED on the outermost level.
 
@@ -1872,7 +1872,8 @@ A Property Definition MUST be composed according to the combination of the requi
 **REQUIRED keys for all levels of the Property Definition:**
 
 - :field:`x-optimade-type`: String
-  Specifies the OPTIMADE data type for this level of the defined property, i.e., MUST be one of :val:`"string"`, :val:`"integer"`, :val:`"float"`, :val:`"boolean"`, :val:`"timestamp"`, :val:`"list"`, or :val:`"dictionary"`.
+  Specifies the OPTIMADE data type for this level of the defined property.
+  MUST be one of :val:`"string"`, :val:`"integer"`, :val:`"float"`, :val:`"boolean"`, :val:`"timestamp"`, :val:`"list"`, or :val:`"dictionary"`.
 
 - :field:`x-optimade-unit`: String.
   A (compound) symbol for the physical unit in which the value of the defined property is given or one of the strings :val:`dimensionless` or :val:`inapplicable`.
@@ -1959,7 +1960,7 @@ The format described in this subsection forms a subset of the `JSON Schema Valid
     * :val:`"float"` then :field:`type` is `"number"`.
     * :val:`"timestamp"` then :field:`type` is `"string"`.
 
-  - A list where the first item MUST be the string above (correlated to the field :field:`x-optimade-type` in the same way) and the second item MUST be the string :val:`"null"`.
+  - A list where the first item MUST be the string described above (correlated to the field :field:`x-optimade-type` in the same way) and the second item MUST be the string :val:`"null"`.
 
 ..
 
@@ -1967,7 +1968,7 @@ The format described in this subsection forms a subset of the `JSON Schema Valid
 
     - The field :field:`type` can be derived from the field :field:`x-optimade-type` and its role is only to provide the JSON type names corresponding to :field:`x-optimade-type`.
       The motivation to include these type names is that it makes the JSON representation of a Property Definition a fully valid standard JSON Schema.
-      Nevertheless, for consistency across formats, these JSON type names MUST still be included when a property definition is represented in other output format (i.e., the JSON names MUST NOT be translated into the type names of that output format).
+      Nevertheless, for consistency across formats, these JSON type names MUST still be included when a property definition is represented in other output formats (i.e., the JSON names MUST NOT be translated into the type names of that output format).
 
     - The allowed values of the :field:`type` field are highly restricted compared to what is permitted using the full JSON Schema standard.
       Values can only be defined to be a single OPTIMADE data type or, optionally, :val:`null`.

--- a/optimade.rst
+++ b/optimade.rst
@@ -1946,7 +1946,7 @@ The format described in this subsection forms a subset of the `JSON Schema Valid
 **REQUIRED keys**
 
 - :field:`type`: String or List.
-  Specifies the corresponding JSON type for this level of the defined property.
+  Specifies the corresponding JSON type for this level of the defined property and whether the property can be :val:`null` or not.
   The value is directly correlated with :field:`x-optimade-type` as explained below.
 
   It MUST be one of:
@@ -1961,6 +1961,7 @@ The format described in this subsection forms a subset of the `JSON Schema Valid
     * :val:`"timestamp"` then :field:`type` is `"string"`.
 
   - A list where the first item MUST be the string described above (correlated to the field :field:`x-optimade-type` in the same way) and the second item MUST be the string :val:`"null"`.
+    This form specifies that the defined property can be :val:`null`.
 
 ..
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1235,7 +1235,7 @@ Example (note: the description strings have been wrapped for readability only):
                   }
                 }
               ]
-            }
+            },
             "x-optimade-implementation": {
               "sortable": false,
               "query-support": "none"
@@ -1244,7 +1244,7 @@ Example (note: the description strings have been wrapped for readability only):
               "support": "should",
               "sortable": false,
               "query-support": "none"
-            }
+            },
             "maxItems": 3,
             "minItems": 3,
             "items": {
@@ -1257,7 +1257,7 @@ Example (note: the description strings have been wrapped for readability only):
                 "type": "number",
                 "x-optimade-type": "float",
                 "x-optimade-unit": "angstrom",
-              "x-optimade-implementation": {
+                "x-optimade-implementation": {
                   "sortable": true,
                   "query-support": "none"
                 },

--- a/optimade.rst
+++ b/optimade.rst
@@ -1245,14 +1245,14 @@ Example (note: the description strings have been wrapped for readability only):
               "sortable": false,
               "query-support": "none"
             }
-            "maxItems": 3
-            "minItems": 3
+            "maxItems": 3,
+            "minItems": 3,
             "items": {
               "type": "array",
               "x-optimade-type": "list",
               "x-optimade-unit": "inapplicable",
-              "maxItems": 3
-              "minItems": 3
+              "maxItems": 3,
+              "minItems": 3,
               "items": {
                 "type": "number",
                 "x-optimade-type": "float",


### PR DESCRIPTION
Some minor adjustments to our property definitions according to what has been discussed in issues:

- Change `x-optimade-property/property-uri` into simply `$id`, which is the JSON Schema standard way of communicating the same thing, see #442.
- Add a field `x-optimade-type` to specify the OPTIMADE data type. It was concluded in #392, #436 that this is necessary if we do not want to make things very complicated when/if we want/need to support more complex data types.

The definition of the `type` field has thus been completely rewritten to take into account the quite direct relationship to `x-optimade-property`.

(Note: I mentioned earlier that I would take this in #445, but upon realizing that I had to do rather significant edits here, I decided not to mix the two up.)

**Edit:** Oh, and this PR also fixes a bug in that the mandatory `x-optimade-property/property-format` was not included in the response example.