### PR TITLE
Add padding to development spec build

### DIFF
--- a/tests/makefiles/style.css
+++ b/tests/makefiles/style.css
@@ -82,6 +82,7 @@ main, footer, header {
 main {
   counter-reset: table figure;
   background-color: var(--bg-color);
+  margin-top: 75px;
 }
 footer, header {
   font-size: smaller;


### PR DESCRIPTION
The development build of the spec lost its padding during code review, this PR reintroduces it.