### PR TITLE
Forbid additional properties in `x-optimade-implementation`, fix misplaced `patternProperties` in `x-optimade-requirements`

### DIFF
--- a/schemas/src/meta/v1.2/optimade/property_definition.yaml
+++ b/schemas/src/meta/v1.2/optimade/property_definition.yaml
@@ -307,6 +307,7 @@ $defs:
       x-optimade-unit:
         type: string
       x-optimade-implementation:
+        additionalProperties: false
         patternProperties:
           "^x-(?!optimade-)": {}
         properties:
@@ -349,9 +350,9 @@ $defs:
         type: object
       x-optimade-requirements:
         additionalProperties: false
+        patternProperties:
+          "^x-(?!optimade-)": {}
         properties:
-          patternProperties:
-            "^x-(?!optimade-)": {}
           query-support:
             enum:
             - all mandatory


### PR DESCRIPTION
This PR fixes what I think to be accidental mistakes in `property_definition.yaml`:
* I think `x-optimade-implementation` should forbid additional properties, as the omission of this requirement will not catch incorrect property definitions as observed in https://github.com/Materials-Consortia/namespace-cheminformatics/pull/12
* `patternProperties` should be defined outside `properties`, otherwise it might be understood as an exotic name of an allowed property.