### PR TITLE
More HTML build CI fixes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,7 @@ jobs:
 
     - name: Commit to gh-pages
       run: |
+        git pull origin gh-pages
         git checkout gh-pages
         git add optimade.html
         mkdir -p specification/develop

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 
@@ -45,7 +45,7 @@ jobs:
         fi
 
     - name: Push changes
-      uses: ad-m/github-push-action@v0.6.0
+      uses: ad-m/github-push-action@v0.8.0
       with:
         branch: gh-pages
         force: true


### PR DESCRIPTION
We need to a) fetch the gh-pages branch before committing, b) update some of the GH actions to avoid node warnings.