### PR TITLE
Change the definition of `query-support: "equality only"` to encompass `IS KNOWN` and `IS UNKNOWN` operators.

### DIFF
--- a/optimade.rst
+++ b/optimade.rst
@@ -2601,7 +2601,8 @@ A Property Definition MUST be composed according to the combination of the requi
     The string MUST be one of the following:
 
     - :val:`all mandatory`: the defined property MUST be queryable using the OPTIMADE filter language with support for all mandatory filter features.
-    - :val:`equality only`: the defined property MUST be queryable using the OPTIMADE filter language equality and inequality operators. Other filter language features do not need to be available.
+    - :val:`equality only`: the defined property MUST be queryable using the OPTIMADE filter language equality, inequality, :val:`IS KNOWN` and :val:`IS UNKNOWN` operators.
+      Other filter language features do not need to be available.
     - :val:`partial`: the defined property MUST be queryable with support for a subset of the filter language operators as specified by the field :field:`query-support-operators`.
     - :val:`none`: the defined property does not need to be queryable with any features of the filter language.
 


### PR DESCRIPTION
Fixes #594 as if this was the intended behavior and left out as a bug of the specification.