### PR TITLE
Add `bonds` for structure type entries

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -2846,7 +2846,7 @@ bonds
   - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.
   - **Query**: Support for queries on this property is OPTIONAL.
     If supported, filters MAY support only a subset of comparison operators.
-  - The property SHOULD be :val:`null` for structures for which the bond perception has not been carried out by the implementation.
+  - The property SHOULD be :val:`null` for structures for which the chemical connectivity is unknown to the implementation.
   - :property:`sites` inside each dictionary contains two integers refering to different sites which are deemed chemically connected.
 
 - **Examples**:

--- a/optimade.rst
+++ b/optimade.rst
@@ -2833,6 +2833,26 @@ assemblies
     These two sites are correlated (either site 2 or 3 is present).
     However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2\*0.3 = 6 % probability; the pair (0, 3) with 0.2\*0.7 = 14 % probability; the pair (1, 2) with 0.8\*0.3 = 24 % probability; and the pair (1, 3) with 0.8\*0.7 = 56 % probability).
 
+bonds
+~~~~~
+
+- **Description**: A list describing the chemical connectivity in the structure.
+- **Type**: list of dictionary with keys:
+
+  - :property:`sites`: a list of integers (REQUIRED)
+
+- **Requirements/Conventions**:
+
+  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.
+  - **Query**: Support for queries on this property is OPTIONAL.
+    If supported, filters MAY support only a subset of comparison operators.
+  - The property SHOULD be :val:`null` for structures for which the bond perception has not been carried out by the implementation.
+  - :property:`sites` inside each dictionary contains two integers refering to different sites which are deemed chemically connected.
+
+- **Examples**:
+
+  - :val:`[ {"sites": [1, 2]} ]`: a structure with a bond between sites 1 and 2.
+
 structure\_features
 ~~~~~~~~~~~~~~~~~~~
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2859,7 +2859,7 @@ bonds
 
 - **Examples**:
 
-  - :val:`[ {"sites": [0, 1]} ]`: a structure with a bond between sites 1 and 2.
+  - :val:`[ {"sites": [0, 1]} ]`: a structure with a bond between sites 0 and 1.
   - :val:`[ {"sites": [0, 0], "translations": [ [0, 0, 0], [0, 0, 1] ]} ]`: a 1D polymer.
 
 structure\_features

--- a/optimade.rst
+++ b/optimade.rst
@@ -2856,7 +2856,8 @@ bonds
 
     - *translations*: a list of two lists of three integers each, defining translations of the sites.
       Omitting this key means that both translation vectors are :val:`[0, 0, 0]`.
-
+    - *distance*: the distance in Angstrom between the two sites after applying the appropriate translation vectors.
+    
 - **Examples**:
 
   - :val:`[ {"sites": [0, 1]} ]`: a structure with a bond between sites 0 and 1.

--- a/optimade.rst
+++ b/optimade.rst
@@ -2847,7 +2847,8 @@ bonds
   - **Query**: Support for queries on this property is OPTIONAL.
     If supported, filters MAY support only a subset of comparison operators.
   - The property SHOULD be :val:`null` for structures for which the chemical connectivity is unknown to the implementation.
-  - :property:`sites` inside each dictionary contains two integers refering to different sites which are deemed chemically connected.
+  - :property:`sites` inside each dictionary contains two integers refering to sites which are deemed chemically connected.
+    The site indexes MUST be ordered in non-decreasing manner.
 
 - **Examples**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2840,6 +2840,7 @@ bonds
 - **Type**: list of dictionary with keys:
 
   - :property:`sites`: a list of integers (REQUIRED)
+  - :property:`translations`: a list of list of integers (OPTIONAL)
 
 - **Requirements/Conventions**:
 
@@ -2851,9 +2852,15 @@ bonds
 
     - *sites*: an ordered list of 0-based indexes of the two sites that form a chemical bond.
 
+  - If translations are needed by at least one of the sites of a bond, the following key SHOULD be used:
+
+    - *translations*: a list of two lists of three integers each, defining translations of the sites.
+      Omitting this key means that both translation vectors are :val:`[0, 0, 0]`.
+
 - **Examples**:
 
   - :val:`[ {"sites": [1, 2]} ]`: a structure with a bond between sites 1 and 2.
+  - :val:`[ {"sites": [1, 1], "translations": [ [0, 0, 0], [0, 0, 1] ]} ]`: a 1D polymer.
 
 structure\_features
 ~~~~~~~~~~~~~~~~~~~

--- a/optimade.rst
+++ b/optimade.rst
@@ -2859,8 +2859,8 @@ bonds
 
 - **Examples**:
 
