### PR TITLE
Use `fetch` instead of pull to avoid needing to rebase gh-pages branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,9 +38,9 @@ jobs:
       run: |
         git fetch origin gh-pages
         git checkout gh-pages
-        git add optimade.html
         mkdir -p specification/develop
         mv optimade.html specification/develop/index.html
+        git add specification/develop/index.html
         git commit -m "Deploy develop specification to GitHub Pages: ${SHA}"
         if git diff --cached --quiet; then
             exit 0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Commit to gh-pages
       run: |
-        git pull origin gh-pages
+        git fetch origin gh-pages
         git checkout gh-pages
         git add optimade.html
         mkdir -p specification/develop


### PR DESCRIPTION
I was too hasty with the previous build fixes. Hopefully this is the last one... I've also added `workflow_dispatch` here which should let us run the action from PR branches, primarily to test CI failures ahead of time (before merging into develop).