### PR TITLE
Change grammatica build source and target to Java 8

### DIFF
--- a/tests/tools/grammatica-build.patch
+++ b/tests/tools/grammatica-build.patch
@@ -2,11 +2,11 @@
 <            source="1.4"
 <            target="1.5"
 ---
->            source="1.7"
->            target="1.7"
+>            source="1.8"
+>            target="1.8"
 116,117c116,117
 <            source="1.4"
 <            target="1.5"
 ---
->            source="1.7"
->            target="1.7"
+>            source="1.8"
+>            target="1.8"


### PR DESCRIPTION
Java 7 is no longer available on the more modern systems therefore the jar file needed to run the OPTIMADE grammar tests fails to build. Switching to Java 8 seems to resolve the issue even if it also results in multiple Java deprecation messages during the build.  