-  - :val:`[ {"sites": [1, 2]} ]`: a structure with a bond between sites 1 and 2.
-  - :val:`[ {"sites": [1, 1], "translations": [ [0, 0, 0], [0, 0, 1] ]} ]`: a 1D polymer.
+  - :val:`[ {"sites": [0, 1]} ]`: a structure with a bond between sites 1 and 2.
+  - :val:`[ {"sites": [0, 0], "translations": [ [0, 0, 0], [0, 0, 1] ]} ]`: a 1D polymer.
 
 structure\_features
 ~~~~~~~~~~~~~~~~~~~

--- a/optimade.rst
+++ b/optimade.rst
@@ -2836,7 +2836,7 @@ assemblies
 bonds
 ~~~~~
 
-- **Description**: A list describing the chemical connectivity in the structure.
+- **Description**: A list describing the chemical connectivity of the structure.
 - **Type**: list of dictionary with keys:
 
   - :property:`sites`: a list of integers (REQUIRED)

--- a/optimade.rst
+++ b/optimade.rst
@@ -2858,7 +2858,7 @@ bonds
     - *translations*: a list of two lists of three integers each, defining translations of the sites.
       Omitting this key means that both translation vectors are :val:`[0, 0, 0]`.
 
-  - OPTIONAL key :property:`distance` MAY be used to provide distance in ångström (Å) between the two sites after applying the appropriate translation vectors.
+  - OPTIONAL key :property:`distance` MAY be used to provide the distance in ångströms (Å) between the two sites after applying the appropriate translation vectors.
 
 - **Examples**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2847,7 +2847,8 @@ bonds
   - **Query**: Support for queries on this property is OPTIONAL.
     If supported, filters MAY support only a subset of comparison operators.
   - The property SHOULD be :val:`null` for structures for which the chemical connectivity is unknown to the implementation.
-  - :property:`sites` inside each dictionary contains two integers refering to different sites which are deemed chemically connected.
+  - If present, it MUST be a list of dictionaries, each of which represents a chemical bond and MUST have the following key:
+    - *sites*: 0-based indexes of the two sites that form a chemical bond.
 
 - **Examples**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2848,6 +2848,7 @@ bonds
     If supported, filters MAY support only a subset of comparison operators.
   - The property SHOULD be :val:`null` for structures for which the chemical connectivity is unknown to the implementation.
   - If present, it MUST be a list of dictionaries, each of which represents a chemical bond and MUST have the following key:
+
     - *sites*: an ordered list of 0-based indexes of the two sites that form a chemical bond.
 
 - **Examples**:

--- a/optimade.rst
+++ b/optimade.rst
@@ -2850,7 +2850,7 @@ bonds
   - The property SHOULD be :val:`null` for structures for which the chemical connectivity is unknown to the implementation.
   - If present, it MUST be a list of dictionaries, each of which represents a chemical bond and MUST have the following key:
 
-    - *sites*: an ordered list of 0-based indexes of the two sites that form a chemical bond.
+    - *sites*: a non-decreasing list of 0-based indexes of the two sites that form a chemical bond.
 
   - If translations are needed by at least one of the sites of a bond, the following key SHOULD be used:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2859,7 +2859,7 @@ bonds
       Omitting this key means that both translation vectors are :val:`[0, 0, 0]`.
 
   - OPTIONAL key :property:`distance` MAY be used to provide distance in ångström (Å) between the two sites after applying the appropriate translation vectors.
-    
+
 - **Examples**:
 
   - :val:`[ {"sites": [0, 1]} ]`: a structure with a bond between sites 0 and 1.

--- a/optimade.rst
+++ b/optimade.rst
@@ -2841,6 +2841,7 @@ bonds
 
   - :property:`sites`: a list of integers (REQUIRED)
   - :property:`translations`: a list of list of integers (OPTIONAL)
+  - :property:`distance`: float (OPTIONAL)
 
 - **Requirements/Conventions**:
 
@@ -2856,7 +2857,8 @@ bonds
 
     - *translations*: a list of two lists of three integers each, defining translations of the sites.
       Omitting this key means that both translation vectors are :val:`[0, 0, 0]`.
-    - *distance*: the distance in Angstrom between the two sites after applying the appropriate translation vectors.
+
+  - OPTIONAL key :property:`distance` MAY be used to provide distance in ångström (Å) between the two sites after applying the appropriate translation vectors.
     
 - **Examples**:
 


### PR DESCRIPTION
In issue Materials-Consortia/namespace-cheminformatics#14 I proposed adding more chemical properties to OPTIMADE structures. This PR implements [my suggestion](https://github.com/Materials-Consortia/namespace-cheminformatics/issues/14#issuecomment-1434603619) on representation of chemical connectivity between pairs of sites in OPTIMADE:
```json
{
    "bonds": [ {"sites": [1, 2]} ]
}
```
I intentionally omit the bond types as this might be difficult to agree upon, whereas having just the connectivity is already beneficial.

Pinging people who have expressed their interest for comments: @eimrek @BobHanson @Austin243

**Edit**: I have introduced means to express connections with translation equivalents of the sites in `sites`.