### PR TITLE
Add `type` and `id` to the entry info endpoints

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -2867,8 +2867,8 @@ species
       Elements denoting vacancies MUST have masses equal to 0.
     - **original\_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.
 
-          **Note**: With regard to "source database", we refer to the immediate source being queried via the OPTIMADE API implementation.
-          The main use of this field is for source databases that use species names, containing characters that are not allowed (see description of the list property `species_at_sites`_).
+    **Note**: With regard to "source database", we refer to the immediate source being queried via the OPTIMADE API implementation.
+    The main use of this field is for source databases that use species names, containing characters that are not allowed (see description of the list property `species_at_sites`_).
 
   - For systems that have only species formed by a single chemical symbol, and that have at most one species per chemical symbol, SHOULD use the chemical symbol as species name (e.g., :val:`"Ti"` for titanium, :val:`"O"` for oxygen, etc.)
     However, note that this is OPTIONAL, and client implementations MUST NOT assume that the key corresponds to a chemical symbol, nor assume that if the species name is a valid chemical symbol, that it represents a species with that chemical symbol.

--- a/optimade.rst
+++ b/optimade.rst
@@ -1324,12 +1324,8 @@ The response for these endpoints SHOULD also include the following information i
 - **type**: :field-val:`"info"`.
 - **id**: This MUST precisely match the entry type name, e.g., :field-val:`"structures"` for the :endpoint:`/info/structures`.
 
-    **Note**: Future versions of the OPTIMADE API will deprecate this behavior and
-    require all keys that are not :field:`type` or :field:`id` to be under the
-    :field:`attributes` key.
-    At this point, :field:`type` and :field:`id` will be made mandatory to allow
-    the :endpoint:`/info/<entry-type>` endpoints to be understood outside the
-    initial context of the request.
+    **Note**: Future versions of the OPTIMADE API will deprecate this behavior and require all keys that are not :field:`type` or :field:`id` to be under the :field:`attributes` key.
+    At this point, :field:`type` and :field:`id` will be made mandatory to allow the :endpoint:`/info/<entry-type>` endpoints to be understood outside the initial context of the request.
     The present format is introduced for backwards-compatibility only.
 
 Example (note: the description strings have been wrapped for readability only):

--- a/optimade.rst
+++ b/optimade.rst
@@ -1314,19 +1314,14 @@ Entry listing info endpoints are accessed under the versioned or unversioned bas
 They return information related to the specific entry types served by the API.
 The response for these endpoints MUST include the following information in the :field:`data` field:
 
-- **description**: Description of the entry.
-- **properties**: A dictionary describing properties for this entry type, where each key is a property name and the value is an OPTIMADE Property Definition described in detail in the section `Property Definitions`_.
-- **formats**: List of output formats available for this type of entry.
-- **output\_fields\_by\_format**: Dictionary of available output fields for this entry type, where the keys are the values of the :field:`formats` list and the values are the keys of the :field:`properties` dictionary.
-
-The response for these endpoints SHOULD also include the following information in the :field:`data` field:
-
 - **type**: :field-val:`"info"`.
 - **id**: This MUST precisely match the entry type name, e.g., :field-val:`"structures"` for the :endpoint:`/info/structures`.
+- **description**: Description of the entry.
+- **properties**: A dictionary describing properties for this entry type, where each key is a property name and the value is an OPTIMADE Property Definition described in detail in the section `Property Definitions`_.
+- **formats**: List of output formats available for this type of entry (see section `Response Format`_)
+- **output\_fields\_by\_format**: Dictionary of available output fields for this entry type, where the keys are the values of the :field:`formats` list and the values are the keys of the :field:`properties` dictionary.
 
-    **Note**: Future versions of the OPTIMADE API will deprecate this behavior and require all keys that are not :field:`type` or :field:`id` to be under the :field:`attributes` key.
-    At this point, :field:`type` and :field:`id` will be made mandatory to allow the :endpoint:`/info/<entry-type>` endpoints to be understood outside the initial context of the request.
-    The present format is introduced for backwards-compatibility only.
+    **Note**: Future versions of the OPTIMADE API will deprecate this format and require all keys that are not :field:`type` or :field:`id` to be under the :field:`attributes` key.
 
 Example (note: the description strings have been wrapped for readability only):
 

--- a/optimade.rst
+++ b/optimade.rst
@@ -1311,6 +1311,7 @@ Entry Listing Info Endpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Entry listing info endpoints are accessed under the versioned or unversioned base URL serving the API as :endpoint:`/info/<entry_type>` (e.g., http://example.com/optimade/v1/info/structures or http://example.com/optimade/info/structures).
+They return information related to the specific entry types served by the API.
 The response for these endpoints MUST include the following information in the :field:`data` field:
 
 - **description**: Description of the entry.
@@ -1318,12 +1319,27 @@ The response for these endpoints MUST include the following information in the :
 - **formats**: List of output formats available for this type of entry.
 - **output\_fields\_by\_format**: Dictionary of available output fields for this entry type, where the keys are the values of the :field:`formats` list and the values are the keys of the :field:`properties` dictionary.
 
+The response for these endpoints SHOULD also include the following information in the :field:`data` field:
+
+- **type**: :field-val:`"info"`.
+- **id**: This MUST precisely match the entry type name, e.g., :field-val:`"structures"` for the :endpoint:`/info/structures`.
+
+    **Note**: Future versions of the OPTIMADE API will deprecate this behavior and
+    require all keys that are not :field:`type` or :field:`id` to be under the
+    :field:`attributes` key.
+    At this point, :field:`type` and :field:`id` will be made mandatory to allow
+    the :endpoint:`/info/<entry-type>` endpoints to be understood outside the
+    initial context of the request.
+    The present format is introduced for backwards-compatibility only.
+
 Example (note: the description strings have been wrapped for readability only):
 
 .. code:: jsonc
 
     {
       "data": {
+        "type": "info",
+        "id": "structures",
         "description": "a structures entry",
         "properties": {
           "nelements": {


### PR DESCRIPTION
Partially addresses #470, in a manner suitable for 1.2 (i.e., without backwards-incompatible changes). It seemed there was consensus in #470 that this is a bug (well, there was a thumbs up and a positive comment), and I think simply adding `type` and `id` fixes it for most use cases (i.e., downloading and storing an `/info/entry_type` endpoint whilst retaining the entry's identity).

I have added a future deprecation warning, as it seems clear to me at least that OPTIMADE v2 will just follow the JSON:API format for this, though I don't see any benefit in supporting both in v1.2. 