### PR TITLE
Introduce roles for files related to calculations

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -3533,12 +3533,12 @@ Calculations Entries
 --------------------
 
 The :entry:`calculations` entries have the properties described above in section `Properties Used by Multiple Entry Types`_.
-Related :entry:`files` entries specified as relationships as described in section `Relationships`_ list files used or produced by a calculation.
-They MAY be defined as either input or output files in the :field:`role` field inside the :field:`meta` dictionary of the JSON:API resource identifier object.
+Related :entry:`files` entries specified as relationships (as described in section `Relationships`_) list files used or produced by a calculation.
+They MAY be defined as either input or output files by the :field:`role` field inside the :field:`meta` dictionary of the JSON:API resource identifier object.
 The allowed values are :val:`input` for input files and :val:`output` for output files.
 Absence of :field:`role` or :val:`null` means that the role is undefined and SHOULD NOT be assumed.
-It is RECOMMENDED to order the output files in the list of calculation's relationships in a way to prioritize the files most likely to contain details describing the performed calculation.
-This way a piece of output parsing software would need to read in a small number of calculation output files to possibly identify the code and the type of calculation performed.
+It is RECOMMENDED to order the output files in the list of calculation's relationships in a way to prioritize the files most likely to contain details which could be used to automatically analyze the performed calculation.
+This way output parsing software would need to read in a small number of calculation output files to possibly identify the code, type and possibly parameters of calculation performed.
 
 References Entries
 ------------------

--- a/optimade.rst
+++ b/optimade.rst
@@ -3533,6 +3533,12 @@ Calculations Entries
 --------------------
 
 The :entry:`calculations` entries have the properties described above in section `Properties Used by Multiple Entry Types`_.
+Related :entry:`files` entries specified as relationships as described in section `Relationships`_ list files used or produced by a calculation.
+They MAY be defined as either input or output files in the :field:`role` field inside the :field:`meta` dictionary of the JSON:API resource identifier object.
+The allowed values are :val:`input` for input files and :val:`output` for output files.
+Absence of :field:`role` or :val:`null` means that the role is undefined and SHOULD NOT be assumed.
+It is RECOMMENDED to order the output files in the list of calculation's relationships in a way to prioritize the files most likely to contain details describing the performed calculation.
+This way a piece of output parsing software would need to read in a small number of calculation output files to possibly identify the code and the type of calculation performed.
 
 References Entries
 ------------------


### PR DESCRIPTION
During workshop discussions, @giovannipizzi suggested introducing a means to specify how files are related to calculations entries. This PR introduces `meta.role` field to specify whether an attached file is input or output relative to the calculation in question.

Furthermore, there was a suggestion to order the related output files in a way to make it easier for automated analysis software to parse the output files in order to identify the code and/or calculation type used. Since it is impossible to define the deterministic orders for all the used codes, the suggestion is to use an arbitrary order where output files most likely to contain the identifying information come first. This way analysis software would encounter the identifying output files earlier and stop before reading in all the output files.