### PR TITLE
Adding the `dimension_slices` query parameter and associated metadata

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -677,7 +677,7 @@ The field :field:`list_axes` is defined as follows:
 
     - :field:`start`: Non-negative integer or :val:`null`.
 
-    - :field:`stop`: Non-negative integer or :val:`null`.
+    - :field:`stop`: Non-negative integer equal or greater to the :field:`start` value or :val:`null`.
 
     - :field:`step`: Positive integer or :val:`null`.
 


### PR DESCRIPTION
This PR introduces the ability for a client to request a specific subset, or "slice", of items from list properties. This is primarily achieved through the addition of a new query parameter, `dimension_slices`, and associated metadata fields to describe slicing capabilities and reflect the requested slices in the response.
Note this new feature is distinct from the existing protocol for large property values (see #467 and follow-up PRs), as slicing is initiated by the client, not the server. This means that even when slicing is requested by the client, the server can still decide whether to return the whole data in line, or via the partial data protocol.

### 1. `dimension_slices` query parameter
- **Purpose**: Request only specific parts of list properties.
- **Syntax**: `dimension_slices=dim_xxx[start:stop:step],...`
  - The slice defaults are as follows: start=0, step=1, stop=null (meaning upto the last value in the list).
  - Note that, at variance with Python, stop is inclusive.

### 2. Metadata enhancements in the response
A new `list_axes` list of dictionaries describing each list dimension. Each dict must contain `dimension_name` (required).
Optional keys: `length`, `sliceable` (bool), `available_slice` (index range), `requested_slice` (returned in `list_axes` for each sliced property, reflecting the exact slice requested).

### 3. Shared dimensions
- A slice on a dimension name applies to all properties that use that same name.

**Result:** Clients can fetch only needed portions of list data, with servers clearly describing slicing capabilities and confirming applied slices in the response.

Note that it surpersedes the original  proposal #452. 
 
