### PR TITLE
Fix missing sha256 property to checksums.yaml

### DIFF
--- a/schemas/src/defs/v1.2/properties/optimade/files/checksums.yaml
+++ b/schemas/src/defs/v1.2/properties/optimade/files/checksums.yaml
@@ -39,6 +39,11 @@ properties:
     x-optimade-unit: "inapplicable"
     type:
       - "string"
+  sha256:
+    x-optimade-type: "string"
+    x-optimade-unit: "inapplicable"
+    type:
+      - "string"
   sha384:
     x-optimade-type: "string"
     x-optimade-unit: "inapplicable"

--- a/schemas/src/defs/v1.2/properties/optimade/files/checksums.yaml
+++ b/schemas/src/defs/v1.2/properties/optimade/files/checksums.yaml
@@ -5,7 +5,7 @@ x-optimade-type: "dictionary"
 x-optimade-definition:
   label: "checksums_optimade_files"
   kind: "property"
-  version: "1.2.0"
+  version: "1.2.1"
   format: "1.2"
   name: "checksums"
 type:


### PR DESCRIPTION
The property definition for checksums is missing the documented sha256 option. In my opinion this should be considered a property definition (schema) bug, and thus only update the patch level version number.