### PR TITLE
InChIKey property

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -2500,6 +2500,20 @@ chemical\_formula\_anonymous
 
   - A filter that matches an exactly given formula is :filter:`chemical_formula_anonymous="A2B"`.
 
+inchikey
+~~~~~~~~
+
+- **Description**: The standard InChIKey representation of the structure.
+- **Type**: string
+- **Requirements/Conventions**:
+
+  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.
+  - **Query**: Support for queries on this property is OPTIONAL.
+
+- **Examples**:
+
+  - Morphine: :val:`BQJCRHHNABKAKU-KBQPJGBKSA-N`
+
 dimension\_types
 ~~~~~~~~~~~~~~~~
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2503,7 +2503,7 @@ chemical\_formula\_anonymous
 inchikey
 ~~~~~~~~
 
-- **Description**: The standard InChIKey representation of the structure, as laid out by the [InChI Trust](https://www.inchi-trust.org)
+- **Description**: The standard InChIKey representation of the structure, as laid out by the `InChI Trust <https://www.inchi-trust.org>`_
 - **Type**: string
 - **Requirements/Conventions**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2503,7 +2503,7 @@ chemical\_formula\_anonymous
 inchikey
 ~~~~~~~~
 
-- **Description**: The standard InChIKey representation of the structure, as laid out by the `InChI Trust <https://www.inchi-trust.org>`_
+- **Description**: The standard InChIKey identifier of the structure, as laid out by the `InChI Trust <https://www.inchi-trust.org>`_
 - **Type**: string
 - **Requirements/Conventions**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2503,7 +2503,7 @@ chemical\_formula\_anonymous
 inchikey
 ~~~~~~~~
 
-- **Description**: The standard InChIKey representation of the structure.
+- **Description**: The standard InChIKey representation of the structure, as laid out by the [InChI Trust](https://www.inchi-trust.org)
 - **Type**: string
 - **Requirements/Conventions**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2503,7 +2503,7 @@ chemical\_formula\_anonymous
 inchikey
 ~~~~~~~~
 
-- **Description**: The standard InChIKey identifier of the structure, as laid out by the `InChI Trust <https://www.inchi-trust.org>`_
+- **Description**: The standard InChIKey identifier of the structure, as laid out by the `InChI Trust <https://www.inchi-trust.org>`_.
   Standard InChIKey is not guaranteed to be unique and in extremely rare cases the same InChIKey may be assigned to several different structures.
 - **Type**: string
 - **Requirements/Conventions**:

--- a/optimade.rst
+++ b/optimade.rst
@@ -2504,6 +2504,7 @@ inchikey
 ~~~~~~~~
 
 - **Description**: The standard InChIKey identifier of the structure, as laid out by the `InChI Trust <https://www.inchi-trust.org>`_
+  Standard InChIKey is non-unique, thus the same InChIKey can be assigned to several different structures.
 - **Type**: string
 - **Requirements/Conventions**:
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -2504,7 +2504,7 @@ inchikey
 ~~~~~~~~
 
 - **Description**: The standard InChIKey identifier of the structure, as laid out by the `InChI Trust <https://www.inchi-trust.org>`_
-  Standard InChIKey is non-unique, thus the same InChIKey can be assigned to several different structures.
+  Standard InChIKey is not guaranteed to be unique and in extremely rare cases the same InChIKey may be assigned to several different structures.
 - **Type**: string
 - **Requirements/Conventions**:
 


### PR DESCRIPTION
This PR adds [InChIKey property](https://en.wikipedia.org/wiki/International_Chemical_Identifier#InChIKey) for structure entries. InChIKey is a chemical structure descriptor alternative to SMILES (proposed in #368). InChIKey is said to avoid the the ambiguity the SMILES possesses, moreover, it does not have any internal structure (essentially being a "chemical checksum"), thus there should be no issues with its comparisons.

Pinging people who have expressed their interest for comments: @eimrek @utf @Austin243